### PR TITLE
feat(saga): integrate trigger DSL definition layer

### DIFF
--- a/docs/reference/sagas-reference.md
+++ b/docs/reference/sagas-reference.md
@@ -10,17 +10,20 @@ For generated API signatures, use `/docs/api/`.
 
 - `createSaga.ts`: typed saga definition builder and intent types.
 - `RetryPolicy.ts`: retry validation, backoff scheduling, and classification helpers.
-- `createSagaAggregate.ts`: public constructor/export for the structure-only `SagaAggregate` contract.
+- `triggers.ts`: definition-only trigger builders (`event`, `parent`, `direct`, `recovery`, `schedule.*`) with typed `toStartInput` and `when` chaining.
+- `startPolicy.ts`: typed start policy helper constructors for trigger contracts.
 
 Public export barrel (`src/sagas/index.ts`):
 
 - `createSaga`
 - `SagaRetryPolicy` + retry helpers
-- `createSagaAggregate`
+- `createSagaTriggerBuilder`
+- `startPolicy`
 
 Usage note:
 
 - `createSagaAggregate(nameOrOptions?)` exposes the public, structure-only saga aggregate contract used for persisted saga records and wire-level shape typing.
+- Trigger builders and start-policy helpers are **definition-layer only** and do not change runtime execution behavior.
 
 Anything outside these documented exports is runtime implementation detail and may change without semver guarantees.
 
@@ -195,6 +198,23 @@ Retry helpers in `RetryPolicy.ts`:
 - `classifyRetryableError(error, options?)`
 
 Policy shape: `SagaRetryPolicy` (`maxAttempts`, `initialBackoffMs`, `backoffCoefficient`, optional caps/jitter).
+
+## Trigger builders and start policies (definition-only)
+
+Use `createSagaTriggerBuilder<TStartInput>()` when you want typed trigger definitions that map source payloads to saga `StartInput` without introducing runtime execution concerns in this package.
+
+- Trigger families: `event`, `parent`, `direct`, `recovery`, and `schedule` (`interval`, `isoInterval`, `cron`, `rrule`).
+- Each trigger requires `toStartInput(source) => startInput`.
+- Optional `.when((source, startInput) => boolean)` chaining preserves strong inference across chained predicates.
+- Schedule definitions carry semantics metadata (`elapsed-time` vs `wall-clock`) and default DST policy at the definition layer.
+
+Use `startPolicy` for typed policy literals:
+
+- `startPolicy.ifIdle()`
+- `startPolicy.joinExisting()`
+- `startPolicy.restart({ mode?: 'graceful' | 'force', reason?: string })`
+
+Attach policies to trigger-adjacent contracts through `SagaTriggerStartContract`.
 
 ## Typed aggregate dispatch
 

--- a/packages/saga/src/createSaga.ts
+++ b/packages/saga/src/createSaga.ts
@@ -810,6 +810,56 @@ export type SagaHandlers<
   >;
 };
 
+/** Handler used by trigger-based saga starts before any aggregate events. */
+export type SagaStartHandler<
+  TStartInput,
+  TState,
+  TPlugins extends SagaPluginManifestList = readonly [],
+  TResponseHandlerBindings extends SagaResponseHandlerTokenBindings = Record<never, never>
+> = (
+  start: TStartInput,
+  ctx: SagaIntentContext<TPlugins, TResponseHandlerBindings>
+) => SagaHandlerResult;
+
+/** Resolver that maps normalized start input to a correlation key. */
+export type SagaStartCorrelationResolver<TStartInput, TCorrelationId = unknown> = (
+  start: TStartInput
+) => TCorrelationId;
+
+/** Normalized trigger contract shape retained in saga definition metadata. */
+export interface SagaTriggerContract<
+  TStartInput,
+  TTriggerInput = unknown,
+  TKind extends string = string
+> {
+  readonly kind: TKind;
+  readonly toStartInput: (trigger: TTriggerInput) => TStartInput;
+  readonly when?: (trigger: TTriggerInput) => boolean;
+  readonly hasWhen: boolean;
+}
+
+/** Trigger definition accepted by `.triggeredBy(...)`. */
+export interface SagaTriggerDefinition<
+  TStartInput,
+  TTriggerInput = unknown,
+  TKind extends string = string
+> {
+  readonly kind: TKind;
+  readonly toStartInput: (trigger: TTriggerInput) => TStartInput;
+  readonly when?: (trigger: TTriggerInput) => boolean;
+}
+
+/** Normalized start/correlation/trigger metadata exported on saga definitions. */
+export interface SagaStartDslContracts<TStartInput = unknown, TCorrelationId = unknown> {
+  readonly start?: {
+    readonly kind: 'definition-only';
+  };
+  readonly correlation?: {
+    readonly correlateBy: SagaStartCorrelationResolver<TStartInput, TCorrelationId>;
+  };
+  readonly triggers: readonly SagaTriggerContract<TStartInput, unknown, string>[];
+}
+
 /** Built saga definition consumed by runtime execution layers. */
 export interface SagaDefinition<
   TState = unknown,
@@ -822,6 +872,8 @@ export interface SagaDefinition<
   sagaUrn: string;
   plugins: SagaPluginRegistryFromManifests<TPlugins>;
   initialState: SagaInitialStateFactory<TState>;
+  start?: SagaStartHandler<unknown, TState, TPlugins, TResponseHandlerBindings>;
+  startContracts: SagaStartDslContracts<unknown, unknown>;
   response_handlers: TResponseHandlerBindings;
   correlations: Array<{
     aggregateType: string;
@@ -854,6 +906,56 @@ export interface SagaBuilder<
     aggregate: TAggregate,
     handlers: SagaHandlers<TState, TAggregate, TPlugins, TResponseHandlerBindings>
   ): SagaBuilder<TState, TPlugins, TResponseHandlerBindings>;
+  start<TStartInput>(
+    handler: SagaStartHandler<TStartInput, TState, TPlugins, TResponseHandlerBindings>
+  ): SagaBuilderAwaitingCorrelation<TState, TPlugins, TResponseHandlerBindings, TStartInput>;
+  build(): SagaDefinition<TState, TPlugins, TResponseHandlerBindings>;
+}
+
+/** Builder phase after `start(...)` and before required `correlateBy(...)`. */
+export interface SagaBuilderAwaitingCorrelation<
+  TState,
+  TPlugins extends SagaPluginManifestList,
+  TResponseHandlerBindings extends SagaResponseHandlerTokenBindings,
+  TStartInput
+> {
+  initialState<TNextState>(factory: SagaInitialStateFactory<TNextState>): SagaBuilderAwaitingCorrelation<TNextState, TPlugins, TResponseHandlerBindings, TStartInput>;
+  responseHandlers<const TNextResponseHandlerBindings extends SagaResponseHandlerTokenBindings>(
+    handlers: TNextResponseHandlerBindings
+  ): SagaBuilderAwaitingCorrelation<TState, TPlugins, TNextResponseHandlerBindings, TStartInput>;
+  correlate<TAggregate extends SagaAggregateDefinition>(aggregate: TAggregate, correlate: SagaCorrelationFactory): SagaBuilderAwaitingCorrelation<TState, TPlugins, TResponseHandlerBindings, TStartInput>;
+  on<TAggregate extends SagaAggregateDefinition>(
+    aggregate: TAggregate,
+    handlers: SagaHandlers<TState, TAggregate, TPlugins, TResponseHandlerBindings>
+  ): SagaBuilderAwaitingCorrelation<TState, TPlugins, TResponseHandlerBindings, TStartInput>;
+  correlateBy<TCorrelationId>(
+    correlate: SagaStartCorrelationResolver<TStartInput, TCorrelationId>
+  ): SagaBuilderCorrelated<TState, TPlugins, TResponseHandlerBindings, TStartInput, TCorrelationId>;
+}
+
+/** Builder phase after `correlateBy(...)`, where triggers and build are available. */
+export interface SagaBuilderCorrelated<
+  TState,
+  TPlugins extends SagaPluginManifestList,
+  TResponseHandlerBindings extends SagaResponseHandlerTokenBindings,
+  TStartInput,
+  TCorrelationId
+> {
+  initialState<TNextState>(factory: SagaInitialStateFactory<TNextState>): SagaBuilderCorrelated<TNextState, TPlugins, TResponseHandlerBindings, TStartInput, TCorrelationId>;
+  responseHandlers<const TNextResponseHandlerBindings extends SagaResponseHandlerTokenBindings>(
+    handlers: TNextResponseHandlerBindings
+  ): SagaBuilderCorrelated<TState, TPlugins, TNextResponseHandlerBindings, TStartInput, TCorrelationId>;
+  correlate<TAggregate extends SagaAggregateDefinition>(aggregate: TAggregate, correlate: SagaCorrelationFactory): SagaBuilderCorrelated<TState, TPlugins, TResponseHandlerBindings, TStartInput, TCorrelationId>;
+  on<TAggregate extends SagaAggregateDefinition>(
+    aggregate: TAggregate,
+    handlers: SagaHandlers<TState, TAggregate, TPlugins, TResponseHandlerBindings>
+  ): SagaBuilderCorrelated<TState, TPlugins, TResponseHandlerBindings, TStartInput, TCorrelationId>;
+  correlateBy<TNextCorrelationId>(
+    correlate: SagaStartCorrelationResolver<TStartInput, TNextCorrelationId>
+  ): SagaBuilderCorrelated<TState, TPlugins, TResponseHandlerBindings, TStartInput, TNextCorrelationId>;
+  triggeredBy<TTriggerInput, TKind extends string = string>(
+    trigger: SagaTriggerDefinition<TStartInput, TTriggerInput, TKind>
+  ): SagaBuilderCorrelated<TState, TPlugins, TResponseHandlerBindings, TStartInput, TCorrelationId>;
   build(): SagaDefinition<TState, TPlugins, TResponseHandlerBindings>;
 }
 
@@ -896,6 +998,8 @@ interface SagaDefinitionDraft<
   sagaUrn: string;
   plugins: TPlugins;
   initialState: SagaInitialStateFactory<unknown>;
+  start?: SagaStartHandler<unknown, unknown, SagaPluginManifestList, SagaResponseHandlerTokenBindings>;
+  startContracts: SagaStartDslContracts<unknown, unknown>;
   response_handlers: TResponseHandlerBindings;
   correlations: Array<{
     aggregateType: string;
@@ -1025,6 +1129,151 @@ function createSagaBuilder<
     TResponseHandlerBindings
   >
 ): SagaBuilder<TState, TPlugins, TResponseHandlerBindings> {
+  const addCorrelation = (aggregate: SagaAggregateDefinition, correlate: SagaCorrelationFactory) => {
+    state.correlations.push({
+      aggregate,
+      aggregateType: getAggregateType(aggregate),
+      sagaType: state.sagaType,
+      sagaUrn: state.sagaUrn,
+      correlate
+    });
+  };
+
+  const addHandlers = (
+    aggregate: SagaAggregateDefinition,
+    handlers: Record<
+      string,
+      SagaHandler<unknown, SagaAggregateDefinition, string, SagaPluginManifestList, SagaResponseHandlerTokenBindings>
+    >
+  ) => {
+    state.handlers.push({
+      aggregate,
+      aggregateType: getAggregateType(aggregate),
+      sagaType: state.sagaType,
+      sagaUrn: state.sagaUrn,
+      handlers
+    });
+  };
+
+  const createAwaitingCorrelationBuilder = <
+    TLocalState,
+    TLocalResponseHandlerBindings extends SagaResponseHandlerTokenBindings,
+    TStartInput
+  >(): SagaBuilderAwaitingCorrelation<TLocalState, TPlugins, TLocalResponseHandlerBindings, TStartInput> => ({
+    initialState<TNextState>(factory: SagaInitialStateFactory<TNextState>) {
+      state.initialState = factory as SagaInitialStateFactory<unknown>;
+      return createAwaitingCorrelationBuilder<TNextState, TLocalResponseHandlerBindings, TStartInput>();
+    },
+    responseHandlers<TNextResponseHandlerBindings extends SagaResponseHandlerTokenBindings>(handlers: TNextResponseHandlerBindings) {
+      (state as unknown as SagaDefinitionDraft<
+        SagaPluginRegistryFromManifests<TPlugins>,
+        TNextResponseHandlerBindings
+      >).response_handlers = handlers;
+      return createAwaitingCorrelationBuilder<TLocalState, TNextResponseHandlerBindings, TStartInput>();
+    },
+    correlate<TAggregate extends SagaAggregateDefinition>(aggregate: TAggregate, correlate: SagaCorrelationFactory) {
+      addCorrelation(aggregate, correlate);
+      return createAwaitingCorrelationBuilder<TLocalState, TLocalResponseHandlerBindings, TStartInput>();
+    },
+    on<TAggregate extends SagaAggregateDefinition>(
+      aggregate: TAggregate,
+      handlers: SagaHandlers<TLocalState, TAggregate, TPlugins, TLocalResponseHandlerBindings>
+    ) {
+      addHandlers(
+        aggregate,
+        handlers as Record<
+          string,
+          SagaHandler<unknown, SagaAggregateDefinition, string, SagaPluginManifestList, SagaResponseHandlerTokenBindings>
+        >
+      );
+      return createAwaitingCorrelationBuilder<TLocalState, TLocalResponseHandlerBindings, TStartInput>();
+    },
+    correlateBy<TCorrelationId>(correlate: SagaStartCorrelationResolver<TStartInput, TCorrelationId>) {
+      state.startContracts = {
+        ...state.startContracts,
+        correlation: {
+          correlateBy: correlate as SagaStartCorrelationResolver<unknown, unknown>
+        }
+      };
+
+      return createCorrelatedBuilder<TLocalState, TLocalResponseHandlerBindings, TStartInput, TCorrelationId>();
+    }
+  });
+
+  const createCorrelatedBuilder = <
+    TLocalState,
+    TLocalResponseHandlerBindings extends SagaResponseHandlerTokenBindings,
+    TStartInput,
+    TCorrelationId
+  >(): SagaBuilderCorrelated<TLocalState, TPlugins, TLocalResponseHandlerBindings, TStartInput, TCorrelationId> => ({
+    initialState<TNextState>(factory: SagaInitialStateFactory<TNextState>) {
+      state.initialState = factory as SagaInitialStateFactory<unknown>;
+      return createCorrelatedBuilder<TNextState, TLocalResponseHandlerBindings, TStartInput, TCorrelationId>();
+    },
+    responseHandlers<TNextResponseHandlerBindings extends SagaResponseHandlerTokenBindings>(handlers: TNextResponseHandlerBindings) {
+      (state as unknown as SagaDefinitionDraft<
+        SagaPluginRegistryFromManifests<TPlugins>,
+        TNextResponseHandlerBindings
+      >).response_handlers = handlers;
+      return createCorrelatedBuilder<TLocalState, TNextResponseHandlerBindings, TStartInput, TCorrelationId>();
+    },
+    correlate<TAggregate extends SagaAggregateDefinition>(aggregate: TAggregate, correlate: SagaCorrelationFactory) {
+      addCorrelation(aggregate, correlate);
+      return createCorrelatedBuilder<TLocalState, TLocalResponseHandlerBindings, TStartInput, TCorrelationId>();
+    },
+    on<TAggregate extends SagaAggregateDefinition>(
+      aggregate: TAggregate,
+      handlers: SagaHandlers<TLocalState, TAggregate, TPlugins, TLocalResponseHandlerBindings>
+    ) {
+      addHandlers(
+        aggregate,
+        handlers as Record<
+          string,
+          SagaHandler<unknown, SagaAggregateDefinition, string, SagaPluginManifestList, SagaResponseHandlerTokenBindings>
+        >
+      );
+      return createCorrelatedBuilder<TLocalState, TLocalResponseHandlerBindings, TStartInput, TCorrelationId>();
+    },
+    correlateBy<TNextCorrelationId>(correlate: SagaStartCorrelationResolver<TStartInput, TNextCorrelationId>) {
+      state.startContracts = {
+        ...state.startContracts,
+        correlation: {
+          correlateBy: correlate as SagaStartCorrelationResolver<unknown, unknown>
+        }
+      };
+
+      return createCorrelatedBuilder<TLocalState, TLocalResponseHandlerBindings, TStartInput, TNextCorrelationId>();
+    },
+    triggeredBy<TTriggerInput, TKind extends string = string>(
+      trigger: SagaTriggerDefinition<TStartInput, TTriggerInput, TKind>
+    ) {
+      const normalizedTrigger: SagaTriggerContract<unknown, unknown, string> = {
+        kind: trigger.kind,
+        toStartInput: trigger.toStartInput as (trigger: unknown) => unknown,
+        when: trigger.when as ((trigger: unknown) => boolean) | undefined,
+        hasWhen: typeof trigger.when === 'function'
+      };
+
+      state.startContracts = {
+        ...state.startContracts,
+        triggers: [...state.startContracts.triggers, normalizedTrigger]
+      };
+
+      return createCorrelatedBuilder<TLocalState, TLocalResponseHandlerBindings, TStartInput, TCorrelationId>();
+    },
+    build() {
+      return ({
+        ...state,
+        plugins: [...state.plugins],
+        startContracts: {
+          ...state.startContracts,
+          triggers: [...state.startContracts.triggers]
+        },
+        response_handlers: { ...state.response_handlers }
+      } as unknown) as SagaDefinition<TLocalState, TPlugins, TLocalResponseHandlerBindings>;
+    }
+  });
+
   return {
     initialState<TNextState>(factory: SagaInitialStateFactory<TNextState>) {
       state.initialState = factory as SagaInitialStateFactory<unknown>;
@@ -1039,32 +1288,38 @@ function createSagaBuilder<
       return createSagaBuilder<TState, TPlugins, TNextResponseHandlerBindings>(nextState);
     },
     correlate(aggregate, correlate) {
-      state.correlations.push({
-        aggregate,
-        aggregateType: getAggregateType(aggregate),
-        sagaType: state.sagaType,
-        sagaUrn: state.sagaUrn,
-        correlate
-      });
+      addCorrelation(aggregate, correlate);
       return createSagaBuilder<TState, TPlugins, TResponseHandlerBindings>(state);
     },
     on(aggregate, handlers) {
-      state.handlers.push({
+      addHandlers(
         aggregate,
-        aggregateType: getAggregateType(aggregate),
-        sagaType: state.sagaType,
-        sagaUrn: state.sagaUrn,
-        handlers: handlers as Record<
+        handlers as Record<
           string,
           SagaHandler<unknown, SagaAggregateDefinition, string, SagaPluginManifestList, SagaResponseHandlerTokenBindings>
         >
-      });
+      );
       return createSagaBuilder<TState, TPlugins, TResponseHandlerBindings>(state);
+    },
+    start<TStartInput>(handler: SagaStartHandler<TStartInput, TState, TPlugins, TResponseHandlerBindings>) {
+      state.start = handler as SagaStartHandler<unknown, unknown, SagaPluginManifestList, SagaResponseHandlerTokenBindings>;
+      state.startContracts = {
+        ...state.startContracts,
+        start: {
+          kind: 'definition-only'
+        }
+      };
+
+      return createAwaitingCorrelationBuilder<TState, TResponseHandlerBindings, TStartInput>();
     },
     build() {
       return ({
         ...state,
         plugins: [...state.plugins],
+        startContracts: {
+          ...state.startContracts,
+          triggers: [...state.startContracts.triggers]
+        },
         response_handlers: { ...state.response_handlers }
       } as unknown) as SagaDefinition<TState, TPlugins, TResponseHandlerBindings>;
     }
@@ -1093,6 +1348,12 @@ export function createSaga<
     sagaUrn: identity.sagaUrn,
     plugins: pluginRegistry,
     initialState: () => undefined,
+    start: undefined,
+    startContracts: {
+      start: undefined,
+      correlation: undefined,
+      triggers: []
+    },
     response_handlers: {},
     correlations: [],
     handlers: []

--- a/packages/saga/src/index.ts
+++ b/packages/saga/src/index.ts
@@ -62,6 +62,50 @@ export {
   type SagaTriggerContract,
   type SagaTriggerDefinition
 } from './createSaga';
+export {
+  startPolicy,
+  type SagaRestartMode,
+  type SagaRestartOptions,
+  type SagaStartPolicy,
+  type SagaStartPolicyIfIdle,
+  type SagaStartPolicyJoinExisting,
+  type SagaStartPolicyRestart
+} from './startPolicy';
+export {
+  type SagaTriggerStartContract
+} from './triggerContracts';
+export {
+  createSagaTriggerBuilder,
+  type SagaCronScheduleInvocation,
+  type SagaCronScheduleTriggerOptions,
+  type SagaDirectTriggerDefinition,
+  type SagaDirectTriggerOptions,
+  type SagaEventTriggerDefinition,
+  type SagaEventTriggerOptions,
+  type SagaIntervalScheduleInvocation,
+  type SagaIntervalScheduleTriggerOptions,
+  type SagaIsoIntervalScheduleInvocation,
+  type SagaIsoIntervalScheduleTriggerOptions,
+  type SagaParentTriggerDefinition,
+  type SagaParentTriggerOptions,
+  type SagaRecoveryTriggerDefinition,
+  type SagaRecoveryTriggerOptions,
+  type SagaRRuleScheduleInvocation,
+  type SagaRRuleScheduleTriggerOptions,
+  type SagaScheduleAmbiguousTimePolicy,
+  type SagaScheduleDstPolicy,
+  type SagaScheduleInvocationBase,
+  type SagaScheduleKind,
+  type SagaScheduleMetadata,
+  type SagaScheduleNonexistentTimePolicy,
+  type SagaScheduleSemantics,
+  type SagaScheduleTriggerDefinition,
+  type SagaTriggerBuilderFactory,
+  type SagaTriggerDefinitionBase,
+  type SagaTriggerDefinitionBuilder,
+  type SagaTriggerPredicate,
+  type SagaTriggerToStartInput
+} from './triggers';
 export { createAggregate } from './aggregateBridge';
 export {
   parseSagaIdentityUrn,

--- a/packages/saga/src/index.ts
+++ b/packages/saga/src/index.ts
@@ -55,7 +55,12 @@ export {
   type SagaResponseHandlerTokenNamespace,
   type SagaRunActivity,
   type SagaRunActivityIntent,
-  type SagaScheduleIntent
+  type SagaScheduleIntent,
+  type SagaStartCorrelationResolver,
+  type SagaStartDslContracts,
+  type SagaStartHandler,
+  type SagaTriggerContract,
+  type SagaTriggerDefinition
 } from './createSaga';
 export { createAggregate } from './aggregateBridge';
 export {

--- a/packages/saga/src/startPolicy.ts
+++ b/packages/saga/src/startPolicy.ts
@@ -1,0 +1,49 @@
+/**
+ * Typed start-policy variants used by saga trigger contracts.
+ */
+export type SagaStartPolicy = SagaStartPolicyIfIdle | SagaStartPolicyJoinExisting | SagaStartPolicyRestart;
+
+export interface SagaStartPolicyIfIdle {
+  readonly type: 'if-idle';
+}
+
+export interface SagaStartPolicyJoinExisting {
+  readonly type: 'join-existing';
+}
+
+export type SagaRestartMode = 'graceful' | 'force';
+
+export interface SagaRestartOptions {
+  /**
+   * Optional restart mode for trigger/runtime integrations.
+   *
+   * This is definition-only and does not alter runtime behavior in this layer.
+   */
+  readonly mode?: SagaRestartMode;
+  readonly reason?: string;
+}
+
+export interface SagaStartPolicyRestart {
+  readonly type: 'restart';
+  readonly options?: SagaRestartOptions;
+}
+
+/**
+ * Public helper API for constructing typed start policies without magic strings.
+ */
+export const startPolicy = {
+  ifIdle(): SagaStartPolicyIfIdle {
+    return { type: 'if-idle' };
+  },
+
+  joinExisting(): SagaStartPolicyJoinExisting {
+    return { type: 'join-existing' };
+  },
+
+  restart(options?: SagaRestartOptions): SagaStartPolicyRestart {
+    return {
+      type: 'restart',
+      options
+    };
+  }
+} as const;

--- a/packages/saga/src/triggerContracts.ts
+++ b/packages/saga/src/triggerContracts.ts
@@ -1,0 +1,11 @@
+import type { SagaStartPolicy } from './startPolicy';
+
+/**
+ * Shared trigger contract for saga-start definitions.
+ *
+ * This is intentionally definition-oriented and can be consumed by future
+ * trigger builders without changing runtime behavior in this bead.
+ */
+export interface SagaTriggerStartContract {
+  readonly startPolicy?: SagaStartPolicy;
+}

--- a/packages/saga/src/triggers.ts
+++ b/packages/saga/src/triggers.ts
@@ -1,0 +1,366 @@
+import type { SagaTriggerStartContract } from './triggerContracts';
+
+export type SagaTriggerPredicate<TSource, TStartInput> = (
+  source: Readonly<TSource>,
+  startInput: Readonly<TStartInput>
+) => boolean;
+
+export type SagaTriggerToStartInput<TSource, TStartInput> = (
+  source: Readonly<TSource>
+) => TStartInput;
+
+export interface SagaTriggerDefinitionBase<
+  TFamily extends string,
+  TSource,
+  TStartInput,
+  TWhen extends readonly SagaTriggerPredicate<TSource, TStartInput>[]
+> extends SagaTriggerStartContract {
+  readonly family: TFamily;
+  readonly toStartInput: SagaTriggerToStartInput<TSource, TStartInput>;
+  readonly when: TWhen;
+}
+
+type TriggerWhenListOf<TDefinition> =
+  TDefinition extends { readonly when: infer TWhen extends readonly unknown[] }
+    ? TWhen
+    : readonly [];
+
+type TriggerSourceOf<TDefinition> =
+  TDefinition extends { readonly toStartInput: SagaTriggerToStartInput<infer TSource, any> }
+    ? TSource
+    : never;
+
+type TriggerStartInputOf<TDefinition> =
+  TDefinition extends { readonly toStartInput: SagaTriggerToStartInput<any, infer TStartInput> }
+    ? TStartInput
+    : never;
+
+type WithAdditionalWhen<TDefinition, TPredicate> = Omit<TDefinition, 'when'> & {
+  readonly when: readonly [...TriggerWhenListOf<TDefinition>, TPredicate];
+};
+
+export interface SagaTriggerDefinitionBuilder<TDefinition> {
+  readonly definition: TDefinition;
+  when<TPredicate extends SagaTriggerPredicate<TriggerSourceOf<TDefinition>, TriggerStartInputOf<TDefinition>>>(
+    predicate: TPredicate
+  ): SagaTriggerDefinitionBuilder<WithAdditionalWhen<TDefinition, TPredicate>>;
+  build(): TDefinition;
+}
+
+function createSagaTriggerDefinitionBuilder<TDefinition extends { readonly when: readonly unknown[] }>(
+  definition: TDefinition
+): SagaTriggerDefinitionBuilder<TDefinition> {
+  return {
+    definition,
+    when(predicate) {
+      const nextWhen = [...definition.when, predicate] as unknown as readonly [
+        ...TriggerWhenListOf<TDefinition>,
+        typeof predicate
+      ];
+
+      const nextDefinition = {
+        ...definition,
+        when: nextWhen
+      };
+
+      return createSagaTriggerDefinitionBuilder(nextDefinition);
+    },
+    build() {
+      return definition;
+    }
+  };
+}
+
+export interface SagaEventTriggerDefinition<
+  TSource,
+  TStartInput,
+  TWhen extends readonly SagaTriggerPredicate<TSource, TStartInput>[] = readonly []
+> extends SagaTriggerDefinitionBase<'event', TSource, TStartInput, TWhen> {
+  readonly event: string;
+}
+
+export interface SagaParentTriggerDefinition<
+  TSource,
+  TStartInput,
+  TWhen extends readonly SagaTriggerPredicate<TSource, TStartInput>[] = readonly []
+> extends SagaTriggerDefinitionBase<'parent', TSource, TStartInput, TWhen> {
+  readonly parent: {
+    readonly allowList?: readonly string[];
+    readonly requiredCapability?: string;
+  };
+}
+
+export interface SagaDirectTriggerDefinition<
+  TSource,
+  TStartInput,
+  TWhen extends readonly SagaTriggerPredicate<TSource, TStartInput>[] = readonly []
+> extends SagaTriggerDefinitionBase<'direct', TSource, TStartInput, TWhen> {
+  readonly direct: {
+    readonly channel?: string;
+  };
+}
+
+export interface SagaRecoveryTriggerDefinition<
+  TSource,
+  TStartInput,
+  TWhen extends readonly SagaTriggerPredicate<TSource, TStartInput>[] = readonly []
+> extends SagaTriggerDefinitionBase<'recovery', TSource, TStartInput, TWhen> {
+  readonly recovery: {
+    readonly reason?: string;
+  };
+}
+
+export type SagaScheduleKind = 'interval' | 'cron' | 'rrule' | 'isoInterval';
+export type SagaScheduleSemantics = 'elapsed-time' | 'wall-clock';
+export type SagaScheduleAmbiguousTimePolicy = 'first-occurrence-only';
+export type SagaScheduleNonexistentTimePolicy = 'next-valid-time';
+
+export interface SagaScheduleDstPolicy {
+  readonly ambiguousTime: SagaScheduleAmbiguousTimePolicy;
+  readonly nonexistentTime: SagaScheduleNonexistentTimePolicy;
+}
+
+export interface SagaScheduleMetadata<TSemantics extends SagaScheduleSemantics> {
+  readonly semantics: TSemantics;
+  readonly dstPolicy: SagaScheduleDstPolicy;
+}
+
+export interface SagaScheduleInvocationBase<TKind extends SagaScheduleKind> {
+  readonly kind: TKind;
+  readonly occurrenceId: string;
+  readonly scheduledFor: string;
+}
+
+export interface SagaIntervalScheduleInvocation
+  extends SagaScheduleInvocationBase<'interval'> {
+  readonly everyMs: number;
+}
+
+export interface SagaIsoIntervalScheduleInvocation
+  extends SagaScheduleInvocationBase<'isoInterval'> {
+  readonly isoInterval: string;
+}
+
+export interface SagaCronScheduleInvocation
+  extends SagaScheduleInvocationBase<'cron'> {
+  readonly cron: string;
+  readonly timezone: string;
+}
+
+export interface SagaRRuleScheduleInvocation
+  extends SagaScheduleInvocationBase<'rrule'> {
+  readonly rrule: string;
+  readonly timezone: string;
+}
+
+export interface SagaScheduleTriggerDefinition<
+  TKind extends SagaScheduleKind,
+  TSource,
+  TStartInput,
+  TSemantics extends SagaScheduleSemantics,
+  TWhen extends readonly SagaTriggerPredicate<TSource, TStartInput>[] = readonly []
+> extends SagaTriggerDefinitionBase<'schedule', TSource, TStartInput, TWhen> {
+  readonly schedule: {
+    readonly kind: TKind;
+    readonly metadata: SagaScheduleMetadata<TSemantics>;
+    readonly everyMs?: number;
+    readonly isoInterval?: string;
+    readonly cron?: string;
+    readonly rrule?: string;
+    readonly timezone?: string;
+  };
+}
+
+export interface SagaEventTriggerOptions<TSource, TStartInput> {
+  readonly event: string;
+  readonly toStartInput: SagaTriggerToStartInput<TSource, TStartInput>;
+}
+
+export interface SagaParentTriggerOptions<TSource, TStartInput> {
+  readonly toStartInput: SagaTriggerToStartInput<TSource, TStartInput>;
+  readonly allowList?: readonly string[];
+  readonly requiredCapability?: string;
+}
+
+export interface SagaDirectTriggerOptions<TSource, TStartInput> {
+  readonly toStartInput: SagaTriggerToStartInput<TSource, TStartInput>;
+  readonly channel?: string;
+}
+
+export interface SagaRecoveryTriggerOptions<TSource, TStartInput> {
+  readonly toStartInput: SagaTriggerToStartInput<TSource, TStartInput>;
+  readonly reason?: string;
+}
+
+export interface SagaIntervalScheduleTriggerOptions<
+  TSource extends SagaIntervalScheduleInvocation,
+  TStartInput
+> {
+  readonly everyMs: number;
+  readonly toStartInput: SagaTriggerToStartInput<TSource, TStartInput>;
+}
+
+export interface SagaIsoIntervalScheduleTriggerOptions<
+  TSource extends SagaIsoIntervalScheduleInvocation,
+  TStartInput
+> {
+  readonly isoInterval: string;
+  readonly toStartInput: SagaTriggerToStartInput<TSource, TStartInput>;
+}
+
+export interface SagaCronScheduleTriggerOptions<
+  TSource extends SagaCronScheduleInvocation,
+  TStartInput
+> {
+  readonly cron: string;
+  readonly timezone: string;
+  readonly toStartInput: SagaTriggerToStartInput<TSource, TStartInput>;
+}
+
+export interface SagaRRuleScheduleTriggerOptions<
+  TSource extends SagaRRuleScheduleInvocation,
+  TStartInput
+> {
+  readonly rrule: string;
+  readonly timezone: string;
+  readonly toStartInput: SagaTriggerToStartInput<TSource, TStartInput>;
+}
+
+const DEFAULT_SCHEDULE_DST_POLICY: SagaScheduleDstPolicy = {
+  ambiguousTime: 'first-occurrence-only',
+  nonexistentTime: 'next-valid-time'
+};
+
+function createElapsedTimeMetadata(): SagaScheduleMetadata<'elapsed-time'> {
+  return {
+    semantics: 'elapsed-time',
+    dstPolicy: DEFAULT_SCHEDULE_DST_POLICY
+  };
+}
+
+function createWallClockMetadata(): SagaScheduleMetadata<'wall-clock'> {
+  return {
+    semantics: 'wall-clock',
+    dstPolicy: DEFAULT_SCHEDULE_DST_POLICY
+  };
+}
+
+export interface SagaTriggerBuilderFactory<TStartInput> {
+  event<TSource>(
+    options: SagaEventTriggerOptions<TSource, TStartInput>
+  ): SagaTriggerDefinitionBuilder<SagaEventTriggerDefinition<TSource, TStartInput>>;
+  parent<TSource>(
+    options: SagaParentTriggerOptions<TSource, TStartInput>
+  ): SagaTriggerDefinitionBuilder<SagaParentTriggerDefinition<TSource, TStartInput>>;
+  direct<TSource>(
+    options: SagaDirectTriggerOptions<TSource, TStartInput>
+  ): SagaTriggerDefinitionBuilder<SagaDirectTriggerDefinition<TSource, TStartInput>>;
+  recovery<TSource>(
+    options: SagaRecoveryTriggerOptions<TSource, TStartInput>
+  ): SagaTriggerDefinitionBuilder<SagaRecoveryTriggerDefinition<TSource, TStartInput>>;
+  readonly schedule: {
+    interval<TSource extends SagaIntervalScheduleInvocation = SagaIntervalScheduleInvocation>(
+      options: SagaIntervalScheduleTriggerOptions<TSource, TStartInput>
+    ): SagaTriggerDefinitionBuilder<SagaScheduleTriggerDefinition<'interval', TSource, TStartInput, 'elapsed-time'>>;
+    isoInterval<TSource extends SagaIsoIntervalScheduleInvocation = SagaIsoIntervalScheduleInvocation>(
+      options: SagaIsoIntervalScheduleTriggerOptions<TSource, TStartInput>
+    ): SagaTriggerDefinitionBuilder<SagaScheduleTriggerDefinition<'isoInterval', TSource, TStartInput, 'elapsed-time'>>;
+    cron<TSource extends SagaCronScheduleInvocation = SagaCronScheduleInvocation>(
+      options: SagaCronScheduleTriggerOptions<TSource, TStartInput>
+    ): SagaTriggerDefinitionBuilder<SagaScheduleTriggerDefinition<'cron', TSource, TStartInput, 'wall-clock'>>;
+    rrule<TSource extends SagaRRuleScheduleInvocation = SagaRRuleScheduleInvocation>(
+      options: SagaRRuleScheduleTriggerOptions<TSource, TStartInput>
+    ): SagaTriggerDefinitionBuilder<SagaScheduleTriggerDefinition<'rrule', TSource, TStartInput, 'wall-clock'>>;
+  };
+}
+
+/**
+ * Definition-only trigger DSL for mapping trigger source payloads into saga StartInput.
+ */
+export function createSagaTriggerBuilder<TStartInput>(): SagaTriggerBuilderFactory<TStartInput> {
+  return {
+    event: <TSource>(options: SagaEventTriggerOptions<TSource, TStartInput>) => createSagaTriggerDefinitionBuilder({
+      family: 'event',
+      event: options.event,
+      toStartInput: options.toStartInput,
+      when: [] as const
+    }),
+    parent: <TSource>(options: SagaParentTriggerOptions<TSource, TStartInput>) => createSagaTriggerDefinitionBuilder({
+      family: 'parent',
+      parent: {
+        allowList: options.allowList,
+        requiredCapability: options.requiredCapability
+      },
+      toStartInput: options.toStartInput,
+      when: [] as const
+    }),
+    direct: <TSource>(options: SagaDirectTriggerOptions<TSource, TStartInput>) => createSagaTriggerDefinitionBuilder({
+      family: 'direct',
+      direct: {
+        channel: options.channel
+      },
+      toStartInput: options.toStartInput,
+      when: [] as const
+    }),
+    recovery: <TSource>(options: SagaRecoveryTriggerOptions<TSource, TStartInput>) => createSagaTriggerDefinitionBuilder({
+      family: 'recovery',
+      recovery: {
+        reason: options.reason
+      },
+      toStartInput: options.toStartInput,
+      when: [] as const
+    }),
+    schedule: {
+      interval: <TSource extends SagaIntervalScheduleInvocation>(
+        options: SagaIntervalScheduleTriggerOptions<TSource, TStartInput>
+      ) => createSagaTriggerDefinitionBuilder({
+        family: 'schedule',
+        schedule: {
+          kind: 'interval',
+          everyMs: options.everyMs,
+          metadata: createElapsedTimeMetadata()
+        },
+        toStartInput: options.toStartInput,
+        when: [] as const
+      }),
+      isoInterval: <TSource extends SagaIsoIntervalScheduleInvocation>(
+        options: SagaIsoIntervalScheduleTriggerOptions<TSource, TStartInput>
+      ) => createSagaTriggerDefinitionBuilder({
+        family: 'schedule',
+        schedule: {
+          kind: 'isoInterval',
+          isoInterval: options.isoInterval,
+          metadata: createElapsedTimeMetadata()
+        },
+        toStartInput: options.toStartInput,
+        when: [] as const
+      }),
+      cron: <TSource extends SagaCronScheduleInvocation>(
+        options: SagaCronScheduleTriggerOptions<TSource, TStartInput>
+      ) => createSagaTriggerDefinitionBuilder({
+        family: 'schedule',
+        schedule: {
+          kind: 'cron',
+          cron: options.cron,
+          timezone: options.timezone,
+          metadata: createWallClockMetadata()
+        },
+        toStartInput: options.toStartInput,
+        when: [] as const
+      }),
+      rrule: <TSource extends SagaRRuleScheduleInvocation>(
+        options: SagaRRuleScheduleTriggerOptions<TSource, TStartInput>
+      ) => createSagaTriggerDefinitionBuilder({
+        family: 'schedule',
+        schedule: {
+          kind: 'rrule',
+          rrule: options.rrule,
+          timezone: options.timezone,
+          metadata: createWallClockMetadata()
+        },
+        toStartInput: options.toStartInput,
+        when: [] as const
+      })
+    }
+  };
+}

--- a/packages/saga/test/start-policy-types.test.ts
+++ b/packages/saga/test/start-policy-types.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from '@jest/globals';
+import { type SagaStartPolicy, startPolicy } from '../src/startPolicy';
+import type { SagaTriggerStartContract } from '../src/triggerContracts';
+
+describe('saga startPolicy typed helpers', () => {
+  it('creates typed ifIdle/joinExisting/restart policies', () => {
+    const idle = startPolicy.ifIdle();
+    const join = startPolicy.joinExisting();
+    const restart = startPolicy.restart({ mode: 'graceful', reason: 'manual re-run' });
+
+    const accepted: SagaStartPolicy[] = [idle, join, restart];
+    const triggerContract: SagaTriggerStartContract = {
+      startPolicy: restart
+    };
+
+    expect(accepted.map((policy) => policy.type)).toEqual(['if-idle', 'join-existing', 'restart']);
+    expect(triggerContract.startPolicy?.type).toBe('restart');
+    expect(restart.options?.mode).toBe('graceful');
+  });
+
+  it('rejects invalid policy literals at compile time', () => {
+    // @ts-expect-error magic string is not assignable to SagaStartPolicy
+    const invalidString: SagaStartPolicy = 'if-idle';
+
+    // @ts-expect-error unknown start policy variant is rejected
+    const invalidType: SagaStartPolicy = { type: 'unknown-policy' };
+
+    // @ts-expect-error restart mode only accepts graceful|force
+    startPolicy.restart({ mode: 'immediate' });
+
+    void invalidString;
+    void invalidType;
+
+    expect(true).toBe(true);
+  });
+});

--- a/packages/saga/test/start-trigger-dsl-type-gating.test.ts
+++ b/packages/saga/test/start-trigger-dsl-type-gating.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from '@jest/globals';
+import { createSaga } from '../src/createSaga';
+
+describe('createSaga start/correlateBy/triggeredBy definition DSL', () => {
+  it('requires correlateBy before triggeredBy/build and stores normalized contracts', () => {
+    const predicate = (trigger: { source: 'event' | 'direct'; payload: { orderId: string } }) => trigger.source === 'event';
+
+    const definition = createSaga<{ started: boolean }>({ name: 'order-start-saga' })
+      .initialState(() => ({ started: false }))
+      .start<{ orderId: string; source: 'event' | 'direct' }>((_start, _ctx) => undefined)
+      .correlateBy((start) => start.orderId)
+      .triggeredBy({
+        kind: 'event',
+        toStartInput: (trigger: { source: 'event' | 'direct'; payload: { orderId: string } }) => ({
+          orderId: trigger.payload.orderId,
+          source: trigger.source
+        }),
+        when: predicate
+      })
+      .triggeredBy({
+        kind: 'direct',
+        toStartInput: (trigger: { orderId: string }) => ({
+          orderId: trigger.orderId,
+          source: 'direct' as const
+        })
+      })
+      .build();
+
+    expect(definition.startContracts.start?.kind).toBe('definition-only');
+    expect(typeof definition.startContracts.correlation?.correlateBy).toBe('function');
+    expect(definition.startContracts.triggers).toHaveLength(2);
+    expect(definition.startContracts.triggers[0].kind).toBe('event');
+    expect(definition.startContracts.triggers[0].hasWhen).toBe(true);
+    expect(definition.startContracts.triggers[0].when).toBe(predicate);
+    expect(definition.startContracts.triggers[1].kind).toBe('direct');
+    expect(definition.startContracts.triggers[1].hasWhen).toBe(false);
+    expect(definition.startContracts.triggers[1].when).toBeUndefined();
+  });
+
+  it('enforces builder-phase gating at compile time', () => {
+    const awaitingCorrelation = createSaga({ name: 'gated-saga' }).start<{ orderId: string }>((_start, _ctx) => undefined);
+
+    // @ts-expect-error build is unavailable before correlateBy
+    type BuildBeforeCorrelateBy = typeof awaitingCorrelation.build;
+
+    // @ts-expect-error triggeredBy is unavailable before correlateBy
+    type TriggeredByBeforeCorrelateBy = typeof awaitingCorrelation.triggeredBy;
+
+    const _typeSmoke: [BuildBeforeCorrelateBy?, TriggeredByBeforeCorrelateBy?] = [];
+    expect(_typeSmoke).toHaveLength(0);
+
+    expect(true).toBe(true);
+  });
+});

--- a/packages/saga/test/triggers-definition.test.ts
+++ b/packages/saga/test/triggers-definition.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from '@jest/globals';
+import { createSagaTriggerBuilder } from '../src/triggers';
+
+describe('saga trigger builder DSL (definition-only)', () => {
+  it('supports event, parent, direct and recovery triggers with required toStartInput', () => {
+    const triggers = createSagaTriggerBuilder<{ sagaId: string; source: string }>();
+
+    const eventTrigger = triggers
+      .event<{ orderId: string; amount: number }>({
+        event: 'orders.created',
+        toStartInput: (source) => ({ sagaId: source.orderId, source: 'event' })
+      })
+      .when((source) => source.amount > 0)
+      .build();
+
+    const parentTrigger = triggers
+      .parent<{ parentSagaId: string }>({
+        allowList: ['parent-a'],
+        requiredCapability: 'link:start',
+        toStartInput: (source) => ({ sagaId: source.parentSagaId, source: 'parent' })
+      })
+      .build();
+
+    const directTrigger = triggers
+      .direct<{ commandId: string }>({
+        channel: 'api',
+        toStartInput: (source) => ({ sagaId: source.commandId, source: 'direct' })
+      })
+      .build();
+
+    const recoveryTrigger = triggers
+      .recovery<{ failedSagaId: string }>({
+        reason: 'retry-window-open',
+        toStartInput: (source) => ({ sagaId: source.failedSagaId, source: 'recovery' })
+      })
+      .build();
+
+    expect(eventTrigger.family).toBe('event');
+    expect(parentTrigger.family).toBe('parent');
+    expect(directTrigger.family).toBe('direct');
+    expect(recoveryTrigger.family).toBe('recovery');
+    expect(eventTrigger.when).toHaveLength(1);
+  });
+
+  it('provides schedule entry points with semantics and DST defaults', () => {
+    const triggers = createSagaTriggerBuilder<{ sagaId: string; kind: string }>();
+
+    const interval = triggers.schedule.interval({
+      everyMs: 30_000,
+      toStartInput: (source) => ({ sagaId: source.occurrenceId, kind: source.kind })
+    }).build();
+
+    const isoInterval = triggers.schedule.isoInterval({
+      isoInterval: 'PT30S',
+      toStartInput: (source) => ({ sagaId: source.occurrenceId, kind: source.kind })
+    }).build();
+
+    const cron = triggers.schedule.cron({
+      cron: '0 9 * * MON-FRI',
+      timezone: 'Europe/Stockholm',
+      toStartInput: (source) => ({ sagaId: source.occurrenceId, kind: source.kind })
+    }).build();
+
+    const rrule = triggers.schedule.rrule({
+      rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+      timezone: 'Europe/Stockholm',
+      toStartInput: (source) => ({ sagaId: source.occurrenceId, kind: source.kind })
+    }).build();
+
+    expect(interval.schedule.kind).toBe('interval');
+    expect(interval.schedule.metadata.semantics).toBe('elapsed-time');
+    expect(interval.schedule.metadata.dstPolicy.ambiguousTime).toBe('first-occurrence-only');
+    expect(interval.schedule.metadata.dstPolicy.nonexistentTime).toBe('next-valid-time');
+
+    expect(isoInterval.schedule.kind).toBe('isoInterval');
+    expect(isoInterval.schedule.metadata.semantics).toBe('elapsed-time');
+
+    expect(cron.schedule.kind).toBe('cron');
+    expect(cron.schedule.timezone).toBe('Europe/Stockholm');
+    expect(cron.schedule.metadata.semantics).toBe('wall-clock');
+
+    expect(rrule.schedule.kind).toBe('rrule');
+    expect(rrule.schedule.timezone).toBe('Europe/Stockholm');
+    expect(rrule.schedule.metadata.semantics).toBe('wall-clock');
+  });
+
+  it('keeps when chaining and source/start-input type inference strong', () => {
+    const triggers = createSagaTriggerBuilder<{ key: string; retries: number }>();
+
+    const def = triggers
+      .event<{ id: string; retries: number }>({
+        event: 'orders.retry.requested',
+        toStartInput: (source) => ({ key: source.id, retries: source.retries })
+      })
+      .when((source, startInput) => {
+        const id: string = source.id;
+        const retries: number = startInput.retries;
+        expect(id).toBeDefined();
+        expect(retries).toBeGreaterThanOrEqual(0);
+        return startInput.retries < 5;
+      })
+      .when((source, startInput) => source.retries === startInput.retries)
+      .build();
+
+    expect(def.when).toHaveLength(2);
+
+    createSagaTriggerBuilder<{ id: string }>().event<{ id: string }>({
+      event: 'orders.created',
+      // @ts-expect-error toStartInput must return StartInput shape
+      toStartInput: (_source) => ({ missing: 'id' })
+    });
+
+    createSagaTriggerBuilder<{ id: string }>().event<{ id: string }>({
+      event: 'orders.created',
+      toStartInput: (source) => ({ id: source.id })
+    })
+      .when((_source, startInput) => {
+        // @ts-expect-error startInput.id is string, not number
+        const invalid: number = startInput.id;
+        expect(invalid).toBeDefined();
+        return true;
+      });
+  });
+});


### PR DESCRIPTION
## Summary
- Epic: redemeine-z00
- Scope: trigger DSL integration in `packages/saga` (definition-only; no runtime worker changes)
- Bead linkage: redemeine-z00.1, redemeine-z00.2, redemeine-z00.3, redemeine-z00.4, redemeine-z00.5, redemeine-z00.6

## Child beads status
- [x] redemeine-z00.1 — implemented and closed
- [x] redemeine-z00.2 — architecture plan delivered and closed
- [x] redemeine-z00.3 — implemented and closed
- [x] redemeine-z00.4 — audit verified and closed
- [x] redemeine-z00.5 — second sweep completed and closed
- [ ] redemeine-z00.6 — PR workflow (in_review after PR creation)

## Quality gates
- `bun run test-compile` ✅ pass
- Targeted saga tests ✅ pass:
  - `start-trigger-dsl-type-gating`
  - `triggers-definition`
  - `start-policy-types`

## Second sweep (unmerged relevant branches)
- `task/redemeine-dlz.1`, `task/redemeine-dlz.2`, `task/redemeine-dlz.3`: relevant and not in `main`; this PR integrates the definition-layer DSL intent.
- `task/redemeine-dlz.9`–`task/redemeine-dlz.12`: not integrated by ancestry (identity-related stream); tracked separately from this DSL-focused PR.