### PR TITLE
feat(projections): support identity fan-out for from-stream routing

### DIFF
--- a/src/projections/ProjectionDaemon.ts
+++ b/src/projections/ProjectionDaemon.ts
@@ -132,48 +132,51 @@ export class ProjectionDaemon<TState = unknown> {
         const eventKey = `${event.aggregateType}:${event.aggregateId}:${event.sequence}`;
         if (processedEvents.has(eventKey)) continue;
         
-        const targetDocId = await this.resolveTargetDocumentId(event);
-        
-        if (targetDocId === null) {
+        const targetDocIds = await this.resolveTargetDocumentIds(event);
+
+        if (targetDocIds.length === 0) {
           // Skip events without valid targets (join events without subscription)
           continue;
         }
-        
-        // Get or create pending document
-        let pending = pendingDocuments.get(targetDocId);
-        if (!pending) {
-          const existingState = await store.load(targetDocId);
-          const state = existingState || projection.initialState(targetDocId);
-          pending = {
-            docId: targetDocId,
-            state: state as TState,
-            events: [],
-            cursor: { sequence: 0 }
-          };
-          pendingDocuments.set(targetDocId, pending);
-        }
-        
-        // Process the event (this may trigger subscriptions via context)
-        this.currentDocId = targetDocId;
-        const context = this.createContext();
-        
-        pending.state = produce(pending.state, (draft: Draft<TState>) => {
-          const handler = this.findHandler(event);
-          if (handler) {
-            handler(draft, event, context);
-          }
-        });
 
-        await this.persistContextSubscriptions(context);
-        
-        // Update cursor to latest event
-        pending.cursor = {
-          sequence: Math.max(pending.cursor.sequence, event.sequence),
-          timestamp: event.timestamp
-        };
-        
+        for (const targetDocId of targetDocIds) {
+          // Get or create pending document
+          let pending = pendingDocuments.get(targetDocId);
+          if (!pending) {
+            const existingState = await store.load(targetDocId);
+            const state = existingState || projection.initialState(targetDocId);
+            pending = {
+              docId: targetDocId,
+              state: state as TState,
+              events: [],
+              cursor: { sequence: 0 }
+            };
+            pendingDocuments.set(targetDocId, pending);
+          }
+
+          // Process the event (this may trigger subscriptions via context)
+          this.currentDocId = targetDocId;
+          const context = this.createContext();
+
+          pending.state = produce(pending.state, (draft: Draft<TState>) => {
+            const handler = this.findHandler(event);
+            if (handler) {
+              handler(draft, event, context);
+            }
+          });
+
+          await this.persistContextSubscriptions(context);
+
+          // Update cursor to latest event
+          pending.cursor = {
+            sequence: Math.max(pending.cursor.sequence, event.sequence),
+            timestamp: event.timestamp
+          };
+
+          this.currentDocId = null;
+        }
+
         processedEvents.add(eventKey);
-        this.currentDocId = null;
         madeProgress = true;
       }
     }
@@ -206,12 +209,14 @@ export class ProjectionDaemon<TState = unknown> {
    * 2. If event is from .join stream: ONLY process if subscribeTo() was called
    *    for this aggregate+id; otherwise IGNORE (prevent ghost documents)
    */
-  private async resolveTargetDocumentId(event: ProjectionEvent): Promise<string | null> {
+  private async resolveTargetDocumentIds(event: ProjectionEvent): Promise<string[]> {
     const { projection } = this.options;
     
     // Check if this is a .from stream event
     if (event.aggregateType === projection.fromStream.aggregate.__aggregateType) {
-      return projection.identity(event); // Primary owner dictates document ID
+      const identity = projection.identity(event);
+      const docIds = Array.isArray(identity) ? identity : [identity];
+      return Array.from(new Set(docIds));
     }
     
     // Check if this is a .join stream event
@@ -224,15 +229,15 @@ export class ProjectionDaemon<TState = unknown> {
       const targetDocId = await this.linkStore.resolveTarget(event.aggregateType, event.aggregateId);
 
       if (targetDocId) {
-        return targetDocId;
+        return [targetDocId];
       }
       
       // No subscription - IGNORE this event (prevents ghost documents)
-      return null;
+      return [];
     }
     
     // Unknown stream type - ignore
-    return null;
+    return [];
   }
   
   /**

--- a/src/projections/createProjection.ts
+++ b/src/projections/createProjection.ts
@@ -163,8 +163,8 @@ export interface ProjectionDefinition<TState = unknown> {
   joinStreams?: JoinStreamDefinition<TState>[];
   /** Initial state factory function */
   initialState: (documentId: string) => TState;
-  /** Identity resolver - determines which document ID receives an event */
-  identity: (event: BaseProjectionEvent) => string;
+  /** Identity resolver - determines which document ID(s) receive an event */
+  identity: (event: BaseProjectionEvent) => string | readonly string[];
   /** Subscriptions captured during projection definition */
   subscriptions: Array<{ aggregate: { __aggregateType: string }; aggregateId: string }>;
 }
@@ -188,7 +188,7 @@ export interface ProjectionBuilder<TState> {
   /**
    * Override the default identity resolver
    */
-  identity(fn: (event: BaseProjectionEvent) => string): ProjectionBuilder<TState>;
+  identity(fn: (event: BaseProjectionEvent) => string | readonly string[]): ProjectionBuilder<TState>;
   
   /**
    * Define the primary stream to project from
@@ -218,7 +218,7 @@ export interface ProjectionBuilder<TState> {
 class ProjectionBuilderImpl<TState> implements ProjectionBuilder<TState> {
   private _name: string;
   private _initialState: (id: string) => TState;
-  private _identity: (event: BaseProjectionEvent) => string;
+  private _identity: (event: BaseProjectionEvent) => string | readonly string[];
   private _fromStream: ProjectionStreamDefinition<TState> | null = null;
   private _joinStreams: JoinStreamDefinition<TState>[] = [];
 
@@ -234,7 +234,7 @@ class ProjectionBuilderImpl<TState> implements ProjectionBuilder<TState> {
     return this;
   }
 
-  identity(fn: (event: BaseProjectionEvent) => string): ProjectionBuilder<TState> {
+  identity(fn: (event: BaseProjectionEvent) => string | readonly string[]): ProjectionBuilder<TState> {
     this._identity = fn;
     return this;
   }

--- a/test/projections/ProjectionDaemon.test.ts
+++ b/test/projections/ProjectionDaemon.test.ts
@@ -308,6 +308,58 @@ describe('ProjectionDaemon', () => {
       expect(state).not.toBeNull();
       expect(state!.name).toBe('Order 2');
     });
+
+    it('should fan out a single .from event to multiple unique identities', async () => {
+      const orderAgg = {
+        __aggregateType: 'order',
+        initialState: {},
+        pure: { eventProjectors: {} }
+      };
+
+      const fanOutProjection = createProjection<TestState>('fanOutIdentity', () => ({
+        count: 0,
+        name: '',
+        events: []
+      }))
+        .identity((event) => ['doc-a', 'doc-b', 'doc-a'] as const)
+        .from(orderAgg, {
+          'order.created': (state, event: any) => {
+            state.name = event.payload.name;
+            state.count += 1;
+            state.events.push(event.type);
+          }
+        })
+        .build();
+
+      const daemon = new ProjectionDaemon({
+        ...options,
+        projection: fanOutProjection,
+        subscription: createMockSubscription([
+          {
+            aggregateType: 'order',
+            aggregateId: 'order-1',
+            type: 'order.created',
+            payload: { name: 'Fan Out' },
+            sequence: 1,
+            timestamp: '2024-01-01T00:00:00Z'
+          }
+        ])
+      });
+
+      const stats = await daemon.processBatch();
+
+      expect(stats.eventsProcessed).toBe(1);
+      expect(stats.documentsUpdated).toBe(2);
+
+      const stateA = await mockStore.load('doc-a');
+      const stateB = await mockStore.load('doc-b');
+      expect(stateA).not.toBeNull();
+      expect(stateB).not.toBeNull();
+      expect(stateA!.name).toBe('Fan Out');
+      expect(stateB!.name).toBe('Fan Out');
+      expect(stateA!.count).toBe(1);
+      expect(stateB!.count).toBe(1);
+    });
     
     it('should handle events from multiple aggregates with different document IDs', async () => {
       const events: ProjectionEvent[] = [

--- a/test/projections/createProjection.test.ts
+++ b/test/projections/createProjection.test.ts
@@ -174,7 +174,7 @@ describe('createProjection Builder API', () => {
     expect(projection.name).toBe('composite-view');
     expect(projection.fromStream.aggregate).toBe(invoiceAggDef);
     expect(projection.joinStreams).toHaveLength(1);
-    expect(projection.joinStreams[0].aggregate).toBe(orderAggDef);
+    expect(projection.joinStreams?.[0].aggregate).toBe(orderAggDef);
   });
 
   test('initialState(fn) overrides the initial state factory', () => {
@@ -215,13 +215,42 @@ describe('createProjection Builder API', () => {
       .identity((event) => `custom-${event.aggregateId}`)
       .build();
 
-    const event: ProjectionEvent<unknown> = {
+    const event: ProjectionEvent = {
       type: 'invoice.created.event',
       payload: {},
-      aggregateId: 'original-id'
+      aggregateType: 'invoice',
+      aggregateId: 'original-id',
+      sequence: 1,
+      timestamp: '2024-01-01T00:00:00Z'
     };
 
     expect(projection.identity(event)).toBe('custom-original-id');
+  });
+
+  test('identity(fn) supports fan-out identity arrays', () => {
+    const projection = createProjection<InvoiceState>('invoice-summary', () => ({
+      id: '',
+      amount: 0,
+      status: 'pending' as const
+    }))
+      .from(invoiceAggDef, {
+        created: (state, event) => {
+          state.amount = event.payload.amount;
+        }
+      })
+      .identity((event) => [`doc-${event.aggregateId}`, 'shared-doc'] as const)
+      .build();
+
+    const event: ProjectionEvent = {
+      type: 'invoice.created.event',
+      payload: {},
+      aggregateType: 'invoice',
+      aggregateId: 'original-id',
+      sequence: 1,
+      timestamp: '2024-01-01T00:00:00Z'
+    };
+
+    expect(projection.identity(event)).toEqual(['doc-original-id', 'shared-doc']);
   });
 
   test('throws error when build() is called without from()', () => {
@@ -320,7 +349,7 @@ describe('createProjection Type Inference', () => {
       .build();
 
     expect(projection.fromStream.aggregate).toBe(invoiceAggDef);
-    expect(projection.joinStreams[0].aggregate).toBe(orderAggDef);
+    expect(projection.joinStreams?.[0].aggregate).toBe(orderAggDef);
   });
 });
 
@@ -383,7 +412,14 @@ describe('createProjection Builder Chaining', () => {
       .build();
 
     expect(projection.name).toBe('invoice-summary');
-    expect(projection.identity({ type: 'test', payload: {}, aggregateId: 'agg-1' })).toBe('id-agg-1');
+    expect(projection.identity({
+      aggregateType: 'invoice',
+      type: 'test',
+      payload: {},
+      aggregateId: 'agg-1',
+      sequence: 1,
+      timestamp: '2024-01-01T00:00:00Z'
+    })).toBe('id-agg-1');
   });
 
   test('creates isolated initial state instances per document id', () => {
@@ -465,9 +501,9 @@ describe('createProjection ProjectionDefinition Output', () => {
       .build();
 
     expect(projection.joinStreams).toHaveLength(1);
-    expect(projection.joinStreams[0].aggregate).toBe(orderAggDef);
-    expect(projection.joinStreams[0].handlers).toHaveProperty('shipped');
-    expect(projection.joinStreams[0].handlers).toHaveProperty('itemAdded');
+    expect(projection.joinStreams?.[0].aggregate).toBe(orderAggDef);
+    expect(projection.joinStreams?.[0].handlers).toHaveProperty('shipped');
+    expect(projection.joinStreams?.[0].handlers).toHaveProperty('itemAdded');
   });
 
   test('subscriptions are captured from handlers', () => {
@@ -508,10 +544,13 @@ describe('createProjection Immer Integration', () => {
     
     // Call the handler to verify it works with Immer
     const initialState = { count: 0 };
-    const mockEvent: ProjectionEvent<InvoiceCreatedPayload> = {
+    const mockEvent: ProjectionEvent = {
       type: 'invoice.created.event',
       payload: { customerId: 'cust-1', amount: 100 },
-      aggregateId: 'inv-1'
+      aggregateType: 'invoice',
+      aggregateId: 'inv-1',
+      sequence: 1,
+      timestamp: '2024-01-01T00:00:00Z'
     };
     
     // The handler is wrapped with produce() - we need to check that produce returns a new state


### PR DESCRIPTION
## Summary
- Support `createProjection.identity(...)` returning either a single document id or a list of document ids for `.from()` events.
- Fan out `.from()` event application in `ProjectionDaemon` to all unique identity targets while preserving per-event accounting (`eventsProcessed`) and updating all touched docs.
- Add tests for identity array typing, runtime fan-out behavior, and duplicate-id de-duplication.

## Scope
- Epic bead: `redemeine-5q1`
- Implemented bead: `redemeine-ns7`
- Non-goal: join-link rewiring (unchanged `.join()` routing behavior)

## Validation
- `bun run test -- test/projections/createProjection.test.ts`
- `bun run test -- test/projections/ProjectionDaemon.test.ts`