### PR TITLE
fix(workflow): enforce beads-aware worktree setup for subagents

### DIFF
--- a/.opencode/prompts/builder.md
+++ b/.opencode/prompts/builder.md
@@ -19,7 +19,9 @@ Operating model:
 
 Startup routine (every session):
 1. Run `bd dolt pull && bd ready --json`.
-2. When delegating, provide Bead ID(s) explicitly so subagents can start with `bd show <bead-id> --json` and stay within assigned scope.
+2. Run `bd context --json` and verify Beads wiring before any delegation.
+3. If context reports `is_worktree=true` and `is_redirected=false`, stop and repair worktree setup before proceeding.
+4. When delegating, provide Bead ID(s) explicitly so subagents can start with `bd show <bead-id> --json` and stay within assigned scope.
 
 Primary responsibilities:
 - Parse intent: restate scope, constraints, risks, and acceptance signals.
@@ -36,9 +38,12 @@ Epic setup protocol:
 2. Create a Draft PR for the Epic branch and include Epic Bead ID(s).
 3. Keep the Draft PR active as the single progress surface while delegated Beads are completed.
 
+Epic worktree command:
+- `bd worktree create worktrees/<epic-name> --branch feature/<epic-name>`
+
 Delegated task execution protocol:
 1. For each delegated Bead `{id}`, create a child worktree:
-   - `git worktree add ../trees/bead-{id} -b task/{id}`
+   - `bd worktree create worktrees/trees/bead-{id} --branch task/{id}`
 2. Invoke the selected subagent internally from the Builder session (Task/@subagent), and run the delegated work in that child worktree context.
 3. Prefer internal invocation so subagent child sessions remain visible in TUI navigation (`session_child_first`, default `<leader>down`).
 4. Use external spawning (`opencode --agent <agent-role>`) only as fallback when internal invocation is unavailable.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,11 +35,29 @@ Protocol:
 
 ## Issue Tracking with bd (beads)
 
-Run git fetch origin main to get latest from remote Create worktree for new feature: git worktree add worktrees/descriptive-name -b feature/descriptive-name Change to the new worktree: cd worktrees/descriptive-name Run mise trust && mise install to make tools available Run bun install to set up dependencies ONLY THEN start making changes in the isolated worktree Always use turbo to run tasks. Always use Bun instead of node or npm. PR titles must follow conventional commits Worktree Structure brownsauce/ <- Repo root (main branch checkout) ├── .beads/ <- Shared issue database ├── .git/ <- Git directory ├── worktrees/ <- All feature worktrees go here │ ├── feature-name-1/ <- Feature worktree │ └── feature-name-2/ <- Another feature worktree ├── packages/ <- Source code └── ... Worktree Benefits Each feature branch gets its own isolated working directory Never risk contaminating main branch with uncommitted changes Can work on multiple features simultaneously in parallel worktrees Clean separation between repo root and feature development Shared .beads/ database discoverable from all worktrees Before Starting Work ALWAYS use /start command to create proper worktree setup Choose a short worktree name based on the work description (worktrees live in worktrees/ subdirectory) NEVER work directly in repo root for feature development - always use a worktree Verify you're in correct worktree with pwd and git branch Each worktree is a complete working copy with its own node_modules and mise config Beads (bd) Issue Tracking We track work in Beads (bd) instead of Markdown. Beads is a lightweight, git-based issue tracker designed for AI coding agents with dependency-aware task management.
+Use Beads for all issue tracking. For worktrees, always use `bd worktree create` so the worktree is wired to the shared repo `.beads` database.
 
-Critical Setup Notes ALWAYS use bd CLI commands via Bash tool - NEVER use MCP beads tools Daemon is disabled (BEADS_NO_DAEMON=1) for worktree safety - MCP won't work bd auto-discovers the shared .beads/ database from any worktree by walking up the tree The .beads/ directory lives at the repo root and is shared across all feature worktrees Works from repo root or any feature worktree - bd walks up to find the database The "Let's Continue" Protocol Start of every session:
+Setup workflow:
+- `git fetch origin main`
+- `bd worktree create worktrees/<descriptive-name> --branch feature/<descriptive-name>`
+- `cd worktrees/<descriptive-name>`
+- `mise trust && mise install`
+- `bun install`
 
-Check for abandoned work: bd list --status in_progress If none, get ready work: bd ready --limit 5 Show top priority issue: bd show hp-X When user says "Let's continue", run these commands to resume work.
+Before coding in a worktree, verify Beads context:
+- `bd context --json`
+- If `is_worktree=true` and `is_redirected=false`, stop and repair the worktree (it is using an isolated `.beads` and will fail to find the shared DB)
+
+Critical setup notes:
+- ALWAYS use bd CLI commands via Bash tool
+- NEVER use MCP beads tools
+- Daemon is disabled (`BEADS_NO_DAEMON=1`) for worktree safety
+- Shared `.beads` lives at repo root and must be used from all worktrees
+
+"Let's Continue" protocol at session start:
+- `bd list --status in_progress --json`
+- If none, run `bd ready --limit 5 --json`
+- Show top priority issue with `bd show <id> --json`
 
 **IMPORTANT**: This project uses **bd (beads)** for ALL issue tracking. Do NOT use markdown TODOs, task lists, or other tracking methods.
 


### PR DESCRIPTION
## Summary
- Replace manual git worktree add guidance with d worktree create in team workflow docs.
- Add Builder startup guard to require d context --json and stop when a worktree is not redirected to shared .beads.
- Document explicit recovery expectation for is_worktree=true + is_redirected=false so subagents avoid local/phantom Dolt databases.

## Why
Subagents were repeatedly failing to access the Beads database because worktrees were created without Beads redirect wiring, causing isolated local .beads directories and missing edemeine Dolt DB state.