### PR TITLE
feat(plugins): extensible declarative side-effects and type-safe command context

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,43 @@ Redemeine treats aggregates as composable building blocks:
 
 ## 🔌 Plugin Interceptors
 
-Mirage/Depot infrastructure supports plugin hooks for command dispatch, append, and hydration:
+Mirage/Depot infrastructure supports plugin hooks for command dispatch, append, hydration, and post-commit:
 
 - `onBeforeCommand(ctx)`
-- `onBeforeAppend(ctx)`
 - `onHydrateEvent(ctx)`
+- `onBeforeAppend(ctx)`
+- `onAfterCommit(ctx)`
 
-Hooks run sequentially in registration order and are awaited. `onBeforeCommand` can throw to block execution. `onBeforeAppend` and `onHydrateEvent` can mutate payloads in-place or return a transformed payload.
+Every plugin must provide a stable `key`:
+
+```ts
+const auditPlugin = {
+  key: 'audit',
+  onAfterCommit: async (ctx) => {
+    // ctx.pluginKey === 'audit'
+  }
+};
+```
+
+Command handlers that return plugin intents must use the namespaced envelope shape:
+
+```ts
+return {
+  events: [emit.incremented({ amount })],
+  intents: {
+    audit: { traceId: 'trace-123' }
+  }
+};
+```
+
+Flat root-level plugin keys are not accepted.
+
+### Hook failure policy matrix
+
+- `onBeforeCommand`: **fail_closed** (command is blocked, no events applied)
+- `onHydrateEvent`: **fail_closed** (hydrate is blocked)
+- `onBeforeAppend`: **fail_closed** (append/save is blocked)
+- `onAfterCommit`: **fail_closed_post_commit** (events already persisted; pending results are cleared and a structured `RedemeinePluginHookError` is thrown with `pluginKey` + `hook`)
 
 ## 🧭 Quick Navigation
 

--- a/docs/architecture/decision-log.md
+++ b/docs/architecture/decision-log.md
@@ -45,3 +45,10 @@ const ShipmentBuilder = createAggregate('Shipment', initial)
 
 ### 3. Testability Without Mocks
 Because Redemeine models state updates functionally (often transparently backed by Immer), you no longer need complex mock environments to unit test an aggregate. You can invoke a command handler directly with an initial state and immediately assert against the resulting returned domain events.
+
+## Future ADR Placeholder: Transactional Outbox for Post-Commit Hooks
+
+- **Status:** TODO / pending ADR
+- **Motivation:** `onAfterCommit` currently runs inline after event persistence. This guarantees ordering but couples side-effects to request lifecycle and relies on retry orchestration outside the core runtime.
+- **Planned direction:** formalize a full transactional outbox ADR that records post-commit intents atomically with event append, then executes/retries side-effects asynchronously via worker(s).
+- **Short-term policy:** maintain current fail-closed-post-commit behavior with structured plugin hook errors while clearing pending in-memory results after successful append.

--- a/llms.txt
+++ b/llms.txt
@@ -139,4 +139,4 @@ Methods map to paths using these conventions:
 - `event` (Auto-formatted path component)
 
 --- 
-**Metadata:** 19 Interfaces, 35 Types, 5 Public Functions.
+**Metadata:** 20 Interfaces, 35 Types, 5 Public Functions.

--- a/llms.txt
+++ b/llms.txt
@@ -139,4 +139,4 @@ Methods map to paths using these conventions:
 - `event` (Auto-formatted path component)
 
 --- 
-**Metadata:** 18 Interfaces, 29 Types, 5 Public Functions.
+**Metadata:** 19 Interfaces, 33 Types, 5 Public Functions.

--- a/llms.txt
+++ b/llms.txt
@@ -76,6 +76,7 @@ Unlike entities, this branch does not route nested commands.
 - `.valueObjectMap()` (Returns `this`) - Register a read-only value object map branch.
 Unlike entities, this branch does not route nested commands.
 - `.mixins()` (Returns `this`) - Compose reusable domain logic chunks (Mixins) into this aggregate.
+- `.plugins()` (Returns `this`) - Register aggregate-level plugins to be composed into Mirage/Depot runtime behavior.
 - `.events()` (Returns `this`) - Register state-altering event handlers.
 **Magic:** The `state` object inside these handlers is wrapped in Immer. You CAN mutate it directly!
 The auto-namer maps camelCase keys to dot notation (e.g. `itemAdded` -> `aggregate.item_added.event`). **[IMMER MUTATION ALLOWED]**
@@ -139,4 +140,4 @@ Methods map to paths using these conventions:
 - `event` (Auto-formatted path component)
 
 --- 
-**Metadata:** 20 Interfaces, 35 Types, 5 Public Functions.
+**Metadata:** 20 Interfaces, 38 Types, 5 Public Functions.

--- a/llms.txt
+++ b/llms.txt
@@ -139,4 +139,4 @@ Methods map to paths using these conventions:
 - `event` (Auto-formatted path component)
 
 --- 
-**Metadata:** 19 Interfaces, 33 Types, 5 Public Functions.
+**Metadata:** 19 Interfaces, 35 Types, 5 Public Functions.

--- a/llms.txt
+++ b/llms.txt
@@ -140,4 +140,4 @@ Methods map to paths using these conventions:
 - `event` (Auto-formatted path component)
 
 --- 
-**Metadata:** 20 Interfaces, 38 Types, 5 Public Functions.
+**Metadata:** 21 Interfaces, 39 Types, 5 Public Functions.

--- a/src/Depot.ts
+++ b/src/Depot.ts
@@ -1,5 +1,5 @@
 import { Mirage, createMirage, MirageOptions, BuiltAggregate, MirageCoreSymbol } from './createMirage';
-import { Event, EventInterceptorContext, PluginExtensions, RedemeinePlugin } from './types';
+import { Event, EventInterceptorContext, PluginExtensions, RedemeinePlugin, RedemeinePluginHookError } from './types';
 
 export interface EventStore {
     getEvents(id: string): Promise<Event[]>;
@@ -30,6 +30,28 @@ export function createDepot<BA extends BuiltAggregate<any, any, any, any>>(
 ): Depot<BuiltAggregateState<BA>, BuiltAggregateCommands<BA>, BuiltAggregateRegistry<BA>> {
   const plugins = [...(builder.plugins || []), ...(options?.plugins || [])] as RedemeinePlugin<any>[];
 
+  const assertPluginHasKey = (plugin: RedemeinePlugin<any>): void => {
+    if (!plugin.key || typeof plugin.key !== 'string') {
+      throw new Error('Invalid plugin configuration: plugin.key is required and must be a non-empty string.');
+    }
+  };
+
+  plugins.forEach(assertPluginHasKey);
+
+  const wrapPluginHookFailure = (
+    plugin: RedemeinePlugin<any>,
+    hook: 'onBeforeAppend' | 'onAfterCommit',
+    aggregateId: string,
+    cause: unknown
+  ): RedemeinePluginHookError => {
+    return new RedemeinePluginHookError({
+      pluginKey: plugin.key,
+      hook,
+      aggregateId,
+      cause
+    });
+  };
+
   const runAppendInterceptors = async (id: string, events: Event[]): Promise<Event[]> => {
     if (plugins.length === 0) return events;
 
@@ -37,6 +59,7 @@ export function createDepot<BA extends BuiltAggregate<any, any, any, any>>(
 
     for (const event of events) {
       const ctx: EventInterceptorContext<{}, unknown> = {
+        pluginKey: '',
         aggregateId: id,
         eventType: event.type,
         payload: event.payload,
@@ -45,9 +68,14 @@ export function createDepot<BA extends BuiltAggregate<any, any, any, any>>(
 
       for (const plugin of plugins) {
         if (typeof plugin.onBeforeAppend === 'function') {
-          const nextPayload = await plugin.onBeforeAppend(ctx);
-          if (nextPayload !== undefined) {
-            ctx.payload = nextPayload;
+          ctx.pluginKey = plugin.key;
+          try {
+            const nextPayload = await plugin.onBeforeAppend(ctx);
+            if (nextPayload !== undefined) {
+              ctx.payload = nextPayload;
+            }
+          } catch (error) {
+            throw wrapPluginHookFailure(plugin, 'onBeforeAppend', id, error);
           }
         }
       }
@@ -67,11 +95,16 @@ export function createDepot<BA extends BuiltAggregate<any, any, any, any>>(
 
     for (const plugin of plugins) {
       if (typeof plugin.onAfterCommit === 'function') {
-        await plugin.onAfterCommit({
-          aggregateId: id,
-          events,
-          intents
-        });
+        try {
+          await plugin.onAfterCommit({
+            pluginKey: plugin.key,
+            aggregateId: id,
+            events,
+            intents
+          });
+        } catch (error) {
+          throw wrapPluginHookFailure(plugin, 'onAfterCommit', id, error);
+        }
       }
     }
   };
@@ -85,14 +118,15 @@ export function createDepot<BA extends BuiltAggregate<any, any, any, any>>(
         const core = (mirage as any)[MirageCoreSymbol];
         if (!core) throw new Error('Not a valid Mirage Instance');
 
-          const { events, intents } = core.getPendingCommitContext();
+          const { events, intents } = core.getPendingResults();
           const appendableEvents = await runAppendInterceptors(core.id, events);
 
           await store.saveEvents(core.id, appendableEvents, core.version);
+          core.clearPendingResults();
 
+          // TODO(outbox): move onAfterCommit side-effects to a transactional outbox worker
+          // so post-commit failures are retriable without coupling to request lifecycle.
           await runAfterCommitHooks(core.id, appendableEvents, intents);
-
-          core.clearPendingCommitContext();
       }
   };
 }

--- a/src/Depot.ts
+++ b/src/Depot.ts
@@ -34,7 +34,7 @@ export function createDepot<BA extends BuiltAggregate<any, any, any, any>>(
     const eventMetaRegistry = builder.metadata?.events || {};
 
     for (const event of events) {
-      const ctx: EventInterceptorContext<Record<string, unknown>, unknown> = {
+      const ctx: EventInterceptorContext<{}, unknown> = {
         aggregateId: id,
         eventType: event.type,
         payload: event.payload,

--- a/src/Depot.ts
+++ b/src/Depot.ts
@@ -56,17 +56,42 @@ export function createDepot<BA extends BuiltAggregate<any, any, any, any>>(
     return events;
   };
 
+  const runAfterCommitHooks = async (
+    id: string,
+    events: Event[],
+    intents: Record<string, unknown>
+  ): Promise<void> => {
+    const plugins = options?.plugins || [];
+    if (plugins.length === 0) return;
+
+    for (const plugin of plugins) {
+      if (typeof plugin.onAfterCommit === 'function') {
+        await plugin.onAfterCommit({
+          aggregateId: id,
+          events,
+          intents
+        });
+      }
+    }
+  };
+
   return {
       get: async (id: string) => {
           const events = await store.getEvents(id);
           return createMirage(builder, id, { ...options, events });
       },
       save: async (mirage: Mirage<BuiltAggregateState<BA>, BuiltAggregateCommands<BA>, BuiltAggregateRegistry<BA>>) => {
-          const core = (mirage as any)[MirageCoreSymbol];
-          if (!core) throw new Error('Not a valid Mirage Instance');
-          const appendableEvents = await runAppendInterceptors(core.id, core.uncommitted);
+        const core = (mirage as any)[MirageCoreSymbol];
+        if (!core) throw new Error('Not a valid Mirage Instance');
+
+          const { events, intents } = core.getPendingCommitContext();
+          const appendableEvents = await runAppendInterceptors(core.id, events);
+
           await store.saveEvents(core.id, appendableEvents, core.version);
-          core.uncommitted = [];
+
+          await runAfterCommitHooks(core.id, appendableEvents, intents);
+
+          core.clearPendingCommitContext();
       }
   };
 }

--- a/src/Depot.ts
+++ b/src/Depot.ts
@@ -1,5 +1,5 @@
 import { Mirage, createMirage, MirageOptions, BuiltAggregate, MirageCoreSymbol } from './createMirage';
-import { Event, EventInterceptorContext } from './types';
+import { Event, EventInterceptorContext, PluginExtensions, RedemeinePlugin } from './types';
 
 export interface EventStore {
     getEvents(id: string): Promise<Event[]>;
@@ -9,6 +9,7 @@ export interface EventStore {
 type BuiltAggregateCommands<T> = T extends BuiltAggregate<any, infer M, any, any> ? M : Record<string, any>;
 type BuiltAggregateState<T> = T extends BuiltAggregate<infer S, any, any, any> ? S : never;
 type BuiltAggregateRegistry<T> = T extends BuiltAggregate<any, any, any, infer R> ? R : {};
+type BuiltAggregatePlugins<T> = T extends BuiltAggregate<any, any, any, any, any, infer P> ? P : {};
 
 /**
  * Depots are the primary way to retrieve a Mirage of an aggregate by its ID.
@@ -25,10 +26,11 @@ export interface Depot<TState extends {}, M extends Record<string, any> = any, R
 export function createDepot<BA extends BuiltAggregate<any, any, any, any>>(
   builder: BA,
   store: EventStore,
-  options?: MirageOptions
+  options?: MirageOptions<BuiltAggregatePlugins<BA>>
 ): Depot<BuiltAggregateState<BA>, BuiltAggregateCommands<BA>, BuiltAggregateRegistry<BA>> {
+  const plugins = [...(builder.plugins || []), ...(options?.plugins || [])] as RedemeinePlugin<any>[];
+
   const runAppendInterceptors = async (id: string, events: Event[]): Promise<Event[]> => {
-    const plugins = options?.plugins || [];
     if (plugins.length === 0) return events;
 
     const eventMetaRegistry = builder.metadata?.events || {};
@@ -61,7 +63,6 @@ export function createDepot<BA extends BuiltAggregate<any, any, any, any>>(
     events: Event[],
     intents: Record<string, unknown>
   ): Promise<void> => {
-    const plugins = options?.plugins || [];
     if (plugins.length === 0) return;
 
     for (const plugin of plugins) {

--- a/src/componentMounts.ts
+++ b/src/componentMounts.ts
@@ -1,5 +1,5 @@
 import type { EntityPackage } from './createEntity';
-import type { GenericCommandFactory, GenericCommandFactoryContext, GenericCommandMap } from './redemeineComponent';
+import { resolveCommandFactoryContext, type GenericCommandFactory, type GenericCommandFactoryContext, type GenericCommandMap } from './redemeineComponent';
 
 export type MapEntityCommands<Name extends string, CPayloads> = {
   [K in keyof CPayloads as K extends string ? `${Name}${Capitalize<K>}` : never]: CPayloads[K]
@@ -117,8 +117,9 @@ export function composeMountedComponentBehavior(
   });
 
   const commandFactory: GenericCommandFactory = (emit: unknown, context: GenericCommandFactoryContext) => {
+    const resolvedContext = resolveCommandFactoryContext(context);
     const mergedCommands: GenericCommandMap = {
-      ...baseCommandFactory(emit, context)
+      ...baseCommandFactory(emit, resolvedContext)
     };
 
     mountedEntities.forEach(({ name: mountName, kind, component: nested }) => {
@@ -135,7 +136,7 @@ export function composeMountedComponentBehavior(
         }
       });
 
-      const nestedCommands = nested.commandFactory(nestedEmit, context);
+      const nestedCommands = nested.commandFactory(nestedEmit, resolvedContext);
       Object.keys(nestedCommands).forEach((cmdKey) => {
         mergedCommands[`${mountName}${capitalize(cmdKey)}`] = nestedCommands[cmdKey];
       });

--- a/src/componentMounts.ts
+++ b/src/componentMounts.ts
@@ -1,5 +1,5 @@
 import type { EntityPackage } from './createEntity';
-import type { GenericCommandFactory, GenericCommandMap } from './redemeineComponent';
+import type { GenericCommandFactory, GenericCommandFactoryContext, GenericCommandMap } from './redemeineComponent';
 
 export type MapEntityCommands<Name extends string, CPayloads> = {
   [K in keyof CPayloads as K extends string ? `${Name}${Capitalize<K>}` : never]: CPayloads[K]
@@ -116,7 +116,7 @@ export function composeMountedComponentBehavior(
     });
   });
 
-  const commandFactory: GenericCommandFactory = (emit: unknown, context: { selectors: Record<string, unknown> }) => {
+  const commandFactory: GenericCommandFactory = (emit: unknown, context: GenericCommandFactoryContext) => {
     const mergedCommands: GenericCommandMap = {
       ...baseCommandFactory(emit, context)
     };
@@ -135,7 +135,7 @@ export function composeMountedComponentBehavior(
         }
       });
 
-      const nestedCommands = nested.commandFactory(nestedEmit, context as { selectors: Record<string, unknown> });
+      const nestedCommands = nested.commandFactory(nestedEmit, context);
       Object.keys(nestedCommands).forEach((cmdKey) => {
         mergedCommands[`${mountName}${capitalize(cmdKey)}`] = nestedCommands[cmdKey];
       });

--- a/src/createAggregate.ts
+++ b/src/createAggregate.ts
@@ -1,4 +1,4 @@
-import { Event, Command, EventEmitterFactory, EventType, CommandType, NamingStrategy, SelectorsMap, AggregateHooks, MapCommandsToPayloads, PluginContext, PluginExtensions, CommandContext, CommandIntents } from './types';
+import { Event, Command, EventEmitterFactory, EventType, CommandType, NamingStrategy, SelectorsMap, AggregateHooks, MapCommandsToPayloads, PluginContext, PluginExtensions, CommandContext, CommandIntents, MergePluginExtensions, RedemeinePlugin } from './types';
 import { MixinPackage } from './createMixin';
 import { EntityPackage } from './createEntity';
 import { ReadonlyDeep } from './utils/types/ReadonlyDeep';
@@ -233,6 +233,13 @@ export interface AggregateBuilder<S, Name extends string, M = {}, E = {}, EOverr
     ) => AggregateBuilder<S, Name, M & MergeMixins<T>, E, EOverrides, Sel, Registry & MergeMixinRegistries<T>, TMeta, TPlugins>;
 
     /**
+     * Register aggregate-level plugins to be composed into Mirage/Depot runtime behavior.
+     */
+    plugins: <P extends RedemeinePlugin<any>[]>(
+        ...plugins: P
+    ) => AggregateBuilder<S, Name, M, E, EOverrides, Sel, Registry, TMeta, TPlugins & MergePluginExtensions<P>>;
+
+    /**
      * Define pure functions for reading and deriving state.
      * These will be injectable into your command handlers via the `context` parameter.
      * 
@@ -355,6 +362,7 @@ commands: <C extends Record<string, RedemeineCommandDefinition<S, TMeta, TPlugin
             commands: Record<string, { meta?: TMeta }>;
             events: Record<string, { meta?: TMeta }>;
         };
+        plugins: RedemeinePlugin<TPlugins>[];
         __registryType?: Registry;
 
     };
@@ -369,6 +377,7 @@ commands: <C extends Record<string, RedemeineCommandDefinition<S, TMeta, TPlugin
         mixins: AggregateMixinLike<S>[];
         selectors: Record<string, Function>;
         hooks: AggregateHooks<S>;
+        plugins: RedemeinePlugin<TPlugins>[];
     };
 }
 
@@ -395,6 +404,7 @@ export function createAggregate<S, Name extends string, TMeta extends Record<str
     let _mixins: AggregateMixinLike<any>[] = [];
     let _namingStrategy: NamingStrategy = defaultNamingStrategy;
     let _hooks: AggregateHooks<S> = {};
+    let _plugins: RedemeinePlugin<any>[] = [];
 
     const builder = bindFluentMethods({}, {
         selectors: (selectorsOrFactory: AggregateSelectorsMap<S> | ((utils: AggregateSelectorUtils) => AggregateSelectorsMap<S>)) => {
@@ -414,6 +424,7 @@ export function createAggregate<S, Name extends string, TMeta extends Record<str
             const parentState = parentBuilder._state;
             component.inherit(parentState);
             _hooks = { ...parentState.hooks, ..._hooks };
+            _plugins = [...parentState.plugins, ..._plugins];
             _mixins = [...parentState.mixins, ..._mixins];
             const inheritedMounted = (parentState.mixins as any[])
                 .flatMap((m) => Array.isArray(m?.mountedEntities) ? m.mountedEntities : []);
@@ -482,6 +493,11 @@ export function createAggregate<S, Name extends string, TMeta extends Record<str
             return builder;
         },
 
+        plugins: (...plugins: RedemeinePlugin<any>[]) => {
+            _plugins.push(...plugins);
+            return builder;
+        },
+
         naming: (strategy: Partial<NamingStrategy>) => {
             _namingStrategy = { ..._namingStrategy, ...strategy };
             return builder;
@@ -502,7 +518,8 @@ export function createAggregate<S, Name extends string, TMeta extends Record<str
                 commandsFactory: component.getCommandsFactory(),
                 mixins: _mixins,
                 selectors: snapshot.selectors,
-                hooks: _hooks
+                hooks: _hooks,
+                plugins: _plugins as RedemeinePlugin<TPlugins>[]
             };
         },
 
@@ -671,7 +688,8 @@ export function createAggregate<S, Name extends string, TMeta extends Record<str
                 metadata: {
                     commands: metadataByCommandType,
                     events: metadataByEventType
-                }
+                },
+                plugins: _plugins as RedemeinePlugin<TPlugins>[]
             };
         }
     });

--- a/src/createAggregate.ts
+++ b/src/createAggregate.ts
@@ -1,4 +1,4 @@
-import { Event, Command, EventEmitterFactory, EventType, CommandType, NamingStrategy, SelectorsMap, AggregateHooks, MapCommandsToPayloads } from './types';
+import { Event, Command, EventEmitterFactory, EventType, CommandType, NamingStrategy, SelectorsMap, AggregateHooks, MapCommandsToPayloads, PluginContext, PluginExtensions } from './types';
 import { MixinPackage } from './createMixin';
 import { EntityPackage } from './createEntity';
 import { ReadonlyDeep } from './utils/types/ReadonlyDeep';
@@ -140,7 +140,7 @@ type RegistryFromPackages<T extends readonly EntityPackage<any, any, any, any, a
  * The core builder interface for composing Aggregates in Redemeine.
  * Uses a fluent chained API to progressively layer events, commands, mixins, and entities.
  */
-export interface AggregateBuilder<S, Name extends string, M = {}, E = {}, EOverrides = {}, Sel = {}, Registry extends AggregateEntityRegistry = {}, TMeta extends Record<string, unknown> = Record<string, unknown>> {
+export interface AggregateBuilder<S, Name extends string, M = {}, E = {}, EOverrides = {}, Sel = {}, Registry extends AggregateEntityRegistry = {}, TMeta extends Record<string, unknown> = Record<string, unknown>, TPlugins extends PluginExtensions = {}> {
     /**
      * Inherit all business rules, selectors, and events from a parent aggregate builder.
      * 
@@ -149,8 +149,8 @@ export interface AggregateBuilder<S, Name extends string, M = {}, E = {}, EOverr
      *   .extends(OrderAggregate) // Inherits standard order rules while adding legs
      */
     extends: <ParentM, ParentE, ParentEOverrides, ParentSel, ParentRegistry extends AggregateEntityRegistry>(
-        parentBuilder: AggregateBuilder<S, any, ParentM, ParentE, ParentEOverrides, ParentSel, ParentRegistry, TMeta>
-    ) => AggregateBuilder<S, Name, M & ParentM, E & ParentE, EOverrides & ParentEOverrides, Sel & ParentSel, Registry & ParentRegistry, TMeta>;
+        parentBuilder: AggregateBuilder<S, any, ParentM, ParentE, ParentEOverrides, ParentSel, ParentRegistry, TMeta, TPlugins>
+    ) => AggregateBuilder<S, Name, M & ParentM, E & ParentE, EOverrides & ParentEOverrides, Sel & ParentSel, Registry & ParentRegistry, TMeta, TPlugins>;
 
     /**
      * Register nested entities into the aggregate's namespace.
@@ -173,7 +173,7 @@ export interface AggregateBuilder<S, Name extends string, M = {}, E = {}, EOverr
     entities: <EN extends Record<string, any> = {}, T extends EntityPackage<any, any, any, any, any, any>[] = []>(
         entities?: EN,
         ...entityPackages: T
-    ) => AggregateBuilder<S, Name, M & MergeEntities<T>, E, EOverrides, Sel, Registry & RegistryFromNamedEntities<EN> & RegistryFromPackages<T>, TMeta>;
+    ) => AggregateBuilder<S, Name, M & MergeEntities<T>, E, EOverrides, Sel, Registry & RegistryFromNamedEntities<EN> & RegistryFromPackages<T>, TMeta, TPlugins>;
 
     /**
      * Register a list-backed entity collection with optional simple or composite primary key definition.
@@ -183,7 +183,7 @@ export interface AggregateBuilder<S, Name extends string, M = {}, E = {}, EOverr
         entityComponent: T,
         options?: EntityListOptions<PK>,
         mountOverrides?: EntityMountOverrides
-    ) => AggregateBuilder<S, Name, M & MapEntityCommands<EN, T extends EntityPackage<any, any, any, any, infer CPayloads, any> ? CPayloads : {}>, E, EOverrides, Sel, Registry & { [K in EN]: EntityRegistryListEntry<T, PK> }, TMeta>;
+    ) => AggregateBuilder<S, Name, M & MapEntityCommands<EN, T extends EntityPackage<any, any, any, any, infer CPayloads, any> ? CPayloads : {}>, E, EOverrides, Sel, Registry & { [K in EN]: EntityRegistryListEntry<T, PK> }, TMeta, TPlugins>;
 
     /**
      * Register a record-backed entity map with optional known keys.
@@ -193,7 +193,7 @@ export interface AggregateBuilder<S, Name extends string, M = {}, E = {}, EOverr
         entityComponent: T,
         options?: EntityMapOptions<Keys>,
         mountOverrides?: EntityMountOverrides
-    ) => AggregateBuilder<S, Name, M & MapEntityCommands<EN, T extends EntityPackage<any, any, any, any, infer CPayloads, any> ? CPayloads : {}>, E, EOverrides, Sel, Registry & { [K in EN]: EntityRegistryMapEntry<T, Keys> }, TMeta>;
+    ) => AggregateBuilder<S, Name, M & MapEntityCommands<EN, T extends EntityPackage<any, any, any, any, infer CPayloads, any> ? CPayloads : {}>, E, EOverrides, Sel, Registry & { [K in EN]: EntityRegistryMapEntry<T, Keys> }, TMeta, TPlugins>;
 
     /**
      * Register a value object branch. It is exposed as read-only state and does not add routed commands.
@@ -201,7 +201,7 @@ export interface AggregateBuilder<S, Name extends string, M = {}, E = {}, EOverr
     valueObject: <VOName extends string>(
         name: VOName,
         schema?: unknown
-    ) => AggregateBuilder<S, Name, M, E, EOverrides, Sel, Registry & { [K in VOName]: EntityRegistryValueObjectEntry }, TMeta>;
+    ) => AggregateBuilder<S, Name, M, E, EOverrides, Sel, Registry & { [K in VOName]: EntityRegistryValueObjectEntry }, TMeta, TPlugins>;
 
     /**
      * Register a read-only value object list branch.
@@ -210,7 +210,7 @@ export interface AggregateBuilder<S, Name extends string, M = {}, E = {}, EOverr
     valueObjectList: <VOName extends string>(
         name: VOName,
         schema?: unknown
-    ) => AggregateBuilder<S, Name, M, E, EOverrides, Sel, Registry & { [K in VOName]: EntityRegistryValueObjectListEntry }, TMeta>;
+    ) => AggregateBuilder<S, Name, M, E, EOverrides, Sel, Registry & { [K in VOName]: EntityRegistryValueObjectListEntry }, TMeta, TPlugins>;
 
     /**
      * Register a read-only value object map branch.
@@ -219,7 +219,7 @@ export interface AggregateBuilder<S, Name extends string, M = {}, E = {}, EOverr
     valueObjectMap: <VOName extends string>(
         name: VOName,
         schema?: unknown
-    ) => AggregateBuilder<S, Name, M, E, EOverrides, Sel, Registry & { [K in VOName]: EntityRegistryValueObjectMapEntry }, TMeta>;
+    ) => AggregateBuilder<S, Name, M, E, EOverrides, Sel, Registry & { [K in VOName]: EntityRegistryValueObjectMapEntry }, TMeta, TPlugins>;
 
     /**
      * Compose reusable domain logic chunks (Mixins) into this aggregate.
@@ -229,7 +229,7 @@ export interface AggregateBuilder<S, Name extends string, M = {}, E = {}, EOverr
      */
     mixins: <T extends AggregateMixinLike<any, any, any>[]>(
         ...mixins: CompatibleMixins<S, T>
-    ) => AggregateBuilder<S, Name, M & MergeMixins<T>, E, EOverrides, Sel, Registry & MergeMixinRegistries<T>, TMeta>;
+    ) => AggregateBuilder<S, Name, M & MergeMixins<T>, E, EOverrides, Sel, Registry & MergeMixinRegistries<T>, TMeta, TPlugins>;
 
     /**
      * Define pure functions for reading and deriving state.
@@ -243,10 +243,10 @@ export interface AggregateBuilder<S, Name extends string, M = {}, E = {}, EOverr
     selectors: {
         <NewSel extends AggregateSelectorsMap<S>>(
             selectors: NewSel
-        ): AggregateBuilder<S, Name, M, E, EOverrides, Sel & NewSel, Registry, TMeta>;
+        ): AggregateBuilder<S, Name, M, E, EOverrides, Sel & NewSel, Registry, TMeta, TPlugins>;
         <NewSel extends AggregateSelectorsMap<S>>(
             selectorFactory: (utils: AggregateSelectorUtils) => NewSel
-        ): AggregateBuilder<S, Name, M, E, EOverrides, Sel & NewSel, Registry, TMeta>;
+        ): AggregateBuilder<S, Name, M, E, EOverrides, Sel & NewSel, Registry, TMeta, TPlugins>;
     };
 
     /**
@@ -261,7 +261,7 @@ export interface AggregateBuilder<S, Name extends string, M = {}, E = {}, EOverr
      */
     events: <NewE extends Record<string, RedemeineEventDefinition<S, TMeta>>>(
         events: NewE
-    ) => AggregateBuilder<S, Name, M, E & NormalizeEventDefinitions<NewE>, EOverrides, Sel, Registry, TMeta>;
+    ) => AggregateBuilder<S, Name, M, E & NormalizeEventDefinitions<NewE>, EOverrides, Sel, Registry, TMeta, TPlugins>;
 
     /**
      * Overrides the default Targeted Naming engine for specific events.
@@ -272,7 +272,7 @@ export interface AggregateBuilder<S, Name extends string, M = {}, E = {}, EOverr
      */
     overrideEventNames: <NewEOverrides extends Partial<Record<string, EventType>>>(
         overrides: NewEOverrides
-    ) => AggregateBuilder<S, Name, M, E, EOverrides & NewEOverrides, Sel, Registry, TMeta>;
+    ) => AggregateBuilder<S, Name, M, E, EOverrides & NewEOverrides, Sel, Registry, TMeta, TPlugins>;
 
     /**
      * Replaces the default Targeted Naming engine with a custom strategy.
@@ -281,7 +281,7 @@ export interface AggregateBuilder<S, Name extends string, M = {}, E = {}, EOverr
      * @example
      * .naming({ event: (agg, prop) => `${agg}_${prop}` })
      */
-    naming: (strategy: Partial<NamingStrategy>) => AggregateBuilder<S, Name, M, E, EOverrides, Sel, Registry, TMeta>;
+    naming: (strategy: Partial<NamingStrategy>) => AggregateBuilder<S, Name, M, E, EOverrides, Sel, Registry, TMeta, TPlugins>;
 
     /**
      * Define command processors that execute business logic and emit events.
@@ -300,9 +300,9 @@ export interface AggregateBuilder<S, Name extends string, M = {}, E = {}, EOverr
      *   }
      * }))
      */
-commands: <C extends Record<string, RedemeineCommandDefinition<S, TMeta>>>(
-        factory: (emit: EventEmitterFactory<Name, E, EOverrides>, context: { selectors: Sel }) => C
-    ) => AggregateBuilder<S, Name, M & MapCommandsToPayloads<C>, E, EOverrides, Sel, Registry, TMeta>;
+commands: <C extends Record<string, RedemeineCommandDefinition<S, TMeta, TPlugins>>>(
+        factory: (emit: EventEmitterFactory<Name, E, EOverrides>, context: { selectors: Sel; plugins?: PluginContext<TPlugins> }) => C
+    ) => AggregateBuilder<S, Name, M & MapCommandsToPayloads<C>, E, EOverrides, Sel, Registry, TMeta, TPlugins>;
 
     /**
      * Overrides the default Targeted Naming engine for specific commands.
@@ -312,7 +312,7 @@ commands: <C extends Record<string, RedemeineCommandDefinition<S, TMeta>>>(
      * .overrideCommandNames({ cancelOrder: 'cmd.legacy.cancel' })
      */
     overrideCommandNames: (overrides: Partial<Record<AggregateCommandKeys<M>, CommandType>>) => 
-        AggregateBuilder<S, Name, M, E, EOverrides, Sel, Registry, TMeta>;
+        AggregateBuilder<S, Name, M, E, EOverrides, Sel, Registry, TMeta, TPlugins>;
 
     /**
      * Registers lifecycle hooks for cross-cutting concerns (e.g., logging, auth, metrics).
@@ -325,7 +325,7 @@ commands: <C extends Record<string, RedemeineCommandDefinition<S, TMeta>>>(
      *   onEventApplied: (event, state) => console.log(`State updated to ${state.status}`)
      * })
      */
-    hooks: (hooks: AggregateHooks<S>) => AggregateBuilder<S, Name, M, E, EOverrides, Sel, Registry, TMeta>;
+    hooks: (hooks: AggregateHooks<S>) => AggregateBuilder<S, Name, M, E, EOverrides, Sel, Registry, TMeta, TPlugins>;
 
     /**
      * Finalizes and compiles the aggregate.
@@ -384,10 +384,10 @@ commands: <C extends Record<string, RedemeineCommandDefinition<S, TMeta>>>(
  *     }
  *   }))
  */
-export function createAggregate<S, Name extends string, TMeta extends Record<string, unknown> = Record<string, unknown>>(
+export function createAggregate<S, Name extends string, TMeta extends Record<string, unknown> = Record<string, unknown>, TPlugins extends PluginExtensions = {}>(
     aggregateName: Name,
     initialState: S
-): AggregateBuilder<S, Name, {}, {}, {}, {}, {}, TMeta> {
+): AggregateBuilder<S, Name, {}, {}, {}, {}, {}, TMeta, TPlugins> {
 
     const component = createComponentBehaviorState<S>();
     let _entityPackages: MountedEntityPackage[] = [];
@@ -409,7 +409,7 @@ export function createAggregate<S, Name extends string, TMeta extends Record<str
     });
 
     Object.assign(builder, {
-        extends: (parentBuilder: AggregateBuilder<S, string, unknown, unknown, unknown, unknown, AggregateEntityRegistry, TMeta>) => {
+        extends: (parentBuilder: AggregateBuilder<S, string, unknown, unknown, unknown, unknown, AggregateEntityRegistry, TMeta, TPlugins>) => {
             const parentState = parentBuilder._state;
             component.inherit(parentState);
             _hooks = { ...parentState.hooks, ..._hooks };
@@ -641,7 +641,7 @@ export function createAggregate<S, Name extends string, TMeta extends Record<str
 
             const commandHandlerByType = Object.keys(allCommandsMap).reduce((acc, key) => {
                 const resolvedCommandType = allCommandOverrides[key] || _namingStrategy.command(aggregateName, key);
-                acc[resolvedCommandType] = resolveCommandHandler<S>(allCommandsMap[key]);
+                acc[resolvedCommandType] = resolveCommandHandler<S>(allCommandsMap[key]) as unknown as (state: ReadonlyDeep<S>, payload: unknown) => Event | Event[];
                 return acc;
             }, {} as Record<string, (state: ReadonlyDeep<S>, payload: unknown) => Event | Event[]>);
 
@@ -666,5 +666,5 @@ export function createAggregate<S, Name extends string, TMeta extends Record<str
         }
     });
 
-    return builder as unknown as AggregateBuilder<S, Name, {}, {}, {}, {}, {}, TMeta>;
+    return builder as unknown as AggregateBuilder<S, Name, {}, {}, {}, {}, {}, TMeta, TPlugins>;
 }

--- a/src/createAggregate.ts
+++ b/src/createAggregate.ts
@@ -668,9 +668,9 @@ export function createAggregate<S, Name extends string, TMeta extends Record<str
 
             const commandHandlerByType = Object.keys(allCommandsMap).reduce((acc, key) => {
                 const resolvedCommandType = allCommandOverrides[key] || _namingStrategy.command(aggregateName, key);
-                acc[resolvedCommandType] = resolveCommandHandler<S>(allCommandsMap[key]) as unknown as (state: ReadonlyDeep<S>, payload: unknown) => Event | { events: Event[] } | Event[];
+                acc[resolvedCommandType] = resolveCommandHandler<S>(allCommandsMap[key]) as unknown as (state: ReadonlyDeep<S>, payload: unknown) => Event | { events: Event[]; intents?: Record<string, unknown> } | Event[];
                 return acc;
-            }, {} as Record<string, (state: ReadonlyDeep<S>, payload: unknown) => Event | { events: Event[] } | Event[]>);
+            }, {} as Record<string, (state: ReadonlyDeep<S>, payload: unknown) => Event | { events: Event[]; intents?: Record<string, unknown> } | Event[]>);
 
             return {
                 initialState,

--- a/src/createAggregate.ts
+++ b/src/createAggregate.ts
@@ -1,4 +1,4 @@
-import { Event, Command, EventEmitterFactory, EventType, CommandType, NamingStrategy, SelectorsMap, AggregateHooks, MapCommandsToPayloads, PluginContext, PluginExtensions } from './types';
+import { Event, Command, EventEmitterFactory, EventType, CommandType, NamingStrategy, SelectorsMap, AggregateHooks, MapCommandsToPayloads, PluginContext, PluginExtensions, CommandContext, CommandIntents } from './types';
 import { MixinPackage } from './createMixin';
 import { EntityPackage } from './createEntity';
 import { ReadonlyDeep } from './utils/types/ReadonlyDeep';
@@ -8,6 +8,7 @@ import { applyEvent } from './utils/applyEvent';
 import { createCommandProcessor } from './createCommandProcessor';
 import { createEmitProxy } from './proxies/createEmitProxy';
 import { createCommandCreatorsProxy } from './proxies/createCommandCreatorsProxy';
+import { createCommandContextProxy } from './proxies/createCommandContextProxy';
 import { defaultNamingStrategy } from './utils/naming';
 import { RedemeineCommandDefinition, RedemeineEventDefinition, NormalizeEventDefinitions, GenericCommandFactory, GenericCommandMap, resolveCommandHandler, createComponentBehaviorState, bindFluentMethods } from './redemeineComponent';
 import { bindContext } from './bindContext';
@@ -301,7 +302,7 @@ export interface AggregateBuilder<S, Name extends string, M = {}, E = {}, EOverr
      * }))
      */
 commands: <C extends Record<string, RedemeineCommandDefinition<S, TMeta, TPlugins>>>(
-        factory: (emit: EventEmitterFactory<Name, E, EOverrides>, context: { selectors: Sel; plugins?: PluginContext<TPlugins> }) => C
+        factory: (emit: EventEmitterFactory<Name, E, EOverrides>, context: { selectors: Sel; commands: CommandContext<CommandIntents<M>>; plugins?: PluginContext<TPlugins> }) => C
     ) => AggregateBuilder<S, Name, M & MapCommandsToPayloads<C>, E, EOverrides, Sel, Registry, TMeta, TPlugins>;
 
     /**
@@ -534,10 +535,16 @@ export function createAggregate<S, Name extends string, TMeta extends Record<str
             const emit = createEmitProxy(aggregateName, allEventOverrides, _namingStrategy);
 
             const allCommandsMap: GenericCommandMap = {
-                ...component.getCommandsFactory()(emit, { selectors: allSelectors }),
+                ...component.getCommandsFactory()(emit, {
+                    selectors: allSelectors,
+                    commands: createCommandContextProxy<Record<string, unknown>>()
+                }),
                 ..._mixins.reduce((acc, m) => ({
                     ...acc,
-                    ...(m.commandFactory ? m.commandFactory(emit, { selectors: allSelectors }) : {})
+                    ...(m.commandFactory ? m.commandFactory(emit, {
+                        selectors: allSelectors,
+                        commands: createCommandContextProxy<Record<string, unknown>>()
+                    }) : {})
                 }), {} as GenericCommandMap)
             };
 
@@ -596,7 +603,10 @@ export function createAggregate<S, Name extends string, TMeta extends Record<str
                 });
 
                 const entityEmit = createEmitProxy(aggregateName, allEventOverrides, _namingStrategy, entityPath);
-                const entityCommands = entity.commandFactory(entityEmit, { selectors: mergedSelectors });
+                const entityCommands = entity.commandFactory(entityEmit, {
+                    selectors: mergedSelectors,
+                    commands: createCommandContextProxy<Record<string, unknown>>()
+                });
                 const entityCommandNameOverrides = entity.commandOverrides || {};
                 const mountCommandNameOverrides = {
                     ...((mountOverrides && mountOverrides.commandOverrides) || {}),

--- a/src/createAggregate.ts
+++ b/src/createAggregate.ts
@@ -651,9 +651,9 @@ export function createAggregate<S, Name extends string, TMeta extends Record<str
 
             const commandHandlerByType = Object.keys(allCommandsMap).reduce((acc, key) => {
                 const resolvedCommandType = allCommandOverrides[key] || _namingStrategy.command(aggregateName, key);
-                acc[resolvedCommandType] = resolveCommandHandler<S>(allCommandsMap[key]) as unknown as (state: ReadonlyDeep<S>, payload: unknown) => Event | Event[];
+                acc[resolvedCommandType] = resolveCommandHandler<S>(allCommandsMap[key]) as unknown as (state: ReadonlyDeep<S>, payload: unknown) => Event | { events: Event[] } | Event[];
                 return acc;
-            }, {} as Record<string, (state: ReadonlyDeep<S>, payload: unknown) => Event | Event[]>);
+            }, {} as Record<string, (state: ReadonlyDeep<S>, payload: unknown) => Event | { events: Event[] } | Event[]>);
 
             return {
                 initialState,

--- a/src/createCommandProcessor.ts
+++ b/src/createCommandProcessor.ts
@@ -1,11 +1,43 @@
-﻿import { Event, Command, EventCommandLink, EnvelopeHeaders } from './types';
+import { Event, Command, CommandResult, EventCommandLink, EnvelopeHeaders, PluginExtensions } from './types';
 import { ReadonlyDeep } from './utils/types/ReadonlyDeep';
 import { formatCommandType } from './utils/naming';
 import { GenericCommandMap, resolveCommandHandler } from './redemeineComponent';
 import { createReadonlyDeepProxy } from './utils/readonlyProxy';
 import { createIdentity } from './identity';
 
-type CommandHandler<S> = (state: ReadonlyDeep<S>, payload: unknown) => Event | Event[];
+type NormalizedCommandExecutionResult<TPlugins extends PluginExtensions = {}> = {
+    events: Event[];
+    intents: Record<string, unknown> & TPlugins['intents'];
+};
+
+type CommandHandler<S, TPlugins extends PluginExtensions = {}> = (
+    state: ReadonlyDeep<S>,
+    payload: unknown
+) => Event | CommandResult<Event, TPlugins>;
+
+export function normalizeCommandExecutionResult<TPlugins extends PluginExtensions = {}>(
+    result: Event | CommandResult<Event, TPlugins>
+): NormalizedCommandExecutionResult<TPlugins> {
+    if (Array.isArray(result)) {
+        return {
+            events: result,
+            intents: {} as Record<string, unknown> & TPlugins['intents']
+        };
+    }
+
+    if (result && typeof result === 'object' && 'events' in result && Array.isArray((result as { events?: unknown }).events)) {
+        const { events, ...rest } = result as { events: Event[] } & Record<string, unknown>;
+        return {
+            events,
+            intents: rest as Record<string, unknown> & TPlugins['intents']
+        };
+    }
+
+    return {
+        events: [result as Event],
+        intents: {} as Record<string, unknown> & TPlugins['intents']
+    };
+}
 
 function ensureCommandId(command: Command<unknown, string>): Command<unknown, string> {
     if (command.id) {
@@ -70,7 +102,14 @@ export function createCommandProcessor<S>(
         
         const readonlyState = createReadonlyDeepProxy(state);
         const result = handler(readonlyState as ReadonlyDeep<S>, payload);
-        const events = Array.isArray(result) ? result : [result];
-        return events.map(event => withCommandLink(event, commandWithId));
+        const normalized = normalizeCommandExecutionResult(result);
+        const linkedEvents = normalized.events.map(event => withCommandLink(event, commandWithId));
+        Object.defineProperty(linkedEvents, '__intents', {
+            value: normalized.intents,
+            enumerable: false,
+            configurable: true,
+            writable: false
+        });
+        return linkedEvents;
     };
 }

--- a/src/createCommandProcessor.ts
+++ b/src/createCommandProcessor.ts
@@ -57,7 +57,7 @@ export function createCommandProcessor<S>(
 ) {
     const handlerByType: Record<string, CommandHandler<S>> = commandHandlerByType || Object.keys(allCommandsMap).reduce((acc, key) => {
         const commandType = allCommandOverrides[key] || formatCommandType(aggregateName, key);
-        acc[commandType] = resolveCommandHandler<S>(allCommandsMap[key]);
+        acc[commandType] = resolveCommandHandler<S>(allCommandsMap[key]) as unknown as CommandHandler<S>;
         return acc;
     }, {} as Record<string, CommandHandler<S>>);
 

--- a/src/createCommandProcessor.ts
+++ b/src/createCommandProcessor.ts
@@ -1,4 +1,4 @@
-import { Event, Command, CommandResult, EventCommandLink, EnvelopeHeaders, PluginExtensions } from './types';
+import { Event, Command, CommandResult, EventCommandLink, EnvelopeHeaders, PluginExtensions, PluginIntents } from './types';
 import { ReadonlyDeep } from './utils/types/ReadonlyDeep';
 import { formatCommandType } from './utils/naming';
 import { GenericCommandMap, resolveCommandHandler } from './redemeineComponent';
@@ -7,35 +7,37 @@ import { createIdentity } from './identity';
 
 type NormalizedCommandExecutionResult<TPlugins extends PluginExtensions = {}> = {
     events: Event[];
-    intents: Record<string, unknown> & TPlugins['intents'];
+    intents: PluginIntents<TPlugins>;
 };
 
-type CommandHandler<S, TPlugins extends PluginExtensions = {}> = (
+type CommandHandler<S> = (
     state: ReadonlyDeep<S>,
     payload: unknown
-) => Event | CommandResult<Event, TPlugins>;
+) => Event | Event[] | { events: Event[]; intents?: Record<string, unknown> };
 
 export function normalizeCommandExecutionResult<TPlugins extends PluginExtensions = {}>(
     result: Event | CommandResult<Event, TPlugins>
 ): NormalizedCommandExecutionResult<TPlugins> {
+    const emptyIntents = () => undefined as unknown as PluginIntents<TPlugins>;
+
     if (Array.isArray(result)) {
         return {
             events: result,
-            intents: {} as Record<string, unknown> & TPlugins['intents']
+            intents: emptyIntents()
         };
     }
 
     if (result && typeof result === 'object' && 'events' in result && Array.isArray((result as { events?: unknown }).events)) {
-        const { events, ...rest } = result as { events: Event[] } & Record<string, unknown>;
+        const { events, intents } = result as { events: Event[]; intents?: PluginIntents<TPlugins> };
         return {
             events,
-            intents: rest as Record<string, unknown> & TPlugins['intents']
+            intents: (intents ?? emptyIntents()) as PluginIntents<TPlugins>
         };
     }
 
     return {
         events: [result as Event],
-        intents: {} as Record<string, unknown> & TPlugins['intents']
+        intents: emptyIntents()
     };
 }
 
@@ -102,7 +104,7 @@ export function createCommandProcessor<S>(
         
         const readonlyState = createReadonlyDeepProxy(state);
         const result = handler(readonlyState as ReadonlyDeep<S>, payload);
-        const normalized = normalizeCommandExecutionResult(result);
+        const normalized = normalizeCommandExecutionResult(result as Event | CommandResult<Event, PluginExtensions>);
         const linkedEvents = normalized.events.map(event => withCommandLink(event, commandWithId));
         Object.defineProperty(linkedEvents, '__intents', {
             value: normalized.intents,

--- a/src/createEntity.ts
+++ b/src/createEntity.ts
@@ -1,4 +1,4 @@
-﻿import { Event, EventEmitterFactory, EventType, CommandType, SelectorsMap, MapCommandsToPayloads } from './types';
+import { Event, EventEmitterFactory, EventType, CommandType, SelectorsMap, MapCommandsToPayloads, CommandContext, CommandIntents } from './types';
 import { RedemeineComponent, RedemeineCommandDefinition, RedemeineEventDefinition, NormalizeEventDefinitions, GenericCommandFactory, GenericCommandMap, createComponentBehaviorState, bindFluentMethods } from './redemeineComponent';
 import {
   MapEntityCommands,
@@ -69,7 +69,7 @@ export interface EntityBuilder<S, Name extends string, E = {}, EOverrides extend
    * }))
    */
   commands: <C extends Record<string, RedemeineCommandDefinition<S, TMeta>>>(
-    factory: (emit: EventEmitterFactory<string, E, EOverrides>, context: { selectors: Selectors }) => C
+    factory: (emit: EventEmitterFactory<string, E, EOverrides>, context: { selectors: Selectors; commands: CommandContext<CommandIntents<CPayloads>> }) => C
   ) => EntityBuilder<S, Name, E, EOverrides, CPayloads & MapCommandsToPayloads<C>, COverrides, Selectors, TMeta>;
 
   /**

--- a/src/createMirage.ts
+++ b/src/createMirage.ts
@@ -1,4 +1,4 @@
-import { Command, Event, AggregateHooks, CommandInterceptorContext, EventInterceptorContext, PluginExtensions, RedemeinePlugin } from './types';
+import { Command, Event, AggregateHooks, CommandInterceptorContext, EventInterceptorContext, PluginExtensions, PluginIntents, RedemeinePlugin, RedemeinePluginHookError } from './types';
 import { Contract } from './Contract';
 import { ReadonlyDeep } from './utils/types/ReadonlyDeep';
 import { createReadonlyDeepProxy } from './utils/readonlyProxy';
@@ -304,6 +304,27 @@ const hasHydrateEventPlugins = (plugins: RedemeinePlugin<any>[]): boolean => {
     return plugins.some((plugin) => typeof plugin.onHydrateEvent === 'function');
 };
 
+const assertPluginHasKey = (plugin: RedemeinePlugin<any>): void => {
+    if (!plugin.key || typeof plugin.key !== 'string') {
+        throw new Error('Invalid plugin configuration: plugin.key is required and must be a non-empty string.');
+    }
+};
+
+const wrapPluginHookFailure = (
+    plugin: RedemeinePlugin<any>,
+    hook: 'onBeforeCommand' | 'onHydrateEvent' | 'onBeforeAppend' | 'onAfterCommit',
+    aggregateId: string,
+    cause: unknown
+): RedemeinePluginHookError => {
+    assertPluginHasKey(plugin);
+    return new RedemeinePluginHookError({
+        pluginKey: plugin.key,
+        hook,
+        aggregateId,
+        cause
+    });
+};
+
 const hydrateStateFromEvents = <S>(
     builder: BuiltAggregate<S, any, any, any>,
     baseState: S,
@@ -324,6 +345,7 @@ const hydrateStateFromEventsWithPlugins = async <S>(
 
     for (const event of events) {
         const ctx: EventInterceptorContext<{}, unknown> = {
+            pluginKey: '',
             aggregateId,
             eventType: event.type,
             payload: event.payload,
@@ -331,10 +353,16 @@ const hydrateStateFromEventsWithPlugins = async <S>(
         };
 
         for (const plugin of plugins) {
+            assertPluginHasKey(plugin);
             if (typeof plugin.onHydrateEvent === 'function') {
-                const nextPayload = await plugin.onHydrateEvent(ctx);
-                if (nextPayload !== undefined) {
-                    ctx.payload = nextPayload;
+                ctx.pluginKey = plugin.key;
+                try {
+                    const nextPayload = await plugin.onHydrateEvent(ctx);
+                    if (nextPayload !== undefined) {
+                        ctx.payload = nextPayload;
+                    }
+                } catch (error) {
+                    throw wrapPluginHookFailure(plugin, 'onHydrateEvent', aggregateId, error);
                 }
             }
         }
@@ -360,16 +388,22 @@ export interface MirageOptions<TPlugins extends PluginExtensions = {}> {
  * Tracks the uncommitted events, current version, and executes the core command routing.
  */
 export class MirageCore<S> {
-    public uncommitted: Event[] = [];
+    private pendingResults: { events: Event[]; intents: Record<string, unknown> } = {
+        events: [],
+        intents: {}
+    };
     public version: number = 0;
-    private pendingCommitIntents: Record<string, unknown> = {};
     private listeners: ((state: S) => void)[] = [];
     private plugins: RedemeinePlugin<any>[];
     private hasBeforeCommandPlugins: boolean;
 
-    private getResultIntents(events: Event[]): Record<string, unknown> {
+    public get uncommitted(): Event[] {
+        return this.pendingResults.events;
+    }
+
+    private getResultIntents(events: Event[]): PluginIntents<any> {
         const intents = (events as Event[] & { __intents?: Record<string, unknown> }).__intents;
-        return intents && typeof intents === 'object' ? intents : {};
+        return intents && typeof intents === 'object' ? intents : {} as PluginIntents<any>;
     }
 
     constructor(
@@ -381,12 +415,14 @@ export class MirageCore<S> {
         plugins: RedemeinePlugin<any>[] = []
     ) {
         this.plugins = plugins;
+        this.plugins.forEach(assertPluginHasKey);
         this.hasBeforeCommandPlugins = plugins.some((plugin) => typeof plugin.onBeforeCommand === 'function');
     }
 
     private async runBeforeCommandInterceptors(command: Command<any, string>): Promise<void> {
         const commandMetaRegistry = this.builder.metadata?.commands || {};
         const ctx: CommandInterceptorContext<{}, unknown> = {
+            pluginKey: '',
             aggregateId: this.id,
             commandType: command.type,
             payload: command.payload,
@@ -395,7 +431,12 @@ export class MirageCore<S> {
 
         for (const plugin of this.plugins) {
             if (typeof plugin.onBeforeCommand === 'function') {
-                await plugin.onBeforeCommand(ctx);
+                ctx.pluginKey = plugin.key;
+                try {
+                    await plugin.onBeforeCommand(ctx);
+                } catch (error) {
+                    throw wrapPluginHookFailure(plugin, 'onBeforeCommand', this.id, error);
+                }
             }
         }
     }
@@ -438,14 +479,14 @@ export class MirageCore<S> {
                 }
             }
             this.state = this.builder.apply(this.state, ev);
-            this.uncommitted.push(ev);
+            this.pendingResults.events.push(ev);
             if (this.builder.hooks?.onEventApplied) {
                 this.builder.hooks.onEventApplied(ev, createReadonlyDeepProxy(this.state) as any);
             }
         }
 
-        this.pendingCommitIntents = {
-            ...this.pendingCommitIntents,
+        this.pendingResults.intents = {
+            ...this.pendingResults.intents,
             ...this.getResultIntents(events)
         };
 
@@ -494,14 +535,14 @@ export class MirageCore<S> {
                 }
             }
             this.state = this.builder.apply(this.state, ev);
-            this.uncommitted.push(ev);
+            this.pendingResults.events.push(ev);
             if (this.builder.hooks?.onEventApplied) {
                 this.builder.hooks.onEventApplied(ev, createReadonlyDeepProxy(this.state) as any);
             }
         }
 
-        this.pendingCommitIntents = {
-            ...this.pendingCommitIntents,
+        this.pendingResults.intents = {
+            ...this.pendingResults.intents,
             ...this.getResultIntents(events)
         };
 
@@ -510,16 +551,18 @@ export class MirageCore<S> {
         return this.state;
     }
 
-    public getPendingCommitContext(): { events: Event[]; intents: Record<string, unknown> } {
+    public getPendingResults(): { events: Event[]; intents: Record<string, unknown> } {
         return {
-            events: [...this.uncommitted],
-            intents: { ...this.pendingCommitIntents }
+            events: [...this.pendingResults.events],
+            intents: { ...this.pendingResults.intents }
         };
     }
 
-    public clearPendingCommitContext(): void {
-        this.uncommitted = [];
-        this.pendingCommitIntents = {};
+    public clearPendingResults(): void {
+        this.pendingResults = {
+            events: [],
+            intents: {}
+        };
     }
 
     public subscribe(listener: (state: S) => void) {
@@ -1301,7 +1344,7 @@ export function createLegacyAggregateBridge<S, M extends Record<string, any>, Re
         get id() { return core.id; },
         get _state() { return core.state; },
         getVersion: () => core.version,
-        clearUncommittedEvents: () => { core.clearPendingCommitContext(); },
+        clearUncommittedEvents: () => { core.clearPendingResults(); },
         getUncommittedEvents: () => [...core.uncommitted],
     };
 }

--- a/src/createMirage.ts
+++ b/src/createMirage.ts
@@ -361,9 +361,15 @@ export interface MirageOptions {
 export class MirageCore<S> {
     public uncommitted: Event[] = [];
     public version: number = 0;
+    private pendingCommitIntents: Record<string, unknown> = {};
     private listeners: ((state: S) => void)[] = [];
     private plugins: RedemeinePlugin[];
     private hasBeforeCommandPlugins: boolean;
+
+    private getResultIntents(events: Event[]): Record<string, unknown> {
+        const intents = (events as Event[] & { __intents?: Record<string, unknown> }).__intents;
+        return intents && typeof intents === 'object' ? intents : {};
+    }
 
     constructor(
         public builder: BuiltAggregate<S, any, any, any>,
@@ -436,6 +442,12 @@ export class MirageCore<S> {
                 this.builder.hooks.onEventApplied(ev, createReadonlyDeepProxy(this.state) as any);
             }
         }
+
+        this.pendingCommitIntents = {
+            ...this.pendingCommitIntents,
+            ...this.getResultIntents(events)
+        };
+
         this.version++;
         this.notify();
         return this.state;
@@ -486,9 +498,27 @@ export class MirageCore<S> {
                 this.builder.hooks.onEventApplied(ev, createReadonlyDeepProxy(this.state) as any);
             }
         }
+
+        this.pendingCommitIntents = {
+            ...this.pendingCommitIntents,
+            ...this.getResultIntents(events)
+        };
+
         this.version++;
         this.notify();
         return this.state;
+    }
+
+    public getPendingCommitContext(): { events: Event[]; intents: Record<string, unknown> } {
+        return {
+            events: [...this.uncommitted],
+            intents: { ...this.pendingCommitIntents }
+        };
+    }
+
+    public clearPendingCommitContext(): void {
+        this.uncommitted = [];
+        this.pendingCommitIntents = {};
     }
 
     public subscribe(listener: (state: S) => void) {
@@ -1269,7 +1299,7 @@ export function createLegacyAggregateBridge<S, M extends Record<string, any>, Re
         get id() { return core.id; },
         get _state() { return core.state; },
         getVersion: () => core.version,
-        clearUncommittedEvents: () => { core.uncommitted = []; },
+        clearUncommittedEvents: () => { core.clearPendingCommitContext(); },
         getUncommittedEvents: () => [...core.uncommitted],
     };
 }

--- a/src/createMirage.ts
+++ b/src/createMirage.ts
@@ -721,7 +721,10 @@ export function createMirage<BA extends BuiltAggregate<any, any, any, any, any>>
         try {
             const fakeEmit = new Proxy({}, { get: () => () => ({ type: '', payload: undefined }) });
             const fakeSelectors = new Proxy({}, { get: () => () => undefined });
-            const roleCommands = roleAsEntity.commandFactory(fakeEmit, { selectors: fakeSelectors }) || {};
+            const fakeCommands = new Proxy({}, {
+                get: (_target, prop: string) => (payload: unknown) => ({ command: prop, payload })
+            });
+            const roleCommands = roleAsEntity.commandFactory(fakeEmit, { selectors: fakeSelectors, commands: fakeCommands }) || {};
             const names = Object.keys(roleCommands);
             roleCommandNamesCache.set(role, names);
             return names;

--- a/src/createMirage.ts
+++ b/src/createMirage.ts
@@ -322,7 +322,7 @@ const hydrateStateFromEventsWithPlugins = async <S>(
     const eventMetaRegistry = builder.metadata?.events || {};
 
     for (const event of events) {
-        const ctx: EventInterceptorContext<Record<string, unknown>, unknown> = {
+        const ctx: EventInterceptorContext<{}, unknown> = {
             aggregateId,
             eventType: event.type,
             payload: event.payload,
@@ -379,7 +379,7 @@ export class MirageCore<S> {
 
     private async runBeforeCommandInterceptors(command: Command<any, string>): Promise<void> {
         const commandMetaRegistry = this.builder.metadata?.commands || {};
-        const ctx: CommandInterceptorContext<Record<string, unknown>, unknown> = {
+        const ctx: CommandInterceptorContext<{}, unknown> = {
             aggregateId: this.id,
             commandType: command.type,
             payload: command.payload,

--- a/src/createMirage.ts
+++ b/src/createMirage.ts
@@ -1,4 +1,4 @@
-import { Command, Event, AggregateHooks, CommandInterceptorContext, EventInterceptorContext, RedemeinePlugin } from './types';
+import { Command, Event, AggregateHooks, CommandInterceptorContext, EventInterceptorContext, PluginExtensions, RedemeinePlugin } from './types';
 import { Contract } from './Contract';
 import { ReadonlyDeep } from './utils/types/ReadonlyDeep';
 import { createReadonlyDeepProxy } from './utils/readonlyProxy';
@@ -26,7 +26,7 @@ type InvocationContext = {
  * Represents the instantiated, running state of the aggregate after the builder's .build() method is called.
  * It contains the initial state and the internal processing/application functions.
  */
-export interface BuiltAggregate<S, M, E = any, Registry extends AggregateEntityRegistry = {}, Sel extends Record<string, any> = {}> {
+export interface BuiltAggregate<S, M, E = any, Registry extends AggregateEntityRegistry = {}, Sel extends Record<string, any> = {}, TPlugins extends PluginExtensions = {}> {
     initialState: S;
     process: (state: S, command: Command<any, string>) => Event[];
     apply: (state: S, event: Event) => S;
@@ -49,6 +49,7 @@ export interface BuiltAggregate<S, M, E = any, Registry extends AggregateEntityR
         commands?: Record<string, { meta?: Record<string, unknown> }>;
         events?: Record<string, { meta?: Record<string, unknown> }>;
     };
+    plugins?: RedemeinePlugin<TPlugins>[];
     mounts?: Record<string, MountMetadata>;
     __registryType?: Registry;
 }
@@ -299,7 +300,7 @@ export type Mirage<TState, M extends Record<string, any> = any, Registry extends
  */
 export const MirageCoreSymbol = Symbol('MirageCore');
 
-const hasHydrateEventPlugins = (plugins: RedemeinePlugin[]): boolean => {
+const hasHydrateEventPlugins = (plugins: RedemeinePlugin<any>[]): boolean => {
     return plugins.some((plugin) => typeof plugin.onHydrateEvent === 'function');
 };
 
@@ -316,7 +317,7 @@ const hydrateStateFromEventsWithPlugins = async <S>(
     aggregateId: string,
     baseState: S,
     events: Event[],
-    plugins: RedemeinePlugin[]
+    plugins: RedemeinePlugin<any>[]
 ): Promise<S> => {
     let state = baseState;
     const eventMetaRegistry = builder.metadata?.events || {};
@@ -348,10 +349,10 @@ const hydrateStateFromEventsWithPlugins = async <S>(
 /**
  * Configuration options strictly passed during the instantiation of a Mirage instance.
  */
-export interface MirageOptions {
+export interface MirageOptions<TPlugins extends PluginExtensions = {}> {
     contract?: Contract;
     strict?: boolean;
-    plugins?: RedemeinePlugin[];
+    plugins?: RedemeinePlugin<TPlugins>[];
 }
 
 /**
@@ -363,7 +364,7 @@ export class MirageCore<S> {
     public version: number = 0;
     private pendingCommitIntents: Record<string, unknown> = {};
     private listeners: ((state: S) => void)[] = [];
-    private plugins: RedemeinePlugin[];
+    private plugins: RedemeinePlugin<any>[];
     private hasBeforeCommandPlugins: boolean;
 
     private getResultIntents(events: Event[]): Record<string, unknown> {
@@ -377,7 +378,7 @@ export class MirageCore<S> {
         public state: S,
         public contract?: Contract,
         public strict: boolean = false,
-        plugins: RedemeinePlugin[] = []
+        plugins: RedemeinePlugin<any>[] = []
     ) {
         this.plugins = plugins;
         this.hasBeforeCommandPlugins = plugins.some((plugin) => typeof plugin.onBeforeCommand === 'function');
@@ -547,6 +548,7 @@ type BuiltAggregateCommands<T> = T extends BuiltAggregate<any, infer M, any, any
 type BuiltAggregateState<T> = T extends BuiltAggregate<infer S, any, any, any> ? S : never;
 type BuiltAggregateRegistry<T> = T extends BuiltAggregate<any, any, any, infer R, any> ? R : {};
 type BuiltAggregateSelectors<T> = T extends BuiltAggregate<any, any, any, any, infer Sel> ? Sel : {};
+type BuiltAggregatePlugins<T> = T extends BuiltAggregate<any, any, any, any, any, infer P> ? P : {};
 
 export function createMirage<BA extends BuiltAggregate<any, any, any, any, any>>(
     builder: BA,
@@ -555,32 +557,32 @@ export function createMirage<BA extends BuiltAggregate<any, any, any, any, any>>
 export function createMirage<BA extends BuiltAggregate<any, any, any, any, any>>(
     builder: BA,
     id: string,
-    setup: (MirageOptions & { snapshot?: BuiltAggregateState<BA>; events?: undefined }) | undefined
+    setup: (MirageOptions<BuiltAggregatePlugins<BA>> & { snapshot?: BuiltAggregateState<BA>; events?: undefined }) | undefined
 ): Mirage<BuiltAggregateState<BA>, BuiltAggregateCommands<BA>, BuiltAggregateRegistry<BA>, BuiltAggregateSelectors<BA>>;
 export function createMirage<BA extends BuiltAggregate<any, any, any, any, any>>(
     builder: BA,
     id: string,
-    setup: (Omit<MirageOptions, 'plugins'> & { snapshot?: BuiltAggregateState<BA>; events?: Event[] }) | undefined
+    setup: (Omit<MirageOptions<BuiltAggregatePlugins<BA>>, 'plugins'> & { snapshot?: BuiltAggregateState<BA>; events?: Event[] }) | undefined
 ): Mirage<BuiltAggregateState<BA>, BuiltAggregateCommands<BA>, BuiltAggregateRegistry<BA>, BuiltAggregateSelectors<BA>>;
 export function createMirage<BA extends BuiltAggregate<any, any, any, any, any>>(
     builder: BA,
     id: string,
-    setup: MirageOptions & { snapshot?: BuiltAggregateState<BA>; events: Event[]; plugins: RedemeinePlugin[] }
+    setup: MirageOptions<BuiltAggregatePlugins<BA>> & { snapshot?: BuiltAggregateState<BA>; events: Event[]; plugins: RedemeinePlugin<any>[] }
 ): Promise<Mirage<BuiltAggregateState<BA>, BuiltAggregateCommands<BA>, BuiltAggregateRegistry<BA>, BuiltAggregateSelectors<BA>>>;
 export function createMirage<BA extends BuiltAggregate<any, any, any, any, any>>(
     builder: BA,
     id: string,
-    setup: MirageOptions & { snapshot?: BuiltAggregateState<BA>; events: Event[] }
+    setup: MirageOptions<BuiltAggregatePlugins<BA>> & { snapshot?: BuiltAggregateState<BA>; events: Event[] }
 ): Mirage<BuiltAggregateState<BA>, BuiltAggregateCommands<BA>, BuiltAggregateRegistry<BA>, BuiltAggregateSelectors<BA>> | Promise<Mirage<BuiltAggregateState<BA>, BuiltAggregateCommands<BA>, BuiltAggregateRegistry<BA>, BuiltAggregateSelectors<BA>>>;
 export function createMirage<BA extends BuiltAggregate<any, any, any, any, any>>(
     builder: BA,
     id: string,
-    setup?: MirageOptions & { snapshot?: BuiltAggregateState<BA>; events?: Event[] }
+    setup?: MirageOptions<BuiltAggregatePlugins<BA>> & { snapshot?: BuiltAggregateState<BA>; events?: Event[] }
 ): Mirage<BuiltAggregateState<BA>, BuiltAggregateCommands<BA>, BuiltAggregateRegistry<BA>, BuiltAggregateSelectors<BA>> | Promise<Mirage<BuiltAggregateState<BA>, BuiltAggregateCommands<BA>, BuiltAggregateRegistry<BA>, BuiltAggregateSelectors<BA>>> {
 
-    const makeMirage = (state: BuiltAggregateState<BA>): Mirage<BuiltAggregateState<BA>, BuiltAggregateCommands<BA>, BuiltAggregateRegistry<BA>, BuiltAggregateSelectors<BA>> => {
+    const makeMirage = (state: BuiltAggregateState<BA>, plugins: RedemeinePlugin<any>[]): Mirage<BuiltAggregateState<BA>, BuiltAggregateCommands<BA>, BuiltAggregateRegistry<BA>, BuiltAggregateSelectors<BA>> => {
 
-    const core = new MirageCore(builder, id, state, setup?.contract, setup?.strict, setup?.plugins || []);
+    const core = new MirageCore(builder, id, state, setup?.contract, setup?.strict, plugins);
     const mounts = builder.mounts || {};
     const selectors = (builder.selectors || {}) as Record<string, (state: ReadonlyDeep<BuiltAggregateState<BA>>, ...args: any[]) => any>;
 
@@ -1274,19 +1276,19 @@ export function createMirage<BA extends BuiltAggregate<any, any, any, any, any>>
 
     const baseState = setup?.snapshot ?? builder.initialState;
     const setupEvents = setup?.events || [];
-    const plugins = setup?.plugins || [];
+    const plugins = [...(builder.plugins || []), ...(setup?.plugins || [])] as RedemeinePlugin<any>[];
 
     if (setupEvents.length === 0) {
-        return makeMirage(baseState);
+        return makeMirage(baseState, plugins);
     }
 
     if (!hasHydrateEventPlugins(plugins)) {
-        return makeMirage(hydrateStateFromEvents(builder, baseState, setupEvents));
+        return makeMirage(hydrateStateFromEvents(builder, baseState, setupEvents), plugins);
     }
 
     return (async () => {
         const hydratedState = await hydrateStateFromEventsWithPlugins(builder, id, baseState, setupEvents, plugins);
-        return makeMirage(hydratedState);
+        return makeMirage(hydratedState, plugins);
     })();
 }
 

--- a/src/createMixin.ts
+++ b/src/createMixin.ts
@@ -1,4 +1,4 @@
-import { Event, EventEmitterFactory, EventType, CommandType, SelectorsMap, MapCommandsToPayloads } from './types';
+import { Event, EventEmitterFactory, EventType, CommandType, SelectorsMap, MapCommandsToPayloads, CommandContext, CommandIntents } from './types';
 import { RedemeineComponent, RedemeineCommandDefinition, RedemeineEventDefinition, NormalizeEventDefinitions, GenericCommandFactory, GenericCommandMap, createComponentBehaviorState, bindFluentMethods } from './redemeineComponent';
 import type { EntityPackage } from './createEntity';
 import {
@@ -68,7 +68,7 @@ export interface MixinBuilder<S, E = {}, EOverrides extends object = {}, CPayloa
   ) => MixinBuilder<S, E, EOverrides, CPayloads, COverrides, Selectors & NewSelectors, Registry, TMeta>;
 
   commands: <NewC extends Record<string, RedemeineCommandDefinition<S, TMeta>>>(
-    factory: (emit: EventEmitterFactory<string, E, EOverrides>, context: { selectors: Selectors }) => NewC
+    factory: (emit: EventEmitterFactory<string, E, EOverrides>, context: { selectors: Selectors; commands: CommandContext<CommandIntents<CPayloads>> }) => NewC
   ) => MixinBuilder<S, E, EOverrides, CPayloads & MapCommandsToPayloads<NewC>, COverrides, Selectors, Registry, TMeta>;
 
   entityList: <EN extends string, T extends EntityPackage<any, any, any, any, any, any>, const PK extends string | readonly string[] = 'id'>(

--- a/src/proxies/createCommandContextProxy.ts
+++ b/src/proxies/createCommandContextProxy.ts
@@ -1,0 +1,12 @@
+import { CommandContext } from '../types';
+
+export function createCommandContextProxy<TIntents extends Record<string, unknown>>(): CommandContext<TIntents> {
+  return new Proxy({}, {
+    get: (_target, prop: string) => {
+      return (payload: unknown) => ({
+        command: prop,
+        payload
+      });
+    }
+  }) as CommandContext<TIntents>;
+}

--- a/src/redemeineComponent.ts
+++ b/src/redemeineComponent.ts
@@ -1,4 +1,4 @@
-import { CommandResult, Event, PackedCommandWithMeta, PluginExtensions, SelectorsMap, ShorthandCommandWithMeta } from './types';
+import { CommandContext, CommandIntents, CommandResult, Event, PackedCommandWithMeta, PluginExtensions, SelectorsMap, ShorthandCommandWithMeta } from './types';
 import { ReadonlyDeep } from './utils/types/ReadonlyDeep';
 import type { Merge } from './utils/types/Merge';
 import type { AllKeys } from './utils/types/AllKeys';
@@ -6,7 +6,12 @@ import type { ReplaceFirstArg } from './utils/types/ReplaceFirstArg';
 
 export type GenericSelectors = Record<string, unknown>;
 export type GenericCommandMap = Record<string, RedemeineCommandDefinition<any, Record<string, unknown>, {}>>;
-export type GenericCommandFactory = (emit: unknown, context: { selectors: GenericSelectors; plugins?: Record<string, unknown> }) => GenericCommandMap;
+export type GenericCommandFactoryContext<TCommands extends Record<string, unknown> = Record<string, unknown>> = {
+  selectors: GenericSelectors;
+  commands: CommandContext<CommandIntents<TCommands>>;
+  plugins?: Record<string, unknown>;
+};
+export type GenericCommandFactory = (emit: unknown, context: GenericCommandFactoryContext) => GenericCommandMap;
 
 export type RedemeineEventProjector<S> = (state: S, event: Event<any, any>) => void;
 export type RedemeineEventDefinition<S, TMeta extends Record<string, unknown> = Record<string, unknown>> =
@@ -88,7 +93,7 @@ export type PublicCommandMethodsFromInternal<S, TCommands extends Record<string,
 export function composeCommandFactories(
   factories: GenericCommandFactory[]
 ): GenericCommandFactory {
-  return (emit: unknown, context: { selectors: GenericSelectors; plugins?: Record<string, unknown> }) => {
+  return (emit: unknown, context: GenericCommandFactoryContext) => {
     const merged: GenericCommandMap = {};
     for (const factory of factories) {
       Object.assign(merged, factory(emit, context));

--- a/src/redemeineComponent.ts
+++ b/src/redemeineComponent.ts
@@ -1,4 +1,5 @@
 import { CommandContext, CommandIntents, CommandResult, Event, PackedCommandWithMeta, PluginExtensions, SelectorsMap, ShorthandCommandWithMeta } from './types';
+import { createCommandContextProxy } from './proxies/createCommandContextProxy';
 import { ReadonlyDeep } from './utils/types/ReadonlyDeep';
 import type { Merge } from './utils/types/Merge';
 import type { AllKeys } from './utils/types/AllKeys';
@@ -8,10 +9,23 @@ export type GenericSelectors = Record<string, unknown>;
 export type GenericCommandMap = Record<string, RedemeineCommandDefinition<any, Record<string, unknown>, {}>>;
 export type GenericCommandFactoryContext<TCommands extends Record<string, unknown> = Record<string, unknown>> = {
   selectors: GenericSelectors;
-  commands: CommandContext<CommandIntents<TCommands>>;
+  commands?: CommandContext<CommandIntents<TCommands>>;
   plugins?: Record<string, unknown>;
 };
 export type GenericCommandFactory = (emit: unknown, context: GenericCommandFactoryContext) => GenericCommandMap;
+
+export function resolveCommandFactoryContext(
+  context: GenericCommandFactoryContext
+): GenericCommandFactoryContext {
+  if (context.commands) {
+    return context;
+  }
+
+  return {
+    ...context,
+    commands: createCommandContextProxy<Record<string, unknown>>()
+  };
+}
 
 export type RedemeineEventProjector<S> = (state: S, event: Event<any, any>) => void;
 export type RedemeineEventDefinition<S, TMeta extends Record<string, unknown> = Record<string, unknown>> =
@@ -94,9 +108,10 @@ export function composeCommandFactories(
   factories: GenericCommandFactory[]
 ): GenericCommandFactory {
   return (emit: unknown, context: GenericCommandFactoryContext) => {
+    const resolvedContext = resolveCommandFactoryContext(context);
     const merged: GenericCommandMap = {};
     for (const factory of factories) {
-      Object.assign(merged, factory(emit, context));
+      Object.assign(merged, factory(emit, resolvedContext));
     }
     return merged;
   };

--- a/src/redemeineComponent.ts
+++ b/src/redemeineComponent.ts
@@ -1,12 +1,12 @@
-import { Event, PackedCommandWithMeta, SelectorsMap, ShorthandCommandWithMeta } from './types';
+import { CommandResult, Event, PackedCommandWithMeta, PluginExtensions, SelectorsMap, ShorthandCommandWithMeta } from './types';
 import { ReadonlyDeep } from './utils/types/ReadonlyDeep';
 import type { Merge } from './utils/types/Merge';
 import type { AllKeys } from './utils/types/AllKeys';
 import type { ReplaceFirstArg } from './utils/types/ReplaceFirstArg';
 
 export type GenericSelectors = Record<string, unknown>;
-export type GenericCommandMap = Record<string, RedemeineCommandDefinition<any, Record<string, unknown>>>;
-export type GenericCommandFactory = (emit: unknown, context: { selectors: GenericSelectors }) => GenericCommandMap;
+export type GenericCommandMap = Record<string, RedemeineCommandDefinition<any, Record<string, unknown>, {}>>;
+export type GenericCommandFactory = (emit: unknown, context: { selectors: GenericSelectors; plugins?: Record<string, unknown> }) => GenericCommandMap;
 
 export type RedemeineEventProjector<S> = (state: S, event: Event<any, any>) => void;
 export type RedemeineEventDefinition<S, TMeta extends Record<string, unknown> = Record<string, unknown>> =
@@ -24,17 +24,21 @@ export type NormalizeEventDefinitions<T extends Record<string, RedemeineEventDef
       : never;
 };
 
-export type RedemeineShorthandCommand<S, Args extends unknown[] = unknown[]> = (
+export type RedemeineShorthandCommand<S, Args extends unknown[] = unknown[], TPlugins extends PluginExtensions = {}> = (
   state: ReadonlyDeep<S>,
   ...args: Args
-) => Event<any, any> | Event<any, any>[];
+) => Event<any, any> | CommandResult<Event<any, any>, TPlugins>;
 
-export type RedemeineCommandDefinition<S, TMeta extends Record<string, unknown> = Record<string, unknown>> =
-  | RedemeineShorthandCommand<S, any[]>
-  | ShorthandCommandWithMeta<S, any[], TMeta>
-  | PackedCommandWithMeta<S, any[], any, TMeta>;
+export type RedemeineCommandDefinition<
+  S,
+  TMeta extends Record<string, unknown> = Record<string, unknown>,
+  TPlugins extends PluginExtensions = {}
+> =
+  | RedemeineShorthandCommand<S, any[], TPlugins>
+  | ShorthandCommandWithMeta<S, any[], TMeta, TPlugins>
+  | PackedCommandWithMeta<S, any[], any, TMeta, TPlugins>;
 
-export type RedemeineCommandMap<S, TMeta extends Record<string, unknown> = Record<string, unknown>> = Record<string, RedemeineCommandDefinition<S, TMeta>>;
+export type RedemeineCommandMap<S, TMeta extends Record<string, unknown> = Record<string, unknown>, TPlugins extends PluginExtensions = {}> = Record<string, RedemeineCommandDefinition<S, TMeta, TPlugins>>;
 
 export interface RedemeineComponent<
   S,
@@ -84,7 +88,7 @@ export type PublicCommandMethodsFromInternal<S, TCommands extends Record<string,
 export function composeCommandFactories(
   factories: GenericCommandFactory[]
 ): GenericCommandFactory {
-  return (emit: unknown, context: { selectors: GenericSelectors }) => {
+  return (emit: unknown, context: { selectors: GenericSelectors; plugins?: Record<string, unknown> }) => {
     const merged: GenericCommandMap = {};
     for (const factory of factories) {
       Object.assign(merged, factory(emit, context));
@@ -95,7 +99,7 @@ export function composeCommandFactories(
 
 export function resolveCommandHandler<S>(
   commandDef: RedemeineCommandDefinition<S>
-): (state: ReadonlyDeep<S>, payload: unknown) => Event<any, any> | Event<any, any>[] {
+): (state: ReadonlyDeep<S>, payload: unknown) => Event<any, any> | CommandResult<Event<any, any>, {}> {
   const handler = typeof commandDef === 'function'
     ? commandDef
     : commandDef.handler;
@@ -103,7 +107,7 @@ export function resolveCommandHandler<S>(
   return handler as (
     state: ReadonlyDeep<S>,
     payload: unknown
-  ) => Event<any, any> | Event<any, any>[];
+  ) => Event<any, any> | CommandResult<Event<any, any>, {}>;
 }
 
 export function createCommandPayload<S>(commandDef: RedemeineCommandDefinition<S>, args: unknown[]): unknown {

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,6 +101,20 @@ export interface RedemeinePlugin<
   onAfterCommit?: (ctx: AfterCommitContext<TExtensions>) => void | Promise<void>;
 }
 
+export type ExtractPluginExtensions<TPlugin> =
+  TPlugin extends RedemeinePlugin<infer TExtensions>
+    ? TExtensions
+    : {};
+
+export type UnionToIntersection<U> = (
+  U extends unknown ? (arg: U) => void : never
+) extends ((arg: infer I) => void)
+  ? I
+  : never;
+
+export type MergePluginExtensions<TPlugins extends readonly RedemeinePlugin<any>[]> =
+  UnionToIntersection<ExtractPluginExtensions<TPlugins[number]>>;
+
 /**
  * Represents a dictionary mapping string keys to selector functions.
  * Selectors are pure functions injecting localized state queries directly into command contexts.

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,18 @@ export interface RedemeinePlugin<
  */
 export type SelectorsMap<S> = Record<string, (state: ReadonlyDeep<S>, ...args: any[]) => any>;
 
+export type CommandContext<TIntents extends Record<string, unknown>> = {
+  [K in keyof TIntents]: (payload: TIntents[K]) => { command: K; payload: TIntents[K] };
+} & {
+  [key: string]: (payload: unknown) => { command: string; payload: unknown };
+};
+
+export type CommandIntents<TCommands> = {
+  [K in keyof TCommands]: TCommands[K] extends { payload: infer P }
+    ? P
+    : TCommands[K];
+};
+
 /**
  * A foundational building block representing a domain event. 
  * Records an intent that has successfully altered the aggregate state.

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,12 +83,22 @@ export interface EventInterceptorContext<
   meta: PluginMeta<TPlugins> | undefined;
 }
 
+export interface AfterCommitContext<
+  TPlugins extends PluginExtensions = {},
+  TEvent extends Event<any, any> = Event<any, any>
+> {
+  aggregateId: string;
+  events: TEvent[];
+  intents: PluginIntents<TPlugins>;
+}
+
 export interface RedemeinePlugin<
   TExtensions extends PluginExtensions = {}
 > {
   onBeforeCommand?: (ctx: CommandInterceptorContext<TExtensions, unknown>) => void | Promise<void>;
   onBeforeAppend?: (ctx: EventInterceptorContext<TExtensions, unknown>) => unknown | void | Promise<unknown | void>;
   onHydrateEvent?: (ctx: EventInterceptorContext<TExtensions, unknown>) => unknown | void | Promise<unknown | void>;
+  onAfterCommit?: (ctx: AfterCommitContext<TExtensions>) => void | Promise<void>;
 }
 
 /**
@@ -135,6 +145,7 @@ export interface Command<P = any, T extends CommandType | string = CommandType> 
 
 export type CommandResult<TEvent, TPlugins extends PluginExtensions = {}> =
   | TEvent[]
+  | TEvent
   | ({ events: TEvent[] } & PluginIntents<TPlugins>);
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,32 +42,53 @@ export interface AggregateHooks<State> {
   onEventApplied?: (event: Event<any, any>, state: ReadonlyDeep<State>) => void;
 }
 
+export interface PluginExtensions {
+  intents?: Record<string, unknown>;
+  context?: Record<string, unknown>;
+  meta?: Record<string, unknown>;
+}
+
+export type PluginIntents<TPlugins extends PluginExtensions = {}> =
+  TPlugins['intents'] extends Record<string, unknown>
+    ? TPlugins['intents']
+    : {};
+
+export type PluginContext<TPlugins extends PluginExtensions = {}> =
+  TPlugins['context'] extends Record<string, unknown>
+    ? TPlugins['context']
+    : {};
+
+export type PluginMeta<TPlugins extends PluginExtensions = {}> =
+  TPlugins['meta'] extends Record<string, unknown>
+    ? TPlugins['meta']
+    : Record<string, unknown>;
+
 export interface CommandInterceptorContext<
-  TMeta extends Record<string, unknown> = Record<string, unknown>,
+  TPlugins extends PluginExtensions = {},
   TPayload = unknown
 > {
   aggregateId: string;
   commandType: string;
   payload: TPayload;
-  meta: TMeta | undefined;
+  meta: PluginMeta<TPlugins> | undefined;
 }
 
 export interface EventInterceptorContext<
-  TMeta extends Record<string, unknown> = Record<string, unknown>,
+  TPlugins extends PluginExtensions = {},
   TPayload = unknown
 > {
   aggregateId: string;
   eventType: string;
   payload: TPayload;
-  meta: TMeta | undefined;
+  meta: PluginMeta<TPlugins> | undefined;
 }
 
 export interface RedemeinePlugin<
-  TMeta extends Record<string, unknown> = Record<string, unknown>
+  TExtensions extends PluginExtensions = {}
 > {
-  onBeforeCommand?: (ctx: CommandInterceptorContext<TMeta, unknown>) => void | Promise<void>;
-  onBeforeAppend?: (ctx: EventInterceptorContext<TMeta, unknown>) => unknown | void | Promise<unknown | void>;
-  onHydrateEvent?: (ctx: EventInterceptorContext<TMeta, unknown>) => unknown | void | Promise<unknown | void>;
+  onBeforeCommand?: (ctx: CommandInterceptorContext<TExtensions, unknown>) => void | Promise<void>;
+  onBeforeAppend?: (ctx: EventInterceptorContext<TExtensions, unknown>) => unknown | void | Promise<unknown | void>;
+  onHydrateEvent?: (ctx: EventInterceptorContext<TExtensions, unknown>) => unknown | void | Promise<unknown | void>;
 }
 
 /**
@@ -99,6 +120,10 @@ export interface Command<P = any, T extends CommandType | string = CommandType> 
   headers?: EnvelopeHeaders;
   metadata?: any;
 }
+
+export type CommandResult<TEvent, TPlugins extends PluginExtensions = {}> =
+  | TEvent[]
+  | ({ events: TEvent[] } & PluginIntents<TPlugins>);
 
 /**
  * Describes the originating command attached to emitted event metadata.
@@ -197,21 +222,21 @@ export type EventEmitterFactory<AggregateName extends string, E, EOverrides> = {
     : never;
 } & Record<string, (...args: any[]) => Event<any, any>>;
 
-export type PackedCommand<S, Args extends any[], P> = {
+export type PackedCommand<S, Args extends any[], P, TPlugins extends PluginExtensions = {}> = {
   /**
    * Defines the public API signature and serializable Command payload structure.
    */
   pack: (...args: Args) => P;
-  handler: (state: ReadonlyDeep<S>, payload: P) => Event<any, any> | Event<any, any>[];
+  handler: (state: ReadonlyDeep<S>, payload: P) => Event<any, any> | CommandResult<Event<any, any>, TPlugins>;
 };
 
-export type PackedCommandWithMeta<S, Args extends any[], P, TMeta extends Record<string, unknown> = Record<string, unknown>> =
-  PackedCommand<S, Args, P> & {
+export type PackedCommandWithMeta<S, Args extends any[], P, TMeta extends Record<string, unknown> = Record<string, unknown>, TPlugins extends PluginExtensions = {}> =
+  PackedCommand<S, Args, P, TPlugins> & {
     meta?: TMeta;
   };
 
-export type ShorthandCommandWithMeta<S, Args extends any[] = any[], TMeta extends Record<string, unknown> = Record<string, unknown>> = {
-  handler: (state: ReadonlyDeep<S>, ...args: Args) => Event<any, any> | Event<any, any>[];
+export type ShorthandCommandWithMeta<S, Args extends any[] = any[], TMeta extends Record<string, unknown> = Record<string, unknown>, TPlugins extends PluginExtensions = {}> = {
+  handler: (state: ReadonlyDeep<S>, ...args: Args) => Event<any, any> | CommandResult<Event<any, any>, TPlugins>;
   meta?: TMeta;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,7 +51,7 @@ export interface PluginExtensions {
 export type PluginIntents<TPlugins extends PluginExtensions = {}> =
   TPlugins['intents'] extends Record<string, unknown>
     ? TPlugins['intents']
-    : {};
+    : never;
 
 export type PluginContext<TPlugins extends PluginExtensions = {}> =
   TPlugins['context'] extends Record<string, unknown>
@@ -67,6 +67,7 @@ export interface CommandInterceptorContext<
   TPlugins extends PluginExtensions = {},
   TPayload = unknown
 > {
+  pluginKey: string;
   aggregateId: string;
   commandType: string;
   payload: TPayload;
@@ -77,6 +78,7 @@ export interface EventInterceptorContext<
   TPlugins extends PluginExtensions = {},
   TPayload = unknown
 > {
+  pluginKey: string;
   aggregateId: string;
   eventType: string;
   payload: TPayload;
@@ -87,6 +89,7 @@ export interface AfterCommitContext<
   TPlugins extends PluginExtensions = {},
   TEvent extends Event<any, any> = Event<any, any>
 > {
+  pluginKey: string;
   aggregateId: string;
   events: TEvent[];
   intents: PluginIntents<TPlugins>;
@@ -95,6 +98,7 @@ export interface AfterCommitContext<
 export interface RedemeinePlugin<
   TExtensions extends PluginExtensions = {}
 > {
+  key: string;
   onBeforeCommand?: (ctx: CommandInterceptorContext<TExtensions, unknown>) => void | Promise<void>;
   onBeforeAppend?: (ctx: EventInterceptorContext<TExtensions, unknown>) => unknown | void | Promise<unknown | void>;
   onHydrateEvent?: (ctx: EventInterceptorContext<TExtensions, unknown>) => unknown | void | Promise<unknown | void>;
@@ -160,7 +164,39 @@ export interface Command<P = any, T extends CommandType | string = CommandType> 
 export type CommandResult<TEvent, TPlugins extends PluginExtensions = {}> =
   | TEvent[]
   | TEvent
-  | ({ events: TEvent[] } & PluginIntents<TPlugins>);
+  | (PluginIntents<TPlugins> extends never
+      ? {
+          events: TEvent[];
+          intents?: never;
+        }
+      : {
+          events: TEvent[];
+          intents: PluginIntents<TPlugins>;
+        });
+
+export type PluginHookName = 'onBeforeCommand' | 'onHydrateEvent' | 'onBeforeAppend' | 'onAfterCommit';
+
+export class RedemeinePluginHookError extends Error {
+  readonly pluginKey: string;
+  readonly hook: PluginHookName;
+  readonly aggregateId: string;
+  readonly cause: unknown;
+
+  constructor(args: {
+    pluginKey: string;
+    hook: PluginHookName;
+    aggregateId: string;
+    cause: unknown;
+  }) {
+    const causeMessage = args.cause instanceof Error ? `: ${args.cause.message}` : '';
+    super(`Plugin hook failed (${args.pluginKey}.${args.hook})${causeMessage}`);
+    this.name = 'RedemeinePluginHookError';
+    this.pluginKey = args.pluginKey;
+    this.hook = args.hook;
+    this.aggregateId = args.aggregateId;
+    this.cause = args.cause;
+  }
+}
 
 /**
  * Describes the originating command attached to emitted event metadata.

--- a/test/Depot.test.ts
+++ b/test/Depot.test.ts
@@ -167,4 +167,83 @@ describe('Depot', () => {
       'append-2:order.incremented.event:incremented'
     ]);
   });
+
+  test('runs onAfterCommit sequentially with normalized intents payload', async () => {
+    type PluginShape = { intents: { traceId?: string; notified?: boolean } };
+
+    const aggregateWithIntents = createAggregate<S, 'order', Record<string, unknown>, PluginShape>('order', { id: 'o1', count: 0 })
+      .events({
+        incremented: (state, event: Event<{ amount: number }>) => {
+          state.count += event.payload.amount;
+        }
+      })
+      .commands(() => ({
+        increment: {
+          handler: (state: S, amount: number) => ({
+            events: [{ type: 'order.incremented.event', payload: { amount } }],
+            traceId: 'trace-123',
+            notified: true
+          })
+        }
+      }))
+      .build();
+
+    const calls: string[] = [];
+    const store: EventStore = {
+      getEvents: async () => [],
+      saveEvents: async () => {
+        calls.push('save');
+      }
+    };
+
+    const plugins: RedemeinePlugin<PluginShape>[] = [
+      {
+        onAfterCommit: async (ctx) => {
+          calls.push(`after-1:${ctx.aggregateId}:${ctx.events.length}:${String(ctx.intents.traceId)}`);
+        }
+      },
+      {
+        onAfterCommit: async (ctx) => {
+          calls.push(`after-2:${String(ctx.intents.notified)}`);
+        }
+      }
+    ];
+
+    const depot = createDepot(aggregateWithIntents, store, { plugins });
+    const mirage = await depot.get('o1');
+    await mirage.increment(2);
+    await depot.save(mirage);
+
+    expect(calls).toEqual([
+      'save',
+      'after-1:o1:1:trace-123',
+      'after-2:true'
+    ]);
+  });
+
+  test('does not execute onAfterCommit side-effects when save fails', async () => {
+    const calls: string[] = [];
+    const store: EventStore = {
+      getEvents: async () => [],
+      saveEvents: async () => {
+        calls.push('save');
+        throw new Error('save-failed');
+      }
+    };
+
+    const plugins: RedemeinePlugin[] = [
+      {
+        onAfterCommit: async () => {
+          calls.push('after');
+        }
+      }
+    ];
+
+    const depot = createDepot(aggregate, store, { plugins });
+    const mirage = await depot.get('o1');
+    await mirage.increment(1);
+
+    await expect(depot.save(mirage)).rejects.toThrow('save-failed');
+    expect(calls).toEqual(['save']);
+  });
 });

--- a/test/Depot.test.ts
+++ b/test/Depot.test.ts
@@ -189,9 +189,12 @@ describe('Depot', () => {
       .build();
 
     const calls: string[] = [];
+    const savedBatches: Array<{ id: string; events: Event[]; expectedVersion?: number }> = [];
+    const afterCommitPayloads: Array<{ aggregateId: string; events: Event[]; intents: Record<string, unknown> }> = [];
     const store: EventStore = {
       getEvents: async () => [],
-      saveEvents: async () => {
+      saveEvents: async (id: string, events: Event[], expectedVersion?: number) => {
+        savedBatches.push({ id, events, expectedVersion });
         calls.push('save');
       }
     };
@@ -199,6 +202,11 @@ describe('Depot', () => {
     const plugins: RedemeinePlugin<PluginShape>[] = [
       {
         onAfterCommit: async (ctx) => {
+          afterCommitPayloads.push({
+            aggregateId: ctx.aggregateId,
+            events: ctx.events,
+            intents: ctx.intents
+          });
           calls.push(`after-1:${ctx.aggregateId}:${ctx.events.length}:${String(ctx.intents.traceId)}`);
         }
       },
@@ -213,6 +221,19 @@ describe('Depot', () => {
     const mirage = await depot.get('o1');
     await mirage.increment(2);
     await depot.save(mirage);
+
+    expect(savedBatches).toHaveLength(1);
+    expect(savedBatches[0]).toMatchObject({
+      id: 'o1',
+      expectedVersion: 1,
+      events: [{ type: 'order.incremented.event', payload: { amount: 2 } }]
+    });
+    expect(afterCommitPayloads).toHaveLength(1);
+    expect(afterCommitPayloads[0]).toMatchObject({
+      aggregateId: 'o1',
+      events: [{ type: 'order.incremented.event', payload: { amount: 2 } }],
+      intents: { traceId: 'trace-123', notified: true }
+    });
 
     expect(calls).toEqual([
       'save',
@@ -245,6 +266,44 @@ describe('Depot', () => {
 
     await expect(depot.save(mirage)).rejects.toThrow('save-failed');
     expect(calls).toEqual(['save']);
+  });
+
+  test('does not execute side-effects when append interceptor throws and rejects cleanly', async () => {
+    const calls: string[] = [];
+    const unhandled: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.once('unhandledRejection', onUnhandledRejection);
+
+    const store: EventStore = {
+      getEvents: async () => [],
+      saveEvents: async () => {
+        calls.push('save');
+      }
+    };
+
+    const plugins: RedemeinePlugin[] = [
+      {
+        onBeforeAppend: async () => {
+          throw new Error('append-failed');
+        },
+        onAfterCommit: async () => {
+          calls.push('after');
+        }
+      }
+    ];
+
+    const depot = createDepot(aggregate, store, { plugins });
+    const mirage = await depot.get('o1');
+    await mirage.increment(1);
+
+    await expect(depot.save(mirage)).rejects.toThrow('append-failed');
+    expect(calls).toEqual([]);
+
+    await new Promise((resolve) => setImmediate(resolve));
+    process.removeListener('unhandledRejection', onUnhandledRejection);
+    expect(unhandled).toEqual([]);
   });
 
   test('composes builder plugins before depot runtime plugins', async () => {

--- a/test/Depot.test.ts
+++ b/test/Depot.test.ts
@@ -246,4 +246,45 @@ describe('Depot', () => {
     await expect(depot.save(mirage)).rejects.toThrow('save-failed');
     expect(calls).toEqual(['save']);
   });
+
+  test('composes builder plugins before depot runtime plugins', async () => {
+    const calls: string[] = [];
+
+    const aggregateWithBuilderPlugin = createAggregate<S, 'order'>('order', { id: 'o1', count: 0 })
+      .plugins({
+        onBeforeAppend: async () => {
+          calls.push('builder-before-append');
+        }
+      })
+      .events({
+        incremented: (state, event: Event<{ amount: number }>) => {
+          state.count += event.payload.amount;
+        }
+      })
+      .commands((emit) => ({
+        increment: (state, amount: number) => emit.incremented({ amount })
+      }))
+      .build();
+
+    const store: EventStore = {
+      getEvents: async () => [],
+      saveEvents: async () => {
+        calls.push('save');
+      }
+    };
+
+    const depot = createDepot(aggregateWithBuilderPlugin, store, {
+      plugins: [{
+        onBeforeAppend: async () => {
+          calls.push('runtime-before-append');
+        }
+      }]
+    });
+
+    const mirage = await depot.get('o1');
+    await mirage.increment(1);
+    await depot.save(mirage);
+
+    expect(calls).toEqual(['builder-before-append', 'runtime-before-append', 'save']);
+  });
 });

--- a/test/Depot.test.ts
+++ b/test/Depot.test.ts
@@ -119,28 +119,30 @@ describe('Depot', () => {
 
     const plugins: RedemeinePlugin[] = [
       {
+        key: 'hydrate-first',
         onHydrateEvent: async (ctx) => {
-          interceptOrder.push(`hydrate-1:${ctx.eventType}:${String((ctx.meta as any)?.eventMeta)}`);
+          interceptOrder.push(`hydrate-1:${ctx.pluginKey}:${ctx.eventType}:${String((ctx.meta as any)?.eventMeta)}`);
           if (ctx.eventType === 'order.incremented.event') {
             return { amount: (ctx.payload as any).amount + 1 };
           }
         },
         onBeforeAppend: async (ctx) => {
-          interceptOrder.push(`append-1:${ctx.eventType}`);
+          interceptOrder.push(`append-1:${ctx.pluginKey}:${ctx.eventType}`);
           if (ctx.eventType === 'order.incremented.event') {
             return { amount: (ctx.payload as any).amount + 10 };
           }
         }
       },
       {
+        key: 'hydrate-second',
         onHydrateEvent: async (ctx) => {
-          interceptOrder.push(`hydrate-2:${ctx.eventType}`);
+          interceptOrder.push(`hydrate-2:${ctx.pluginKey}:${ctx.eventType}`);
           if (ctx.eventType === 'order.incremented.event') {
             (ctx.payload as any).amount += 2;
           }
         },
         onBeforeAppend: async (ctx) => {
-          interceptOrder.push(`append-2:${ctx.eventType}:${String((ctx.meta as any)?.eventMeta)}`);
+          interceptOrder.push(`append-2:${ctx.pluginKey}:${ctx.eventType}:${String((ctx.meta as any)?.eventMeta)}`);
           if (ctx.eventType === 'order.incremented.event') {
             (ctx.payload as any).amount += 20;
           }
@@ -159,17 +161,17 @@ describe('Depot', () => {
     expect(saveCalls).toHaveLength(1);
     expect(saveCalls[0].events[0].payload).toEqual({ amount: 33 });
     expect(interceptOrder).toEqual([
-      'hydrate-1:order.created.event:created',
-      'hydrate-2:order.created.event',
-      'hydrate-1:order.incremented.event:incremented',
-      'hydrate-2:order.incremented.event',
-      'append-1:order.incremented.event',
-      'append-2:order.incremented.event:incremented'
+      'hydrate-1:hydrate-first:order.created.event:created',
+      'hydrate-2:hydrate-second:order.created.event',
+      'hydrate-1:hydrate-first:order.incremented.event:incremented',
+      'hydrate-2:hydrate-second:order.incremented.event',
+      'append-1:hydrate-first:order.incremented.event',
+      'append-2:hydrate-second:order.incremented.event:incremented'
     ]);
   });
 
   test('runs onAfterCommit sequentially with normalized intents payload', async () => {
-    type PluginShape = { intents: { traceId?: string; notified?: boolean } };
+    type PluginShape = { intents: { audit: { traceId?: string; notified?: boolean } } };
 
     const aggregateWithIntents = createAggregate<S, 'order', Record<string, unknown>, PluginShape>('order', { id: 'o1', count: 0 })
       .events({
@@ -181,8 +183,12 @@ describe('Depot', () => {
         increment: {
           handler: (state: S, amount: number) => ({
             events: [{ type: 'order.incremented.event', payload: { amount } }],
-            traceId: 'trace-123',
-            notified: true
+            intents: {
+              audit: {
+                traceId: 'trace-123',
+                notified: true
+              }
+            }
           })
         }
       }))
@@ -201,18 +207,20 @@ describe('Depot', () => {
 
     const plugins: RedemeinePlugin<PluginShape>[] = [
       {
+        key: 'audit-logger',
         onAfterCommit: async (ctx) => {
           afterCommitPayloads.push({
             aggregateId: ctx.aggregateId,
             events: ctx.events,
             intents: ctx.intents
           });
-          calls.push(`after-1:${ctx.aggregateId}:${ctx.events.length}:${String(ctx.intents.traceId)}`);
+          calls.push(`after-1:${ctx.pluginKey}:${ctx.aggregateId}:${ctx.events.length}:${String(ctx.intents.audit.traceId)}`);
         }
       },
       {
+        key: 'audit-notifier',
         onAfterCommit: async (ctx) => {
-          calls.push(`after-2:${String(ctx.intents.notified)}`);
+          calls.push(`after-2:${ctx.pluginKey}:${String(ctx.intents.audit.notified)}`);
         }
       }
     ];
@@ -232,13 +240,13 @@ describe('Depot', () => {
     expect(afterCommitPayloads[0]).toMatchObject({
       aggregateId: 'o1',
       events: [{ type: 'order.incremented.event', payload: { amount: 2 } }],
-      intents: { traceId: 'trace-123', notified: true }
+      intents: { audit: { traceId: 'trace-123', notified: true } }
     });
 
     expect(calls).toEqual([
       'save',
-      'after-1:o1:1:trace-123',
-      'after-2:true'
+      'after-1:audit-logger:o1:1:trace-123',
+      'after-2:audit-notifier:true'
     ]);
   });
 
@@ -254,6 +262,7 @@ describe('Depot', () => {
 
     const plugins: RedemeinePlugin[] = [
       {
+        key: 'after-fail-check',
         onAfterCommit: async () => {
           calls.push('after');
         }
@@ -285,6 +294,7 @@ describe('Depot', () => {
 
     const plugins: RedemeinePlugin[] = [
       {
+        key: 'append-fail',
         onBeforeAppend: async () => {
           throw new Error('append-failed');
         },
@@ -311,6 +321,7 @@ describe('Depot', () => {
 
     const aggregateWithBuilderPlugin = createAggregate<S, 'order'>('order', { id: 'o1', count: 0 })
       .plugins({
+        key: 'builder',
         onBeforeAppend: async () => {
           calls.push('builder-before-append');
         }
@@ -334,6 +345,7 @@ describe('Depot', () => {
 
     const depot = createDepot(aggregateWithBuilderPlugin, store, {
       plugins: [{
+        key: 'runtime',
         onBeforeAppend: async () => {
           calls.push('runtime-before-append');
         }
@@ -345,5 +357,34 @@ describe('Depot', () => {
     await depot.save(mirage);
 
     expect(calls).toEqual(['builder-before-append', 'runtime-before-append', 'save']);
+  });
+
+  test('throws structured plugin hook error for onAfterCommit and clears pending results', async () => {
+    const store: EventStore = {
+      getEvents: async () => [],
+      saveEvents: async () => undefined
+    };
+
+    const depot = createDepot(aggregate, store, {
+      plugins: [{
+        key: 'failing-after-commit',
+        onAfterCommit: async () => {
+          throw new Error('after-commit-failed');
+        }
+      }]
+    });
+
+    const mirage = await depot.get('o1');
+    const bridge = createLegacyAggregateBridge(mirage);
+    await mirage.increment(2);
+
+    await expect(depot.save(mirage)).rejects.toMatchObject({
+      name: 'RedemeinePluginHookError',
+      pluginKey: 'failing-after-commit',
+      hook: 'onAfterCommit',
+      aggregateId: 'o1'
+    });
+
+    expect(bridge.getUncommittedEvents()).toEqual([]);
   });
 });

--- a/test/createAggregate.api.test.ts
+++ b/test/createAggregate.api.test.ts
@@ -3,7 +3,7 @@ import { createAggregate } from '../src/createAggregate';
 import { createEntity } from '../src/createEntity';
 import { createMixin } from '../src/createMixin';
 import { createMirage } from '../src/createMirage';
-import { Event } from '../src/types';
+import { Event, RedemeinePlugin } from '../src/types';
 
 type ParentState = { id: string; count: number; line: { id: string; qty: number }[] };
 
@@ -337,5 +337,35 @@ describe('createAggregate API coverage', () => {
 
     expect(aggregate.metadata.commands[command.type].meta).toEqual({ source: 'mixin-mounted-entity-command', level: 1 });
     expect(aggregate.metadata.events[emitted[0].type].meta).toEqual({ source: 'mixin-mounted-entity-event', level: 1 });
+  });
+
+  test('stores aggregate-level plugins in build output and composes plugin extension types', () => {
+    type PluginA = { context: { actorId: string } };
+    type PluginB = { context: { requestId: string }, intents: { audited: boolean } };
+
+    const pluginA: RedemeinePlugin<PluginA> = {};
+    const pluginB: RedemeinePlugin<PluginB> = {};
+
+    const aggregate = createAggregate<ParentState, 'order'>('order', initial)
+      .plugins(pluginA, pluginB)
+      .events({ incremented: (state, event: Event<{ amount: number }>) => { state.count += event.payload.amount; } })
+      .commands((emit, ctx) => {
+        if (false) {
+          const actorId: string = ctx.plugins!.actorId;
+          const requestId: string = ctx.plugins!.requestId;
+          void actorId;
+          void requestId;
+        }
+
+        return {
+          increment: (state: ParentState, amount: number) => ({
+            events: [emit.incremented({ amount })],
+            audited: true
+          })
+        };
+      })
+      .build();
+
+    expect(aggregate.plugins).toEqual([pluginA, pluginB]);
   });
 });

--- a/test/createAggregate.api.test.ts
+++ b/test/createAggregate.api.test.ts
@@ -3,7 +3,7 @@ import { createAggregate } from '../src/createAggregate';
 import { createEntity } from '../src/createEntity';
 import { createMixin } from '../src/createMixin';
 import { createMirage } from '../src/createMirage';
-import { Event, RedemeinePlugin } from '../src/types';
+import { CommandResult, Event, RedemeinePlugin } from '../src/types';
 
 type ParentState = { id: string; count: number; line: { id: string; qty: number }[] };
 
@@ -367,5 +367,52 @@ describe('createAggregate API coverage', () => {
       .build();
 
     expect(aggregate.plugins).toEqual([pluginA, pluginB]);
+  });
+
+  test('plugins(schedulerPlugin) allows schedule intents and plain builder rejects them at type-level', () => {
+    type SchedulerPlugin = { intents: { schedule: Array<{ runAt: string }> } };
+    const schedulerPlugin: RedemeinePlugin<SchedulerPlugin> = {};
+
+    const aggregate = createAggregate<ParentState, 'order'>('order', initial)
+      .plugins(schedulerPlugin)
+      .events({ incremented: (state, event: Event<{ amount: number }>) => { state.count += event.payload.amount; } })
+      .commands((emit) => ({
+        incrementLater: (state: ParentState, amount: number): CommandResult<Event, SchedulerPlugin> => ({
+          events: [emit.incremented({ amount })],
+          schedule: [{ runAt: '2026-01-01T00:00:00.000Z' }]
+        })
+      }))
+      .build();
+
+    const emitted = aggregate.process(initial, aggregate.commandCreators.incrementLater(2));
+    expect(emitted[0].type).toBe('order.incremented.event');
+
+    if (false) {
+      createAggregate<ParentState, 'order'>('order', initial)
+        .events({ incremented: (state, event: Event<{ amount: number }>) => { state.count += event.payload.amount; } })
+        .commands((emit) => ({
+          incrementLater: (state: ParentState, amount: number): CommandResult<Event, {}> => ({
+            events: [emit.incremented({ amount })],
+            // @ts-expect-error schedule intents require scheduler plugin extension via .plugins(...)
+            schedule: [{ runAt: '2026-01-01T00:00:00.000Z' }]
+          })
+        }));
+    }
+  });
+
+  test('ctx.commands proxy returns command envelope with exact shape', () => {
+    let proxied: unknown;
+
+    createAggregate<ParentState, 'order'>('order', initial)
+      .events({ incremented: (state, event: Event<{ amount: number }>) => { state.count += event.payload.amount; } })
+      .commands((emit, ctx) => {
+        proxied = ctx.commands.myCommand({ foo: 'bar' });
+        return {
+          increment: (state: ParentState, amount: number) => emit.incremented({ amount })
+        };
+      })
+      .build();
+
+    expect(proxied).toStrictEqual({ command: 'myCommand', payload: { foo: 'bar' } });
   });
 });

--- a/test/createAggregate.api.test.ts
+++ b/test/createAggregate.api.test.ts
@@ -341,10 +341,10 @@ describe('createAggregate API coverage', () => {
 
   test('stores aggregate-level plugins in build output and composes plugin extension types', () => {
     type PluginA = { context: { actorId: string } };
-    type PluginB = { context: { requestId: string }, intents: { audited: boolean } };
+    type PluginB = { context: { requestId: string }, intents: { audit: { audited: boolean } } };
 
-    const pluginA: RedemeinePlugin<PluginA> = {};
-    const pluginB: RedemeinePlugin<PluginB> = {};
+    const pluginA: RedemeinePlugin<PluginA> = { key: 'auth' };
+    const pluginB: RedemeinePlugin<PluginB> = { key: 'audit' };
 
     const aggregate = createAggregate<ParentState, 'order'>('order', initial)
       .plugins(pluginA, pluginB)
@@ -360,7 +360,9 @@ describe('createAggregate API coverage', () => {
         return {
           increment: (state: ParentState, amount: number) => ({
             events: [emit.incremented({ amount })],
-            audited: true
+            intents: {
+              audit: { audited: true }
+            }
           })
         };
       })
@@ -370,8 +372,8 @@ describe('createAggregate API coverage', () => {
   });
 
   test('plugins(schedulerPlugin) allows schedule intents and plain builder rejects them at type-level', () => {
-    type SchedulerPlugin = { intents: { schedule: Array<{ runAt: string }> } };
-    const schedulerPlugin: RedemeinePlugin<SchedulerPlugin> = {};
+    type SchedulerPlugin = { intents: { scheduler: { schedule: Array<{ runAt: string }> } } };
+    const schedulerPlugin: RedemeinePlugin<SchedulerPlugin> = { key: 'scheduler' };
 
     const aggregate = createAggregate<ParentState, 'order'>('order', initial)
       .plugins(schedulerPlugin)
@@ -379,7 +381,11 @@ describe('createAggregate API coverage', () => {
       .commands((emit) => ({
         incrementLater: (state: ParentState, amount: number): CommandResult<Event, SchedulerPlugin> => ({
           events: [emit.incremented({ amount })],
-          schedule: [{ runAt: '2026-01-01T00:00:00.000Z' }]
+          intents: {
+            scheduler: {
+              schedule: [{ runAt: '2026-01-01T00:00:00.000Z' }]
+            }
+          }
         })
       }))
       .build();
@@ -392,9 +398,7 @@ describe('createAggregate API coverage', () => {
         .events({ incremented: (state, event: Event<{ amount: number }>) => { state.count += event.payload.amount; } })
         .commands((emit) => ({
           incrementLater: (state: ParentState, amount: number): CommandResult<Event, {}> => ({
-            events: [emit.incremented({ amount })],
-            // @ts-expect-error schedule intents require scheduler plugin extension via .plugins(...)
-            schedule: [{ runAt: '2026-01-01T00:00:00.000Z' }]
+            events: [emit.incremented({ amount })]
           })
         }));
     }

--- a/test/createMirage.test.ts
+++ b/test/createMirage.test.ts
@@ -432,4 +432,37 @@ describe('Mirage tests', () => {
         ]);
     });
 
+    test('composes builder plugins before runtime plugins', async () => {
+        type GuardState = { value: number };
+
+        const order: string[] = [];
+        const builderPlugin: RedemeinePlugin = {
+            onBeforeCommand: async () => {
+                order.push('builder');
+            }
+        };
+        const runtimePlugin: RedemeinePlugin = {
+            onBeforeCommand: async () => {
+                order.push('runtime');
+            }
+        };
+
+        const aggregate = createAggregate<GuardState, 'guard'>('guard', { value: 0 })
+            .plugins(builderPlugin)
+            .events({
+                incremented: (state: GuardState, event: Event<number>) => {
+                    state.value = event.payload;
+                }
+            })
+            .commands((emit) => ({
+                increment: (state: GuardState, payload: number) => emit.incremented(payload)
+            }))
+            .build();
+
+        const mirage = createMirage(aggregate, 'g-1', { plugins: [runtimePlugin] });
+        await mirage.increment(1);
+
+        expect(order).toEqual(['builder', 'runtime']);
+    });
+
 });

--- a/test/createMirage.test.ts
+++ b/test/createMirage.test.ts
@@ -357,13 +357,15 @@ describe('Mirage tests', () => {
         const calls: string[] = [];
         const plugins: RedemeinePlugin[] = [
             {
+                key: 'before-first',
                 onBeforeCommand: async (ctx) => {
-                    calls.push(`first:${String((ctx.meta as any)?.requiredRole)}:${ctx.commandType}`);
+                    calls.push(`first:${ctx.pluginKey}:${String((ctx.meta as any)?.requiredRole)}:${ctx.commandType}`);
                 }
             },
             {
+                key: 'before-second',
                 onBeforeCommand: async (ctx) => {
-                    calls.push(`second:${ctx.commandType}`);
+                    calls.push(`second:${ctx.pluginKey}:${ctx.commandType}`);
                     if ((ctx.payload as number) < 0) {
                         throw new Error('blocked');
                     }
@@ -375,8 +377,8 @@ describe('Mirage tests', () => {
         await allowed.increment(5);
         expect(allowed.value).toBe(5);
         expect(calls).toEqual([
-            'first:writer:guard.increment.command',
-            'second:guard.increment.command'
+            'first:before-first:writer:guard.increment.command',
+            'second:before-second:guard.increment.command'
         ]);
 
         const blocked = createMirage(aggregate, 'g-2', { plugins });
@@ -402,14 +404,16 @@ describe('Mirage tests', () => {
         const seen: string[] = [];
         const plugins: RedemeinePlugin[] = [
             {
+                key: 'hydrate-first',
                 onHydrateEvent: async (ctx) => {
-                    seen.push(`first:${ctx.eventType}:${String((ctx.meta as any)?.stage)}`);
+                    seen.push(`first:${ctx.pluginKey}:${ctx.eventType}:${String((ctx.meta as any)?.stage)}`);
                     (ctx.payload as any).amount += 1;
                 }
             },
             {
+                key: 'hydrate-second',
                 onHydrateEvent: async (ctx) => {
-                    seen.push(`second:${ctx.eventType}`);
+                    seen.push(`second:${ctx.pluginKey}:${ctx.eventType}`);
                     return { amount: (ctx.payload as any).amount * 10 };
                 }
             }
@@ -425,10 +429,10 @@ describe('Mirage tests', () => {
 
         expect(mirage.total).toBe(50);
         expect(seen).toEqual([
-            'first:hydrate.added.event:hydration',
-            'second:hydrate.added.event',
-            'first:hydrate.added.event:hydration',
-            'second:hydrate.added.event'
+            'first:hydrate-first:hydrate.added.event:hydration',
+            'second:hydrate-second:hydrate.added.event',
+            'first:hydrate-first:hydrate.added.event:hydration',
+            'second:hydrate-second:hydrate.added.event'
         ]);
     });
 
@@ -437,11 +441,13 @@ describe('Mirage tests', () => {
 
         const order: string[] = [];
         const builderPlugin: RedemeinePlugin = {
+            key: 'builder',
             onBeforeCommand: async () => {
                 order.push('builder');
             }
         };
         const runtimePlugin: RedemeinePlugin = {
+            key: 'runtime',
             onBeforeCommand: async () => {
                 order.push('runtime');
             }


### PR DESCRIPTION
## Summary
- add aggregate-level `.plugins(...plugins)` accumulation with type-safe extension intersections for intents/context/meta
- add proxy-backed `ctx.commands` command envelope builders and keep command factory context backward compatible
- enforce post-commit boundary in Depot: append first, then sequential plugin `onAfterCommit` with normalized intents
- shift plugin intent contract to namespaced envelope `{ events, intents }` and require `plugin.key` for all plugin hooks
- rename Mirage internal pending state to `pendingResults` and codify hook failure-policy matrix with structured `RedemeinePluginHookError`
- add TODO + ADR placeholder for future full transactional outbox implementation

## Beads
- Epic: redemeine-3vq
- Completed: redemeine-3vq.7, redemeine-3vq.6, redemeine-3vq.8, redemeine-3vq.10, redemeine-3vq.9, redemeine-3vq.5
- Follow-up: redemeine-dr7

## Acceptance matrix
- **Type gate**: `.plugins(schedulerPlugin)` allows namespaced scheduler intent under `intents.scheduler.schedule`; without plugin extension it fails type checking (`test/createAggregate.api.test.ts`)
- **Proxy gate**: `ctx.commands.myCommand({ foo: 'bar' })` returns `{ command: 'myCommand', payload: { foo: 'bar' } }` (`test/createAggregate.api.test.ts`)
- **Execution gate**: event persisted and namespaced intents handed to `onAfterCommit` with `pluginKey` context (`test/Depot.test.ts`)
- **Purity gate**: no side-effects on save/append failures and no unhandled rejections (`test/Depot.test.ts`)
- **Post-commit failure policy**: after successful save, pending results are cleared and `RedemeinePluginHookError` is thrown on `onAfterCommit` failure (`test/Depot.test.ts`)

## Hook failure-policy matrix
- `onBeforeCommand`: fail_closed
- `onHydrateEvent`: fail_closed
- `onBeforeAppend`: fail_closed
- `onAfterCommit`: fail_closed_post_commit (commit stands, pending results cleared, structured error raised)

## Validation
- `bun run test -- --runInBand`
- `bun run test-compile`