### PR TITLE
feat(runtime): begin epic redemeine-8te saga runtime v1 contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,3 +373,11 @@ Strict Purity: The entire @redemeine/testing suite can be executed on a machine 
 Depot End-to-End: An integration test successfully dispatches a Command, which emits an Event, which updates an in-memory Projection, all within a single createTestDepot instance.
 
 ## Plugins for opentelemetry in runtimes
+
+## Saga Runtime v1 follow-up notes
+
+- Consider replacing local `SagaDefinitionLike` with a shared type boundary from `@redemeine/saga` (for example `Pick<SagaDefinition, ...>`) to reduce drift risk while keeping runtime internals decoupled.
+- Prefer persisting source-event references by default (`eventId`, `type`, `aggregateId`, `sequence`, `correlation`, `causation`, `timestamp`), with an optional redacted payload snapshot only when audit/debug needs justify it.
+- Keep `SagaAggregate` as the authoritative write model, and consider adding a `createMirage`-style DX overlay/facade for bridge ergonomics without allowing invariant bypass.
+- Consider durable per-saga inbound inbox/queue semantics (persist-before-ack, idempotency keys, replay-safe drains) so queued inbound work survives server restarts.
+- Clarify the `referenceAdapters` API boundary by separating stable SPI contracts from in-memory reference implementations and test-harness surfaces.

--- a/docs/architecture/redemeine-b13-scale-validation-report.md
+++ b/docs/architecture/redemeine-b13-scale-validation-report.md
@@ -1,0 +1,39 @@
+# redemeine-b13 Scale Validation Report
+
+## Scenario
+- Seed: 13
+- Horizon: 1440 minutes (24h representative simulation)
+- Base arrivals/minute: 160
+- Scheduler max decisions/minute: 165
+- Target: 200,000 sagas/day
+
+## Throughput envelope
+- Arrived: 235,091
+- Selected (processed): 234,049
+- Projected sagas/day from average throughput: 234,043
+- Final backlog after horizon: 1,042
+- Throughput min/avg/p95/max per minute: 149/162.53/165/165
+- Minutes at or above target rate (138.89 per minute): 1440/1440
+
+## Methodology
+- Model: Deterministic minute-level simulation with carry-over backlog and seeded pseudo-random arrivals
+- Workload: 8-tenant mixed profile, weighted shares, periodic bursts, and recurring global spikes
+- Policy coverage: fairness_weight, tenant_rate_limit, global_capacity_limit, anti_starvation_rotation
+
+## Policy behavior under load
+- Deferred due to tenant rate limits: 875,012
+- Deferred due to global capacity: 118,745
+- Tenants with arrivals but zero selections: none
+- Worst blocked streak: tenant-enterprise-a (0 consecutive minutes with demand but no selection)
+
+## Per-tenant stats
+| Tenant | Arrived | Selected | Deferred (rate-limited) | Deferred (global cap) | Max blocked streak (minutes) |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| tenant-enterprise-a | 71,042 | 71,042 | 1,460 | 11,172 | 0 |
+| tenant-enterprise-b | 51,842 | 51,842 | 0 | 2,443 | 0 |
+| tenant-growth-a | 34,782 | 34,782 | 2,205 | 23,845 | 0 |
+| tenant-growth-b | 26,119 | 26,119 | 13,620 | 62,651 | 0 |
+| tenant-longtail-a | 9,099 | 8,640 | 363,894 | 0 | 0 |
+| tenant-longtail-b | 7,492 | 7,200 | 214,402 | 0 | 0 |
+| tenant-smb-a | 18,828 | 18,592 | 200,168 | 18,634 | 0 |
+| tenant-smb-b | 15,887 | 15,832 | 79,263 | 0 | 0 |

--- a/docs/architecture/redemeine-vpn-adr-traceability-matrix.md
+++ b/docs/architecture/redemeine-vpn-adr-traceability-matrix.md
@@ -1,0 +1,32 @@
+# redemeine-vpn — ADR Traceability Matrix (Saga Runtime v1)
+
+## Purpose
+
+Operational handoff artifact mapping **accepted ADR decisions** in `docs/architecture/decision-log.md` to delivered beads, validation evidence, and explicitly deferred scope for saga runtime v1.
+
+## Source ADRs in scope
+
+1. **ADR: Event-Sourced Process Managers (Sagas)** — Status: Accepted (2026-03-30)
+2. **ADR: Typed-first Testing Pyramid and In-Memory Integration Depot** — Status: Accepted (Epic kickoff, 2026-04-02)
+
+## Traceability matrix
+
+| Accepted ADR decision | Implemented beads (runtime v1 wave) | Validation / evidence references | Deferred scope / explicit non-goals |
+|---|---|---|---|
+| **Event-Sourced Process Managers (Sagas): canonical lifecycle + intent taxonomy, deterministic replay, persisted intent execution** | `redemeine-9dd`, `redemeine-g74`, `redemeine-dtt`, `redemeine-efj`, `redemeine-rvb`, `redemeine-r04`, `redemeine-sfc`, `redemeine-1d7`, `redemeine-c6o`, `redemeine-ckb`, `redemeine-mbi`, `redemeine-u3w` | Bead evidence notes show passing focused suites, including: `bun test ./test/saga-runtime-domain-contracts.test.ts`; `bun test ./test/saga-aggregate-transition-invariants.test.ts`; `bun test ./test/reference-adapters.integration.test.ts`; `bun test ./test/reliability-delivery-modes.integration.test.ts`; `bun test packages/saga-runtime/test/order-workflow-v1.e2e.test.ts`; `bun test ./test/runtime-audit-projections.test.ts`; plus merge evidence in Draft PR #25 / commits cited in bead notes. | `decision-log.md` keeps **Transactional Outbox for Post-Commit Hooks** as TODO/pending ADR. Current short-term policy remains inline post-commit behavior; full outbox worker model is deferred beyond runtime v1 scope. |
+| **Event-Sourced Process Managers (Sagas): pluginized runtime seams and scheduling policy contracts** | `redemeine-c3p`, `redemeine-88r`, `redemeine-p1s`, `redemeine-auj`, `redemeine-tor`, `redemeine-06k`, `redemeine-777`, `redemeine-dsk` | Contract + conformance evidence in bead notes, including: `bun test ./test/runtime-contracts-structure.test.ts`; `bun test ./test/plugin-registry-precedence.test.ts`; `bun test ./test/plugin-spi-conformance-harness.test.ts`; `bun test ./test/scheduler-policy-evaluator.test.ts`; `bun test ./test/reference-adapters.integration.test.ts`. | `redemeine-88r` notes runtime-loaded hot-plugin model remains out of scope for v1 (compile-time registry delivered). |
+| **Typed-first Testing Pyramid + In-Memory Integration Depot: deterministic, typed-first validation strategy** | Runtime v1 evidence-producing beads: `redemeine-dsk`, `redemeine-ckb`, `redemeine-c6o`, `redemeine-b13`, `redemeine-t2v` | Delivered artifacts and checks include: plugin SPI conformance harness (`plugin-spi-conformance-harness.test.ts`), end-to-end workflow validation (`order-workflow-v1.e2e.test.ts`), reliability fault-injection tests (`reliability-delivery-modes.integration.test.ts`), scale report (`docs/architecture/redemeine-b13-scale-validation-report.md`), and runtime contract documentation updates (`docs/reference/sagas-reference.md`). | ADR scope note in `decision-log.md`: **full worker response simulation** is an explicit follow-up slice after v1; raw envelope dispatch retained for boundary/replay/negative-shape tests. |
+
+## Coverage summary
+
+- Accepted ADR decisions traced: **2 / 2** in scope.
+- Runtime v1 implementation beads referenced: **21** (`redemeine-06k`, `1d7`, `777`, `88r`, `9dd`, `auj`, `b13`, `c3p`, `c6o`, `ckb`, `dsk`, `dtt`, `efj`, `g74`, `mbi`, `p1s`, `r04`, `rvb`, `sfc`, `t2v`, `u3w`).
+- Deferred scope explicitly captured from ADRs and bead notes: **3 items**
+  1. Transactional outbox ADR still pending.
+  2. Runtime-loaded hot plugins out of scope for v1.
+  3. Full worker response simulation deferred post-v1.
+
+## Handoff notes
+
+- This matrix is derived from accepted ADR content in `docs/architecture/decision-log.md` and implementation/validation evidence recorded in child bead notes under epic `redemeine-8te`.
+- Intended consumer: Auditor/Diplomat handoff for runtime v1 closure and release traceability.

--- a/docs/reference/sagas-reference.md
+++ b/docs/reference/sagas-reference.md
@@ -383,6 +383,58 @@ In other words, the saga definition emits intents; runtime infrastructure may la
 
 > Out of scope for this reference: runtime worker/executor implementation details (queueing, polling, retries in workers, etc.).
 
+## `createSaga` runtime contracts (v1, implemented)
+
+This section documents the runtime behavior currently implemented in `@redemeine/saga-runtime` for saga definitions built with `createSaga(...)`.
+
+### Delivery contract
+
+- Inbound handler execution is deterministic per saga id when routed through `createSagaInboundRouter(...)` (strict single-flight by default).
+- Outbound side-effect intents (`plugin-one-way`, `plugin-request`, `run-activity`) are persisted as `in_progress` executions before execution and then updated to terminal status (`succeeded` / `failed`) after completion.
+- Side-effect execution in `runReferenceAdapterFlowV1(...)` is concurrent (`Promise.all`) for intents collected in one dispatch turn.
+- The runtime currently does **not** provide an `effectively_once` deduplication guarantee by itself. Treat delivery as at-least-once unless your plugin/persistence layer adds idempotency.
+
+### Ordering contract
+
+- **Inbound ordering:** commands/events for the same saga route in arrival order by default (`resolveSingleFlightKey` defaults to `sagaId`).
+- **Cross-saga concurrency:** different saga ids may process concurrently.
+- **Outbound ordering:** side-effects are launched as parallel fan-out for a dispatch turn; completion order is not guaranteed.
+- **Execution identity continuity:** `createSagaExecutionBridge(...)` allocates monotonic per-saga intent ids (`<sagaId>:intent:<n>`) and reuses those ids for persisted side-effect execution identity, preserving traceability across repeated dispatches.
+
+### Waiting policy contract
+
+Inbound waiting policies are explicit in `createSagaInboundRouter(...)`:
+
+- `arrival_order` (default): no barrier gate, process as each item arrives.
+- `barrier_gated`: requires `coordination.stepId`; waits until `coordination.barrierSize` arrivals for the same step key before releasing.
+
+Validation behavior:
+
+- Using `barrier_gated` without `coordination.stepId` throws: `barrier_gated waiting policy requires coordination.stepId`.
+
+### Plugin touchpoints (runtime integration)
+
+`createSaga` remains definition-first. Runtime integration happens via bridge + adapters:
+
+- `createSagaExecutionBridge(...)`
+  - Resolves matching saga handlers from incoming domain events.
+  - Executes handler turns via `runSagaHandler(...)`.
+  - Captures emitted intents and records lifecycle entries in `SagaAggregate`.
+- `runReferenceAdapterFlowV1(...)`
+  - Routes `schedule` / `cancel-schedule` intents to scheduler adapter.
+  - Routes side-effect intents to side-effects adapter.
+  - Writes execution projection updates through persistence adapter.
+  - Emits counters/events via telemetry adapter.
+
+Adapter/plugin interfaces used by the runtime contract:
+
+- `SagaRuntimePersistencePluginV1`
+- `SagaRuntimeSchedulerPluginV1`
+- `SagaRuntimeSideEffectsPluginV1`
+- `SagaRuntimeTelemetryPluginV1`
+
+For saga authors this means plugin action contracts (`defineOneWay`, `defineRequestResponse`, `defineCustomAction`) stay definition-level, while execution semantics are provided by runtime adapters implementing the interfaces above.
+
 ## Migration summary (breaking)
 
 If you used older/expanded saga docs, migrate as follows:

--- a/packages/saga-runtime/src/SagaAggregate.ts
+++ b/packages/saga-runtime/src/SagaAggregate.ts
@@ -33,9 +33,110 @@ export interface SagaIntentLifecycleRecord {
   intentId: string;
   intentType: string;
   stage: 'created' | 'scheduled' | 'dispatched' | 'acknowledged' | 'failed' | 'cancelled';
+  executionId?: string;
+  retryPolicySnapshot?: IntentExecutionRetryPolicySnapshot | null;
+  responseRef?: IntentExecutionResponseRef | null;
   recordedAt: string;
   error?: string;
   metadata?: Record<string, unknown>;
+}
+
+export interface IntentExecutionRetryPolicySnapshot {
+  maxAttempts?: number;
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+  backoffMultiplier?: number;
+  timeoutMs?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface IntentExecutionResponseRef {
+  responseKey: string;
+  responseId: string;
+  receivedAt?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export type IntentExecutionStatus =
+  | 'created'
+  | 'scheduled'
+  | 'in_progress'
+  | 'succeeded'
+  | 'failed'
+  | 'cancelled'
+  | 'timed_out';
+
+export interface IntentExecution {
+  id: string;
+  sagaId: string;
+  intentId: string;
+  status: IntentExecutionStatus;
+  attempt: number;
+  retryPolicySnapshot: IntentExecutionRetryPolicySnapshot | null;
+  responseRef: IntentExecutionResponseRef | null;
+  createdAt: string;
+  updatedAt: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface IntentExecutionCreateCommandPayload {
+  id: string;
+  sagaId: string;
+  intentId: string;
+  status?: IntentExecutionStatus;
+  attempt?: number;
+  retryPolicySnapshot?: IntentExecutionRetryPolicySnapshot | null;
+  responseRef?: IntentExecutionResponseRef | null;
+  createdAt?: string;
+  updatedAt?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface IntentExecutionRecordAttemptCommandPayload {
+  id: string;
+  attempt: number;
+  status?: IntentExecutionStatus;
+  retryPolicySnapshot?: IntentExecutionRetryPolicySnapshot | null;
+  updatedAt?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface IntentExecutionRecordResponseRefCommandPayload {
+  id: string;
+  responseRef: IntentExecutionResponseRef;
+  status?: IntentExecutionStatus;
+  updatedAt?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface IntentExecutionMarkTerminalCommandPayload {
+  id: string;
+  status: Extract<IntentExecutionStatus, 'succeeded' | 'failed' | 'cancelled' | 'timed_out'>;
+  updatedAt?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface IntentExecutionProjectionRecord {
+  id: string;
+  sagaId: string;
+  intentId: string;
+  status: IntentExecutionStatus;
+  attempt: number;
+  retryPolicySnapshot: IntentExecutionRetryPolicySnapshot | null;
+  responseRef: IntentExecutionResponseRef | null;
+  createdAt: string;
+  updatedAt: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface IntentExecutionProjection {
+  getById(id: string): IntentExecutionProjectionRecord | null;
+  upsert(record: IntentExecutionProjectionRecord): void;
+}
+
+export interface SagaAggregateProjection {
+  getById(id: string): SagaAggregateState | null;
+  upsert(record: SagaAggregateState): void;
 }
 
 export interface SagaActivityLifecycleRecord {
@@ -49,7 +150,7 @@ export interface SagaActivityLifecycleRecord {
 }
 
 export interface SagaAggregateState {
-  sagaId: string | null;
+  id: string | null;
   sagaType: string | null;
   lifecycleState: 'idle' | 'active' | 'completed' | 'failed' | 'cancelled';
   createdAt: string | null;
@@ -70,7 +171,7 @@ export interface SagaAggregateState {
 }
 
 export interface SagaCreateInstanceCommandPayload {
-  sagaId: string;
+  id: string;
   sagaType: string;
   lifecycleState?: SagaAggregateState['lifecycleState'];
   createdAt?: string;
@@ -118,7 +219,7 @@ export interface SagaRecordActivityLifecycleCommandPayload {
 }
 
 export interface SagaInstanceCreatedEventPayload {
-  sagaId: string;
+  id: string;
   sagaType: string;
   lifecycleState: SagaAggregateState['lifecycleState'];
   createdAt: string;
@@ -155,7 +256,7 @@ const defaultRecentWindowLimits: SagaRecentWindowLimits = {
 };
 
 const createInitialState = (): SagaAggregateState => ({
-  sagaId: null,
+  id: null,
   sagaType: null,
   lifecycleState: 'idle',
   createdAt: null,
@@ -232,7 +333,7 @@ export function createSagaAggregate<TAggregateName extends string = 'saga'>(
   const built = createAggregate(aggregateName, initialState)
     .events({
       instanceCreated: (state, event: Event<SagaInstanceCreatedEventPayload>) => {
-        state.sagaId = event.payload.sagaId;
+        state.id = event.payload.id;
         state.sagaType = event.payload.sagaType;
         state.lifecycleState = event.payload.lifecycleState;
         state.createdAt = event.payload.createdAt;
@@ -267,7 +368,7 @@ export function createSagaAggregate<TAggregateName extends string = 'saga'>(
     })
     .commands((emit) => ({
       createInstance: (_state, payload: SagaCreateInstanceCommandPayload) => emit.instanceCreated({
-        sagaId: payload.sagaId,
+        id: payload.id,
         sagaType: payload.sagaType,
         lifecycleState: payload.lifecycleState ?? 'active',
         createdAt: toIso8601(payload.createdAt),

--- a/packages/saga-runtime/src/SagaAggregate.ts
+++ b/packages/saga-runtime/src/SagaAggregate.ts
@@ -242,6 +242,26 @@ export interface SagaActivityLifecycleRecordedEventPayload {
   record: SagaActivityLifecycleRecord;
 }
 
+export type SagaTransitionInvariantCode =
+  | 'saga_instance_not_created'
+  | 'saga_instance_already_created'
+  | 'saga_transition_from_state_mismatch'
+  | 'saga_transition_noop'
+  | 'saga_transition_from_terminal_state';
+
+export class SagaTransitionInvariantError extends Error {
+  readonly code: SagaTransitionInvariantCode;
+
+  readonly details: Record<string, unknown>;
+
+  constructor(code: SagaTransitionInvariantCode, message: string, details: Record<string, unknown> = {}) {
+    super(message);
+    this.name = 'SagaTransitionInvariantError';
+    this.code = code;
+    this.details = details;
+  }
+}
+
 export interface CreateSagaAggregateOptions {
   aggregateName?: string;
   initialState?: Partial<SagaAggregateState>;
@@ -306,6 +326,27 @@ const toIso8601 = (value?: string): string => {
 
 const toSnakeCase = (value: string): string => value.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase();
 
+const isTerminalLifecycleState = (state: string): boolean => state === 'completed' || state === 'failed' || state === 'cancelled';
+
+type SagaInvariantStateView = Readonly<Pick<SagaAggregateState, 'id' | 'lifecycleState' | 'transitionVersion'>>;
+
+const requireCreatedInstance = (state: SagaInvariantStateView, command: string): void => {
+  if (state.id) {
+    return;
+  }
+
+  throw new SagaTransitionInvariantError(
+    'saga_instance_not_created',
+    `${command} rejected: saga instance must be created first`,
+    {
+      command,
+      sagaId: state.id,
+      currentState: state.lifecycleState,
+      transitionVersion: state.transitionVersion
+    }
+  );
+};
+
 export function createSagaAggregate<TAggregateName extends string = 'saga'>(
   options: CreateSagaAggregateOptions & { aggregateName?: TAggregateName } = {}
 ) {
@@ -367,37 +408,113 @@ export function createSagaAggregate<TAggregateName extends string = 'saga'>(
       }
     })
     .commands((emit) => ({
-      createInstance: (_state, payload: SagaCreateInstanceCommandPayload) => emit.instanceCreated({
-        id: payload.id,
-        sagaType: payload.sagaType,
-        lifecycleState: payload.lifecycleState ?? 'active',
-        createdAt: toIso8601(payload.createdAt),
-        metadata: payload.metadata
-      }),
-      observeSourceEvent: (_state, payload: SagaObserveSourceEventCommandPayload) => emit.sourceEventObserved({
+      createInstance: (state, payload: SagaCreateInstanceCommandPayload) => {
+        if (state.id) {
+          throw new SagaTransitionInvariantError(
+            'saga_instance_already_created',
+            'createInstance rejected: saga instance already exists',
+            {
+              command: 'createInstance',
+              sagaId: state.id,
+              currentState: state.lifecycleState,
+              transitionVersion: state.transitionVersion
+            }
+          );
+        }
+
+        return emit.instanceCreated({
+          id: payload.id,
+          sagaType: payload.sagaType,
+          lifecycleState: payload.lifecycleState ?? 'active',
+          createdAt: toIso8601(payload.createdAt),
+          metadata: payload.metadata
+        });
+      },
+      observeSourceEvent: (state, payload: SagaObserveSourceEventCommandPayload) => {
+        requireCreatedInstance(state, 'observeSourceEvent');
+
+        return emit.sourceEventObserved({
         record: {
           ...payload,
           observedAt: toIso8601(payload.observedAt)
         }
-      }),
-      recordStateTransition: (_state, payload: SagaRecordStateTransitionCommandPayload) => emit.stateTransitioned({
-        record: {
-          ...payload,
-          transitionAt: toIso8601(payload.transitionAt)
+      });
+      },
+      recordStateTransition: (state, payload: SagaRecordStateTransitionCommandPayload) => {
+        requireCreatedInstance(state, 'recordStateTransition');
+
+        if (isTerminalLifecycleState(state.lifecycleState)) {
+          throw new SagaTransitionInvariantError(
+            'saga_transition_from_terminal_state',
+            'recordStateTransition rejected: terminal saga state cannot transition',
+            {
+              command: 'recordStateTransition',
+              sagaId: state.id,
+              fromState: payload.fromState,
+              toState: payload.toState,
+              currentState: state.lifecycleState,
+              transitionVersion: state.transitionVersion
+            }
+          );
         }
-      }),
-      recordIntentLifecycle: (_state, payload: SagaRecordIntentLifecycleCommandPayload) => emit.intentLifecycleRecorded({
+
+        if (payload.fromState !== state.lifecycleState) {
+          throw new SagaTransitionInvariantError(
+            'saga_transition_from_state_mismatch',
+            'recordStateTransition rejected: fromState does not match current lifecycle state',
+            {
+              command: 'recordStateTransition',
+              sagaId: state.id,
+              fromState: payload.fromState,
+              toState: payload.toState,
+              currentState: state.lifecycleState,
+              transitionVersion: state.transitionVersion
+            }
+          );
+        }
+
+        if (payload.fromState === payload.toState) {
+          throw new SagaTransitionInvariantError(
+            'saga_transition_noop',
+            'recordStateTransition rejected: fromState and toState must differ',
+            {
+              command: 'recordStateTransition',
+              sagaId: state.id,
+              fromState: payload.fromState,
+              toState: payload.toState,
+              currentState: state.lifecycleState,
+              transitionVersion: state.transitionVersion
+            }
+          );
+        }
+
+        return emit.stateTransitioned({
+          record: {
+            ...payload,
+            transitionAt: toIso8601(payload.transitionAt)
+          }
+        });
+      },
+      recordIntentLifecycle: (state, payload: SagaRecordIntentLifecycleCommandPayload) => {
+        requireCreatedInstance(state, 'recordIntentLifecycle');
+
+        return emit.intentLifecycleRecorded({
         record: {
           ...payload,
           recordedAt: toIso8601(payload.recordedAt)
         }
-      }),
-      recordActivityLifecycle: (_state, payload: SagaRecordActivityLifecycleCommandPayload) => emit.activityLifecycleRecorded({
+      });
+      },
+      recordActivityLifecycle: (state, payload: SagaRecordActivityLifecycleCommandPayload) => {
+        requireCreatedInstance(state, 'recordActivityLifecycle');
+
+        return emit.activityLifecycleRecorded({
         record: {
           ...payload,
           recordedAt: toIso8601(payload.recordedAt)
         }
-      })
+      });
+      }
     }))
     .overrideEventNames({
       instanceCreated: `${aggregateName}.${toSnakeCase('instanceCreated')}.event`,

--- a/packages/saga-runtime/src/inboundRouter.ts
+++ b/packages/saga-runtime/src/inboundRouter.ts
@@ -21,6 +21,14 @@ export interface SagaInboundAggregate<
 export interface SagaInboundRouteInput<TCommand extends SagaInboundCommand = SagaInboundCommand> {
   readonly sagaId: string;
   readonly command: TCommand;
+  readonly coordination?: SagaInboundStepCoordination;
+}
+
+export type SagaStepWaitingPolicy = 'arrival_order' | 'barrier_gated';
+
+export interface SagaInboundStepCoordination {
+  readonly stepId: string;
+  readonly barrierSize?: number;
 }
 
 export interface SagaInboundRouteResult<TState, TEvent extends SagaInboundEvent = SagaInboundEvent> {
@@ -41,8 +49,36 @@ export interface SagaInboundRouterOptions<
   readonly setSagaState?: (sagaId: string, state: TState) => void;
   readonly createInitialSagaState?: (sagaId: string) => TState;
   readonly resolveSingleFlightKey?: (input: SagaInboundRouteInput<TCommand>) => string;
+  readonly resolveWaitingPolicy?: (input: SagaInboundRouteInput<TCommand>) => SagaStepWaitingPolicy;
   readonly beforeProcess?: (input: SagaInboundRouteInput<TCommand>) => Promise<void> | void;
 }
+
+interface BarrierGate {
+  readonly wait: Promise<void>;
+  readonly arrived: number;
+  readonly required: number;
+  readonly release: () => void;
+  readonly released: boolean;
+}
+
+const createBarrierGate = (required: number): BarrierGate => {
+  let released = false;
+  let release!: () => void;
+  const wait = new Promise<void>((resolve) => {
+    release = () => {
+      released = true;
+      resolve();
+    };
+  });
+
+  return {
+    wait,
+    arrived: 0,
+    required,
+    release,
+    released
+  };
+};
 
 /**
  * Deterministic inbound router with strict per-saga single-flight by default.
@@ -71,11 +107,15 @@ export class SagaInboundRouter<
 
   private readonly resolveSingleFlightKey: (input: SagaInboundRouteInput<TCommand>) => string;
 
+  private readonly resolveWaitingPolicy: (input: SagaInboundRouteInput<TCommand>) => SagaStepWaitingPolicy;
+
   private readonly beforeProcess?: (input: SagaInboundRouteInput<TCommand>) => Promise<void> | void;
 
   private inboundSequence = 0;
 
   private readonly sagaSequenceBySaga = new Map<string, number>();
+
+  private readonly barrierByStepKey = new Map<string, BarrierGate>();
 
   constructor(options: SagaInboundRouterOptions<TState, TCommand, TEvent>) {
     this.aggregate = options.aggregate;
@@ -83,6 +123,7 @@ export class SagaInboundRouter<
     this.setSagaState = options.setSagaState;
     this.createInitialSagaState = options.createInitialSagaState ?? (() => this.aggregate.initialState);
     this.resolveSingleFlightKey = options.resolveSingleFlightKey ?? ((input) => input.sagaId);
+    this.resolveWaitingPolicy = options.resolveWaitingPolicy ?? (() => 'arrival_order');
     this.beforeProcess = options.beforeProcess;
   }
 
@@ -92,9 +133,12 @@ export class SagaInboundRouter<
 
   async route(input: SagaInboundRouteInput<TCommand>): Promise<SagaInboundRouteResult<TState, TEvent>> {
     const key = this.resolveSingleFlightKey(input);
+    const waitingPolicy = this.resolveWaitingPolicy(input);
+    const coordinationGate = this.resolveCoordinationGate(input, key, waitingPolicy);
     const previous = this.inFlightByKey.get(key) ?? Promise.resolve();
 
     const run = async (): Promise<SagaInboundRouteResult<TState, TEvent>> => {
+      await coordinationGate;
       await this.beforeProcess?.(input);
 
       const currentState = this.getState(input.sagaId) ?? this.createInitialSagaState(input.sagaId);
@@ -137,6 +181,40 @@ export class SagaInboundRouter<
     task.then(clearIfCurrent, clearIfCurrent);
 
     return task;
+  }
+
+  private resolveCoordinationGate(
+    input: SagaInboundRouteInput<TCommand>,
+    singleFlightKey: string,
+    waitingPolicy: SagaStepWaitingPolicy
+  ): Promise<void> {
+    if (waitingPolicy === 'arrival_order') {
+      return Promise.resolve();
+    }
+
+    const stepId = input.coordination?.stepId;
+    if (!stepId) {
+      throw new Error('barrier_gated waiting policy requires coordination.stepId');
+    }
+
+    const required = Math.max(1, Math.floor(input.coordination?.barrierSize ?? 1));
+    const barrierKey = `${singleFlightKey}::${stepId}`;
+    const current = this.barrierByStepKey.get(barrierKey) ?? createBarrierGate(required);
+    const nextArrived = current.arrived + 1;
+    const next: BarrierGate = {
+      ...current,
+      arrived: nextArrived,
+      required: current.required
+    };
+
+    this.barrierByStepKey.set(barrierKey, next);
+
+    if (nextArrived >= next.required && !next.released) {
+      next.release();
+      this.barrierByStepKey.delete(barrierKey);
+    }
+
+    return next.wait;
   }
 }
 

--- a/packages/saga-runtime/src/inboundRouter.ts
+++ b/packages/saga-runtime/src/inboundRouter.ts
@@ -1,0 +1,149 @@
+export interface SagaInboundCommand<TPayload = unknown, TType extends string = string> {
+  readonly type: TType;
+  readonly payload: TPayload;
+}
+
+export interface SagaInboundEvent<TPayload = unknown, TType extends string = string> {
+  readonly type: TType;
+  readonly payload: TPayload;
+}
+
+export interface SagaInboundAggregate<
+  TState,
+  TCommand extends SagaInboundCommand = SagaInboundCommand,
+  TEvent extends SagaInboundEvent = SagaInboundEvent
+> {
+  readonly initialState: TState;
+  process(state: TState, command: TCommand): TEvent[];
+  apply(state: TState, event: TEvent): TState;
+}
+
+export interface SagaInboundRouteInput<TCommand extends SagaInboundCommand = SagaInboundCommand> {
+  readonly sagaId: string;
+  readonly command: TCommand;
+}
+
+export interface SagaInboundRouteResult<TState, TEvent extends SagaInboundEvent = SagaInboundEvent> {
+  readonly sagaId: string;
+  readonly state: TState;
+  readonly events: readonly TEvent[];
+  readonly inboundSequence: number;
+  readonly sagaSequence: number;
+}
+
+export interface SagaInboundRouterOptions<
+  TState,
+  TCommand extends SagaInboundCommand = SagaInboundCommand,
+  TEvent extends SagaInboundEvent = SagaInboundEvent
+> {
+  readonly aggregate: SagaInboundAggregate<TState, TCommand, TEvent>;
+  readonly getSagaState?: (sagaId: string) => TState | undefined;
+  readonly setSagaState?: (sagaId: string, state: TState) => void;
+  readonly createInitialSagaState?: (sagaId: string) => TState;
+  readonly resolveSingleFlightKey?: (input: SagaInboundRouteInput<TCommand>) => string;
+  readonly beforeProcess?: (input: SagaInboundRouteInput<TCommand>) => Promise<void> | void;
+}
+
+/**
+ * Deterministic inbound router with strict per-saga single-flight by default.
+ *
+ * - Commands for the same saga are serialized in arrival order.
+ * - Commands for different sagas can run concurrently.
+ * - Aggregate invariants are enforced by delegating command execution through
+ *   the supplied aggregate `process/apply` pipeline.
+ */
+export class SagaInboundRouter<
+  TState,
+  TCommand extends SagaInboundCommand = SagaInboundCommand,
+  TEvent extends SagaInboundEvent = SagaInboundEvent
+> {
+  private readonly aggregate: SagaInboundAggregate<TState, TCommand, TEvent>;
+
+  private readonly stateBySaga = new Map<string, TState>();
+
+  private readonly inFlightByKey = new Map<string, Promise<unknown>>();
+
+  private readonly getSagaState?: (sagaId: string) => TState | undefined;
+
+  private readonly setSagaState?: (sagaId: string, state: TState) => void;
+
+  private readonly createInitialSagaState: (sagaId: string) => TState;
+
+  private readonly resolveSingleFlightKey: (input: SagaInboundRouteInput<TCommand>) => string;
+
+  private readonly beforeProcess?: (input: SagaInboundRouteInput<TCommand>) => Promise<void> | void;
+
+  private inboundSequence = 0;
+
+  private readonly sagaSequenceBySaga = new Map<string, number>();
+
+  constructor(options: SagaInboundRouterOptions<TState, TCommand, TEvent>) {
+    this.aggregate = options.aggregate;
+    this.getSagaState = options.getSagaState;
+    this.setSagaState = options.setSagaState;
+    this.createInitialSagaState = options.createInitialSagaState ?? (() => this.aggregate.initialState);
+    this.resolveSingleFlightKey = options.resolveSingleFlightKey ?? ((input) => input.sagaId);
+    this.beforeProcess = options.beforeProcess;
+  }
+
+  getState(sagaId: string): TState | undefined {
+    return this.stateBySaga.get(sagaId) ?? this.getSagaState?.(sagaId);
+  }
+
+  async route(input: SagaInboundRouteInput<TCommand>): Promise<SagaInboundRouteResult<TState, TEvent>> {
+    const key = this.resolveSingleFlightKey(input);
+    const previous = this.inFlightByKey.get(key) ?? Promise.resolve();
+
+    const run = async (): Promise<SagaInboundRouteResult<TState, TEvent>> => {
+      await this.beforeProcess?.(input);
+
+      const currentState = this.getState(input.sagaId) ?? this.createInitialSagaState(input.sagaId);
+      const events = this.aggregate.process(currentState, input.command);
+
+      let nextState = currentState;
+      for (const event of events) {
+        nextState = this.aggregate.apply(nextState, event);
+      }
+
+      this.stateBySaga.set(input.sagaId, nextState);
+      this.setSagaState?.(input.sagaId, nextState);
+
+      this.inboundSequence += 1;
+      const sagaSequence = (this.sagaSequenceBySaga.get(input.sagaId) ?? 0) + 1;
+      this.sagaSequenceBySaga.set(input.sagaId, sagaSequence);
+
+      return {
+        sagaId: input.sagaId,
+        state: nextState,
+        events,
+        inboundSequence: this.inboundSequence,
+        sagaSequence
+      };
+    };
+
+    const task = previous
+      .catch(() => undefined)
+      .then(run);
+
+    const marker = task.then(() => undefined, () => undefined);
+    this.inFlightByKey.set(key, marker);
+
+    const clearIfCurrent = () => {
+      if (this.inFlightByKey.get(key) === marker) {
+        this.inFlightByKey.delete(key);
+      }
+    };
+
+    task.then(clearIfCurrent, clearIfCurrent);
+
+    return task;
+  }
+}
+
+export function createSagaInboundRouter<
+  TState,
+  TCommand extends SagaInboundCommand = SagaInboundCommand,
+  TEvent extends SagaInboundEvent = SagaInboundEvent
+>(options: SagaInboundRouterOptions<TState, TCommand, TEvent>): SagaInboundRouter<TState, TCommand, TEvent> {
+  return new SagaInboundRouter(options);
+}

--- a/packages/saga-runtime/src/index.ts
+++ b/packages/saga-runtime/src/index.ts
@@ -5,3 +5,13 @@ const sagaPackage = require('@redemeine/saga');
 export const createSagaDispatchContext = sagaPackage.createSagaDispatchContext as any;
 export const runSagaHandler = sagaPackage.runSagaHandler as any;
 export * from './createSagaAggregate';
+export type {
+  SagaSchedulerTriggerPolicyContract,
+  SagaTriggerMisfirePolicy,
+  SagaTriggerMisfirePolicyCatchUpAll,
+  SagaTriggerMisfirePolicyCatchUpBounded,
+  SagaTriggerMisfirePolicyLatestOnly,
+  SagaTriggerMisfirePolicySkipUntilNext,
+  SagaTriggerRestartPolicy,
+  SagaTriggerStartContract
+} from '@redemeine/saga';

--- a/packages/saga-runtime/src/index.ts
+++ b/packages/saga-runtime/src/index.ts
@@ -8,6 +8,29 @@ export * from './createSagaAggregate';
 export * from './inboundRouter';
 export * from './referenceAdapters';
 export type {
+  RuntimeAuditActor,
+  RuntimeAuditCategory,
+  RuntimeAuditCursor,
+  RuntimeAuditQuery,
+  RuntimeAuditQueryResult,
+  RuntimeAuditReaderContract,
+  RuntimeAuditRecord,
+  RuntimeAuditReference,
+  RuntimeAuditWriterContract,
+  RuntimeIntentExecutionQuery,
+  RuntimeIntentExecutionQueryResult,
+  RuntimeIntentExecutionReadModel,
+  RuntimeObservabilityReadApiContract,
+  RuntimeReadModelContract,
+  RuntimeReadModelWindowRequest,
+  RuntimeSagaReadModel,
+  RuntimeTelemetryContext,
+  RuntimeTelemetryKind,
+  RuntimeTelemetryLevel,
+  RuntimeTelemetryPublisherContract,
+  RuntimeTelemetryRecord
+} from './runtimeObservabilityContracts';
+export type {
   SagaSchedulerTriggerPolicyContract,
   SagaTriggerMisfirePolicy,
   SagaTriggerMisfirePolicyCatchUpAll,

--- a/packages/saga-runtime/src/index.ts
+++ b/packages/saga-runtime/src/index.ts
@@ -7,6 +7,14 @@ export const runSagaHandler = sagaPackage.runSagaHandler as any;
 export * from './createSagaAggregate';
 export * from './inboundRouter';
 export * from './referenceAdapters';
+export {
+  createRuntimeAuditLifecycleReadModel,
+  type IntentExecutionLifecycleHistoryEntry,
+  type LifecycleHistoryQuery,
+  type LifecycleHistoryQueryResult,
+  type RuntimeAuditLifecycleReadModel,
+  type SagaLifecycleHistoryEntry
+} from './runtimeAuditProjections';
 export type {
   RuntimeAuditActor,
   RuntimeAuditCategory,

--- a/packages/saga-runtime/src/index.ts
+++ b/packages/saga-runtime/src/index.ts
@@ -5,6 +5,7 @@ const sagaPackage = require('@redemeine/saga');
 export const createSagaDispatchContext = sagaPackage.createSagaDispatchContext as any;
 export const runSagaHandler = sagaPackage.runSagaHandler as any;
 export * from './createSagaAggregate';
+export * from './inboundRouter';
 export type {
   SagaSchedulerTriggerPolicyContract,
   SagaTriggerMisfirePolicy,

--- a/packages/saga-runtime/src/index.ts
+++ b/packages/saga-runtime/src/index.ts
@@ -6,6 +6,7 @@ export const createSagaDispatchContext = sagaPackage.createSagaDispatchContext a
 export const runSagaHandler = sagaPackage.runSagaHandler as any;
 export * from './createSagaAggregate';
 export * from './inboundRouter';
+export * from './referenceAdapters';
 export type {
   SagaSchedulerTriggerPolicyContract,
   SagaTriggerMisfirePolicy,

--- a/packages/saga-runtime/src/index.ts
+++ b/packages/saga-runtime/src/index.ts
@@ -7,6 +7,7 @@ export const runSagaHandler = sagaPackage.runSagaHandler as any;
 export * from './createSagaAggregate';
 export * from './inboundRouter';
 export * from './referenceAdapters';
+export * from './schedulerPolicyEvaluator';
 export type {
   RuntimeAuditActor,
   RuntimeAuditCategory,

--- a/packages/saga-runtime/src/index.ts
+++ b/packages/saga-runtime/src/index.ts
@@ -5,6 +5,7 @@ const sagaPackage = require('@redemeine/saga');
 export const createSagaDispatchContext = sagaPackage.createSagaDispatchContext as any;
 export const runSagaHandler = sagaPackage.runSagaHandler as any;
 export * from './createSagaAggregate';
+export * from './sagaExecutionBridge';
 export * from './inboundRouter';
 export * from './referenceAdapters';
 export * from './schedulerPolicyEvaluator';

--- a/packages/saga-runtime/src/referenceAdapters.ts
+++ b/packages/saga-runtime/src/referenceAdapters.ts
@@ -106,6 +106,33 @@ export interface SagaRuntimeScheduledTrigger {
   readonly runAt: string;
   readonly policy?: SagaSchedulerTriggerPolicyContract;
   readonly metadata?: Record<string, unknown>;
+  readonly execution?: SagaRuntimeScheduledTriggerExecution;
+  readonly policyOutcome?: SagaRuntimeSchedulerPolicyOutcome;
+}
+
+export interface SagaRuntimeScheduledTriggerExecution {
+  readonly triggerId: string;
+  readonly ordinal: number;
+  readonly scheduledFor: string;
+}
+
+export interface SagaRuntimeSchedulerPolicyOutcome {
+  readonly drainedAt: string;
+  readonly wasMisfire: boolean;
+  readonly misfireMode: SagaTriggerMisfirePolicy['mode'];
+  readonly dueCount: number;
+  readonly executedCount: number;
+  readonly skippedCount: number;
+  readonly restartMode?: 'graceful' | 'force';
+  readonly restartReason?: string;
+  readonly nextRunAt?: string;
+}
+
+export interface SagaRuntimeSchedulerPolicyOutcomeRecord {
+  readonly triggerId: string;
+  readonly sagaId: string;
+  readonly runAt: string;
+  readonly outcome: SagaRuntimeSchedulerPolicyOutcome;
 }
 
 export interface SagaRuntimeSchedulerPluginV1 {
@@ -113,6 +140,7 @@ export interface SagaRuntimeSchedulerPluginV1 {
   cancel(id: string): boolean;
   listScheduled(): readonly SagaRuntimeScheduledTrigger[];
   drainDue(nowIso: string): readonly SagaRuntimeScheduledTrigger[];
+  listPolicyOutcomes(): readonly SagaRuntimeSchedulerPolicyOutcomeRecord[];
 }
 
 export type SagaRuntimeSideEffectIntent =
@@ -202,6 +230,118 @@ export function createInMemoryPersistencePluginV1(): SagaRuntimePersistencePlugi
 
 export function createInMemorySchedulerPluginV1(): SagaRuntimeSchedulerPluginV1 {
   const scheduled = new Map<string, SagaRuntimeScheduledTrigger>();
+  const policyOutcomes: SagaRuntimeSchedulerPolicyOutcomeRecord[] = [];
+
+  const toFinitePositiveInteger = (value: unknown): number | undefined => {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      return undefined;
+    }
+
+    const normalized = Math.floor(value);
+    return normalized > 0 ? normalized : undefined;
+  };
+
+  const parseTriggerIntervalMs = (trigger: SagaRuntimeScheduledTrigger): number | undefined => {
+    const intervalFromMetadata = trigger.metadata?.['intervalMs'];
+    return toFinitePositiveInteger(intervalFromMetadata);
+  };
+
+  const buildDueOccurrences = (
+    runAtMs: number,
+    nowMs: number,
+    intervalMs: number | undefined
+  ): readonly string[] => {
+    const maxDueCount = typeof intervalMs === 'number'
+      ? Math.floor((nowMs - runAtMs) / intervalMs) + 1
+      : 1;
+
+    const dueCount = Math.max(1, maxDueCount);
+    const due: string[] = [];
+
+    for (let index = 0; index < dueCount; index += 1) {
+      const scheduledForMs = typeof intervalMs === 'number'
+        ? runAtMs + (index * intervalMs)
+        : runAtMs;
+
+      due.push(new Date(scheduledForMs).toISOString());
+    }
+
+    return due;
+  };
+
+  const resolveMisfireExecution = (
+    trigger: SagaRuntimeScheduledTrigger,
+    nowIso: string
+  ): {
+    readonly executions: readonly SagaRuntimeScheduledTrigger[];
+    readonly outcome: SagaRuntimeSchedulerPolicyOutcome;
+  } => {
+    const runAtMs = Date.parse(trigger.runAt);
+    const nowMs = Date.parse(nowIso);
+    const intervalMs = parseTriggerIntervalMs(trigger);
+    const dueOccurrences = buildDueOccurrences(runAtMs, nowMs, intervalMs);
+    const wasMisfire = nowMs > runAtMs;
+    const misfirePolicy = trigger.policy?.misfire;
+    const misfireMode = misfirePolicy?.mode ?? 'latest_only';
+
+    let scheduledForToExecute: readonly string[] = dueOccurrences;
+
+    if (wasMisfire) {
+      if (misfireMode === 'skip_until_next') {
+        scheduledForToExecute = [];
+      } else if (misfireMode === 'latest_only') {
+        scheduledForToExecute = [dueOccurrences[dueOccurrences.length - 1]];
+      } else if (misfireMode === 'catch_up_bounded') {
+        const bounded = toFinitePositiveInteger(
+          misfirePolicy && misfirePolicy.mode === 'catch_up_bounded'
+            ? misfirePolicy.maxCatchUpCount
+            : undefined
+        ) ?? 1;
+        scheduledForToExecute = dueOccurrences.slice(0, bounded);
+      }
+    } else {
+      scheduledForToExecute = [dueOccurrences[0]];
+    }
+
+    const nextRunAt = typeof intervalMs === 'number'
+      ? new Date(runAtMs + (dueOccurrences.length * intervalMs)).toISOString()
+      : undefined;
+
+    const outcome: SagaRuntimeSchedulerPolicyOutcome = {
+      drainedAt: nowIso,
+      wasMisfire,
+      misfireMode,
+      dueCount: dueOccurrences.length,
+      executedCount: scheduledForToExecute.length,
+      skippedCount: dueOccurrences.length - scheduledForToExecute.length,
+      restartMode: trigger.policy?.restart?.mode,
+      restartReason: trigger.policy?.restart?.reason,
+      nextRunAt
+    };
+
+    const executions = scheduledForToExecute.map((scheduledFor, index, list) => {
+      const executionId = list.length > 1
+        ? `${trigger.id}:exec:${index + 1}`
+        : trigger.id;
+
+      return {
+        ...trigger,
+        id: executionId,
+        runAt: scheduledFor,
+        execution: {
+          triggerId: trigger.id,
+          ordinal: index + 1,
+          scheduledFor
+        },
+        policyOutcome: outcome
+      };
+    });
+
+    return {
+      executions,
+      outcome
+    };
+  };
 
   return {
     schedule(trigger) {
@@ -216,13 +356,43 @@ export function createInMemorySchedulerPluginV1(): SagaRuntimeSchedulerPluginV1 
     drainDue(nowIso) {
       const due = Array.from(scheduled.values())
         .filter((trigger) => trigger.runAt <= nowIso)
-        .sort((a, b) => a.runAt.localeCompare(b.runAt));
+        .sort((a, b) => {
+          const runAtCompare = a.runAt.localeCompare(b.runAt);
+          if (runAtCompare !== 0) {
+            return runAtCompare;
+          }
+
+          return a.id.localeCompare(b.id);
+        });
+
+      const drained: SagaRuntimeScheduledTrigger[] = [];
 
       for (const trigger of due) {
-        scheduled.delete(trigger.id);
+        const { executions, outcome } = resolveMisfireExecution(trigger, nowIso);
+
+        policyOutcomes.push({
+          triggerId: trigger.id,
+          sagaId: trigger.sagaId,
+          runAt: trigger.runAt,
+          outcome
+        });
+
+        if (outcome.nextRunAt) {
+          scheduled.set(trigger.id, {
+            ...trigger,
+            runAt: outcome.nextRunAt
+          });
+        } else {
+          scheduled.delete(trigger.id);
+        }
+
+        drained.push(...executions);
       }
 
-      return due;
+      return drained;
+    },
+    listPolicyOutcomes() {
+      return policyOutcomes;
     }
   };
 }

--- a/packages/saga-runtime/src/referenceAdapters.ts
+++ b/packages/saga-runtime/src/referenceAdapters.ts
@@ -1,0 +1,413 @@
+import type {
+  IntentExecutionProjectionRecord,
+  SagaAggregateProjection,
+  SagaAggregateState,
+  IntentExecutionProjection,
+  IntentExecutionStatus,
+  IntentExecutionResponseRef
+} from './SagaAggregate';
+
+export type SagaTriggerMisfirePolicy =
+  | { readonly mode: 'catch_up_all' }
+  | { readonly mode: 'catch_up_bounded'; readonly maxCatchUpCount: number }
+  | { readonly mode: 'latest_only' }
+  | { readonly mode: 'skip_until_next' };
+
+export interface SagaTriggerRestartPolicy {
+  readonly mode?: 'graceful' | 'force';
+  readonly reason?: string;
+}
+
+export interface SagaSchedulerTriggerPolicyContract {
+  readonly restart?: SagaTriggerRestartPolicy;
+  readonly misfire?: SagaTriggerMisfirePolicy;
+}
+
+export interface SagaIntentMetadata {
+  readonly sagaId: string;
+  readonly correlationId: string;
+  readonly causationId: string;
+}
+
+export interface SagaScheduleIntent {
+  readonly type: 'schedule';
+  readonly id: string;
+  readonly delay: number;
+  readonly metadata: SagaIntentMetadata;
+}
+
+export interface SagaCancelScheduleIntent {
+  readonly type: 'cancel-schedule';
+  readonly id: string;
+  readonly metadata: SagaIntentMetadata;
+}
+
+export interface SagaRunActivityIntent<TResult = unknown> {
+  readonly type: 'run-activity';
+  readonly name: string;
+  readonly closure: () => TResult | Promise<TResult>;
+  readonly metadata: SagaIntentMetadata;
+}
+
+export interface SagaPluginOneWayIntent<
+  TPluginKey extends string = string,
+  TActionName extends string = string,
+  TExecutionPayload = unknown
+> {
+  readonly type: 'plugin-one-way';
+  readonly plugin_key: TPluginKey;
+  readonly action_name: TActionName;
+  readonly action_kind: 'void';
+  readonly execution_payload: TExecutionPayload;
+  readonly metadata: SagaIntentMetadata;
+}
+
+export interface SagaPluginRequestIntent<
+  TPluginKey extends string = string,
+  TActionName extends string = string,
+  TExecutionPayload = unknown
+> {
+  readonly type: 'plugin-request';
+  readonly plugin_key: TPluginKey;
+  readonly action_name: TActionName;
+  readonly action_kind: 'request_response';
+  readonly execution_payload: TExecutionPayload;
+  readonly routing_metadata: {
+    readonly response_handler_key: string;
+    readonly error_handler_key: string;
+    readonly handler_data: unknown;
+    readonly retry_handler_key?: string;
+  };
+  readonly metadata: SagaIntentMetadata;
+}
+
+export type SagaIntent =
+  | SagaScheduleIntent
+  | SagaCancelScheduleIntent
+  | SagaRunActivityIntent
+  | SagaPluginOneWayIntent
+  | SagaPluginRequestIntent
+  | {
+    readonly type: 'dispatch';
+    readonly command: string;
+    readonly payload: unknown;
+    readonly metadata: SagaIntentMetadata;
+  };
+
+export interface SagaRuntimePersistencePluginV1 {
+  readonly sagaProjection: SagaAggregateProjection;
+  readonly intentExecutionProjection: IntentExecutionProjection;
+  listIntentExecutionsBySagaId(sagaId: string): readonly IntentExecutionProjectionRecord[];
+}
+
+export interface SagaRuntimeScheduledTrigger {
+  readonly id: string;
+  readonly sagaId: string;
+  readonly runAt: string;
+  readonly policy?: SagaSchedulerTriggerPolicyContract;
+  readonly metadata?: Record<string, unknown>;
+}
+
+export interface SagaRuntimeSchedulerPluginV1 {
+  schedule(trigger: SagaRuntimeScheduledTrigger): void;
+  cancel(id: string): boolean;
+  listScheduled(): readonly SagaRuntimeScheduledTrigger[];
+  drainDue(nowIso: string): readonly SagaRuntimeScheduledTrigger[];
+}
+
+export type SagaRuntimeSideEffectIntent =
+  | SagaPluginOneWayIntent
+  | SagaPluginRequestIntent
+  | SagaRunActivityIntent;
+
+export interface SagaRuntimeSideEffectResult {
+  readonly status: Extract<IntentExecutionStatus, 'succeeded' | 'failed'>;
+  readonly responseRef?: IntentExecutionResponseRef;
+  readonly output?: unknown;
+  readonly error?: string;
+}
+
+export interface SagaRuntimeSideEffectsPluginV1 {
+  execute(intent: SagaRuntimeSideEffectIntent): Promise<SagaRuntimeSideEffectResult>;
+  listHandled(): readonly SagaRuntimeSideEffectIntent[];
+}
+
+export interface SagaRuntimeTelemetryEvent {
+  readonly name: string;
+  readonly tags?: Record<string, string>;
+  readonly at: string;
+}
+
+export interface SagaRuntimeTelemetrySnapshot {
+  readonly counters: Readonly<Record<string, number>>;
+  readonly events: readonly SagaRuntimeTelemetryEvent[];
+}
+
+export interface SagaRuntimeTelemetryPluginV1 {
+  count(metric: string, delta?: number): void;
+  event(name: string, tags?: Record<string, string>): void;
+  snapshot(): SagaRuntimeTelemetrySnapshot;
+}
+
+export interface SagaRuntimeReferenceAdapters {
+  readonly persistence: SagaRuntimePersistencePluginV1;
+  readonly scheduler: SagaRuntimeSchedulerPluginV1;
+  readonly sideEffects: SagaRuntimeSideEffectsPluginV1;
+  readonly telemetry: SagaRuntimeTelemetryPluginV1;
+}
+
+export interface SagaRuntimeReferenceFlowInput {
+  readonly sagaId: string;
+  readonly intents: readonly SagaIntent[];
+  readonly schedulerPolicy?: SagaSchedulerTriggerPolicyContract;
+  readonly nowIso?: string;
+}
+
+export interface SagaRuntimeReferenceFlowResult {
+  readonly processedIntents: number;
+  readonly persistedExecutions: readonly string[];
+  readonly scheduledTriggerIds: readonly string[];
+}
+
+export function createInMemoryPersistencePluginV1(): SagaRuntimePersistencePluginV1 {
+  const sagaState = new Map<string, SagaAggregateState>();
+  const executions = new Map<string, IntentExecutionProjectionRecord>();
+
+  return {
+    sagaProjection: {
+      getById(id) {
+        return sagaState.get(id) ?? null;
+      },
+      upsert(record) {
+        if (!record.id) {
+          return;
+        }
+
+        sagaState.set(record.id, record);
+      }
+    },
+    intentExecutionProjection: {
+      getById(id) {
+        return executions.get(id) ?? null;
+      },
+      upsert(record) {
+        executions.set(record.id, record);
+      }
+    },
+    listIntentExecutionsBySagaId(sagaId) {
+      return Array.from(executions.values()).filter((record) => record.sagaId === sagaId);
+    }
+  };
+}
+
+export function createInMemorySchedulerPluginV1(): SagaRuntimeSchedulerPluginV1 {
+  const scheduled = new Map<string, SagaRuntimeScheduledTrigger>();
+
+  return {
+    schedule(trigger) {
+      scheduled.set(trigger.id, trigger);
+    },
+    cancel(id) {
+      return scheduled.delete(id);
+    },
+    listScheduled() {
+      return Array.from(scheduled.values()).sort((a, b) => a.runAt.localeCompare(b.runAt));
+    },
+    drainDue(nowIso) {
+      const due = Array.from(scheduled.values())
+        .filter((trigger) => trigger.runAt <= nowIso)
+        .sort((a, b) => a.runAt.localeCompare(b.runAt));
+
+      for (const trigger of due) {
+        scheduled.delete(trigger.id);
+      }
+
+      return due;
+    }
+  };
+}
+
+export function createInMemorySideEffectsPluginV1(
+  executeIntent?: (intent: SagaRuntimeSideEffectIntent) => SagaRuntimeSideEffectResult | Promise<SagaRuntimeSideEffectResult>
+): SagaRuntimeSideEffectsPluginV1 {
+  const handled: SagaRuntimeSideEffectIntent[] = [];
+
+  return {
+    async execute(intent) {
+      handled.push(intent);
+
+      if (executeIntent) {
+        return await executeIntent(intent);
+      }
+
+      if (intent.type === 'plugin-request') {
+        return {
+          status: 'succeeded',
+          responseRef: {
+            responseKey: `${intent.plugin_key}.${intent.action_name}`,
+            responseId: `${intent.metadata.correlationId}:${intent.action_name}`,
+            receivedAt: new Date().toISOString()
+          }
+        };
+      }
+
+      if (intent.type === 'run-activity') {
+        return {
+          status: 'succeeded',
+          output: await intent.closure()
+        };
+      }
+
+      return { status: 'succeeded' };
+    },
+    listHandled() {
+      return handled;
+    }
+  };
+}
+
+export function createInMemoryTelemetryPluginV1(): SagaRuntimeTelemetryPluginV1 {
+  const counters = new Map<string, number>();
+  const events: SagaRuntimeTelemetryEvent[] = [];
+
+  return {
+    count(metric, delta = 1) {
+      counters.set(metric, (counters.get(metric) ?? 0) + delta);
+    },
+    event(name, tags) {
+      events.push({
+        name,
+        tags,
+        at: new Date().toISOString()
+      });
+    },
+    snapshot() {
+      return {
+        counters: Object.freeze(Object.fromEntries(counters.entries())),
+        events
+      };
+    }
+  };
+}
+
+export function createReferenceAdaptersV1(): SagaRuntimeReferenceAdapters {
+  return {
+    persistence: createInMemoryPersistencePluginV1(),
+    scheduler: createInMemorySchedulerPluginV1(),
+    sideEffects: createInMemorySideEffectsPluginV1(),
+    telemetry: createInMemoryTelemetryPluginV1()
+  };
+}
+
+const asScheduleIntent = (intent: SagaIntent): SagaScheduleIntent | null => intent.type === 'schedule' ? intent : null;
+const asCancelIntent = (intent: SagaIntent): SagaCancelScheduleIntent | null => intent.type === 'cancel-schedule' ? intent : null;
+
+const asSideEffectIntent = (intent: SagaIntent): SagaRuntimeSideEffectIntent | null => {
+  if (intent.type === 'plugin-one-way' || intent.type === 'plugin-request' || intent.type === 'run-activity') {
+    return intent;
+  }
+
+  return null;
+};
+
+const createExecutionRecord = (
+  executionId: string,
+  sagaId: string,
+  intentId: string,
+  nowIso: string,
+  status: IntentExecutionStatus,
+  responseRef: IntentExecutionResponseRef | null = null
+): IntentExecutionProjectionRecord => ({
+  id: executionId,
+  sagaId,
+  intentId,
+  attempt: 1,
+  status,
+  retryPolicySnapshot: null,
+  responseRef,
+  createdAt: nowIso,
+  updatedAt: nowIso
+});
+
+export async function runReferenceAdapterFlowV1(
+  adapters: SagaRuntimeReferenceAdapters,
+  input: SagaRuntimeReferenceFlowInput
+): Promise<SagaRuntimeReferenceFlowResult> {
+  const persistedExecutionIds: string[] = [];
+  const scheduledTriggerIds: string[] = [];
+  const nowIso = input.nowIso ?? new Date().toISOString();
+
+  for (let index = 0; index < input.intents.length; index += 1) {
+    const intent = input.intents[index];
+    adapters.telemetry.count('saga.intent.received');
+
+    const schedule = asScheduleIntent(intent);
+    if (schedule) {
+      const runAt = new Date(Date.parse(nowIso) + schedule.delay).toISOString();
+      adapters.scheduler.schedule({
+        id: schedule.id,
+        sagaId: input.sagaId,
+        runAt,
+        policy: input.schedulerPolicy,
+        metadata: { correlationId: schedule.metadata.correlationId }
+      });
+      adapters.telemetry.count('saga.intent.scheduled');
+      adapters.telemetry.event('saga.schedule.created', { sagaId: input.sagaId, intentId: schedule.id });
+      scheduledTriggerIds.push(schedule.id);
+      continue;
+    }
+
+    const cancel = asCancelIntent(intent);
+    if (cancel) {
+      adapters.scheduler.cancel(cancel.id);
+      adapters.telemetry.count('saga.intent.cancelled_schedule');
+      adapters.telemetry.event('saga.schedule.cancelled', { sagaId: input.sagaId, intentId: cancel.id });
+      continue;
+    }
+
+    const sideEffectIntent = asSideEffectIntent(intent);
+    if (!sideEffectIntent) {
+      adapters.telemetry.count('saga.intent.skipped');
+      continue;
+    }
+
+    const executionId = `${input.sagaId}:intent:${index + 1}`;
+    const intentId = `${sideEffectIntent.type}:${index + 1}`;
+
+    adapters.persistence.intentExecutionProjection.upsert(
+      createExecutionRecord(executionId, input.sagaId, intentId, nowIso, 'in_progress')
+    );
+
+    const result = await adapters.sideEffects.execute(sideEffectIntent);
+    adapters.persistence.intentExecutionProjection.upsert(
+      createExecutionRecord(
+        executionId,
+        input.sagaId,
+        intentId,
+        new Date().toISOString(),
+        result.status,
+        result.responseRef ?? null
+      )
+    );
+
+    adapters.telemetry.count('saga.intent.executed');
+    adapters.telemetry.count(
+      result.status === 'succeeded'
+        ? 'saga.intent.execution_succeeded'
+        : 'saga.intent.execution_failed'
+    );
+    adapters.telemetry.event('saga.intent.executed', {
+      sagaId: input.sagaId,
+      executionId,
+      status: result.status
+    });
+
+    persistedExecutionIds.push(executionId);
+  }
+
+  return {
+    processedIntents: input.intents.length,
+    persistedExecutions: persistedExecutionIds,
+    scheduledTriggerIds
+  };
+}

--- a/packages/saga-runtime/src/referenceAdapters.ts
+++ b/packages/saga-runtime/src/referenceAdapters.ts
@@ -167,6 +167,15 @@ export interface SagaRuntimeReferenceFlowResult {
   readonly processedIntents: number;
   readonly persistedExecutions: readonly string[];
   readonly scheduledTriggerIds: readonly string[];
+  readonly responseCorrelations: readonly SagaRuntimeResponseCorrelation[];
+}
+
+export interface SagaRuntimeResponseCorrelation {
+  readonly executionId: string;
+  readonly intentId: string;
+  readonly status: Extract<IntentExecutionStatus, 'succeeded' | 'failed'>;
+  readonly responseRef?: IntentExecutionResponseRef;
+  readonly error?: string;
 }
 
 export function createInMemoryPersistencePluginV1(): SagaRuntimePersistencePluginV1 {
@@ -335,7 +344,13 @@ export async function runReferenceAdapterFlowV1(
 ): Promise<SagaRuntimeReferenceFlowResult> {
   const persistedExecutionIds: string[] = [];
   const scheduledTriggerIds: string[] = [];
+  const responseCorrelations: SagaRuntimeResponseCorrelation[] = [];
   const nowIso = input.nowIso ?? new Date().toISOString();
+  const sideEffectExecutions: Array<{
+    executionId: string;
+    intentId: string;
+    intent: SagaRuntimeSideEffectIntent;
+  }> = [];
 
   for (let index = 0; index < input.intents.length; index += 1) {
     const intent = input.intents[index];
@@ -378,12 +393,21 @@ export async function runReferenceAdapterFlowV1(
       createExecutionRecord(executionId, input.sagaId, intentId, nowIso, 'in_progress')
     );
 
-    const result = await adapters.sideEffects.execute(sideEffectIntent);
+    sideEffectExecutions.push({
+      executionId,
+      intentId,
+      intent: sideEffectIntent
+    });
+    persistedExecutionIds.push(executionId);
+  }
+
+  const completed = await Promise.all(sideEffectExecutions.map(async (execution) => {
+    const result = await adapters.sideEffects.execute(execution.intent);
     adapters.persistence.intentExecutionProjection.upsert(
       createExecutionRecord(
-        executionId,
+        execution.executionId,
         input.sagaId,
-        intentId,
+        execution.intentId,
         new Date().toISOString(),
         result.status,
         result.responseRef ?? null
@@ -398,16 +422,25 @@ export async function runReferenceAdapterFlowV1(
     );
     adapters.telemetry.event('saga.intent.executed', {
       sagaId: input.sagaId,
-      executionId,
+      executionId: execution.executionId,
       status: result.status
     });
 
-    persistedExecutionIds.push(executionId);
-  }
+    return {
+      executionId: execution.executionId,
+      intentId: execution.intentId,
+      status: result.status,
+      responseRef: result.responseRef,
+      error: result.error
+    };
+  }));
+
+  responseCorrelations.push(...completed);
 
   return {
     processedIntents: input.intents.length,
     persistedExecutions: persistedExecutionIds,
-    scheduledTriggerIds
+    scheduledTriggerIds,
+    responseCorrelations
   };
 }

--- a/packages/saga-runtime/src/referenceAdapters.ts
+++ b/packages/saga-runtime/src/referenceAdapters.ts
@@ -161,6 +161,15 @@ export interface SagaRuntimeReferenceFlowInput {
   readonly intents: readonly SagaIntent[];
   readonly schedulerPolicy?: SagaSchedulerTriggerPolicyContract;
   readonly nowIso?: string;
+  readonly resolveExecutionIdentity?: (input: {
+    readonly sagaId: string;
+    readonly intent: SagaRuntimeSideEffectIntent;
+    readonly intentIndex: number;
+    readonly sideEffectIndex: number;
+  }) => {
+    readonly executionId: string;
+    readonly intentId: string;
+  };
 }
 
 export interface SagaRuntimeReferenceFlowResult {
@@ -336,6 +345,7 @@ export async function runReferenceAdapterFlowV1(
   const persistedExecutionIds: string[] = [];
   const scheduledTriggerIds: string[] = [];
   const nowIso = input.nowIso ?? new Date().toISOString();
+  let sideEffectIndex = 0;
 
   for (let index = 0; index < input.intents.length; index += 1) {
     const intent = input.intents[index];
@@ -371,8 +381,15 @@ export async function runReferenceAdapterFlowV1(
       continue;
     }
 
-    const executionId = `${input.sagaId}:intent:${index + 1}`;
-    const intentId = `${sideEffectIntent.type}:${index + 1}`;
+    sideEffectIndex += 1;
+    const resolvedIdentity = input.resolveExecutionIdentity?.({
+      sagaId: input.sagaId,
+      intent: sideEffectIntent,
+      intentIndex: index,
+      sideEffectIndex
+    });
+    const executionId = resolvedIdentity?.executionId ?? `${input.sagaId}:intent:${index + 1}`;
+    const intentId = resolvedIdentity?.intentId ?? `${sideEffectIntent.type}:${index + 1}`;
 
     adapters.persistence.intentExecutionProjection.upsert(
       createExecutionRecord(executionId, input.sagaId, intentId, nowIso, 'in_progress')

--- a/packages/saga-runtime/src/runtimeAuditProjections.ts
+++ b/packages/saga-runtime/src/runtimeAuditProjections.ts
@@ -1,0 +1,421 @@
+import type {
+  IntentExecutionProjectionRecord,
+  SagaActivityLifecycleRecord,
+  SagaAggregateState,
+  SagaIntentLifecycleRecord,
+  SagaObservedSourceEventRecord,
+  SagaStateTransitionRecord
+} from './SagaAggregate';
+import type {
+  RuntimeIntentExecutionQuery,
+  RuntimeIntentExecutionQueryResult,
+  RuntimeReadModelContract,
+  RuntimeReadModelWindowRequest,
+  RuntimeSagaReadModel
+} from './runtimeObservabilityContracts';
+
+type SagaLifecycleHistoryKind =
+  | 'source_event_observed'
+  | 'state_transition_recorded'
+  | 'intent_lifecycle_recorded'
+  | 'activity_lifecycle_recorded';
+
+type IntentExecutionLifecycleChangeKind =
+  | 'created'
+  | 'status_changed'
+  | 'attempt_changed'
+  | 'response_ref_recorded'
+  | 'metadata_changed';
+
+export interface SagaLifecycleHistoryEntry {
+  sagaId: string;
+  transitionVersion: number;
+  kind: SagaLifecycleHistoryKind;
+  recordedAt: string;
+  tieBreakerKey: string;
+  record:
+    | SagaObservedSourceEventRecord
+    | SagaStateTransitionRecord
+    | SagaIntentLifecycleRecord
+    | SagaActivityLifecycleRecord;
+}
+
+export interface IntentExecutionLifecycleHistoryEntry {
+  executionId: string;
+  sagaId: string;
+  intentId: string;
+  sequence: number;
+  recordedAt: string;
+  kind: IntentExecutionLifecycleChangeKind;
+  previous: IntentExecutionProjectionRecord | null;
+  current: IntentExecutionProjectionRecord;
+}
+
+export interface LifecycleHistoryQuery {
+  readonly sagaId?: string;
+  readonly executionId?: string;
+  readonly limit?: number;
+  readonly cursor?: string;
+}
+
+export interface LifecycleHistoryQueryResult<TItem> {
+  readonly items: readonly TItem[];
+  readonly nextCursor?: string;
+}
+
+export interface RuntimeAuditLifecycleReadModel extends RuntimeReadModelContract {
+  upsertSaga(record: SagaAggregateState): void;
+  upsertIntentExecution(record: IntentExecutionProjectionRecord): void;
+  querySagaLifecycleHistory(query: LifecycleHistoryQuery & { readonly sagaId: string }): LifecycleHistoryQueryResult<SagaLifecycleHistoryEntry>;
+  queryIntentExecutionLifecycleHistory(query: LifecycleHistoryQuery): LifecycleHistoryQueryResult<IntentExecutionLifecycleHistoryEntry>;
+}
+
+const sagaLifecycleKindRank: Record<SagaLifecycleHistoryKind, number> = {
+  source_event_observed: 0,
+  state_transition_recorded: 1,
+  intent_lifecycle_recorded: 2,
+  activity_lifecycle_recorded: 3
+};
+
+const cloneState = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+const toIso8601 = (value: string): string => {
+  const parsed = new Date(value);
+  if (!Number.isNaN(parsed.getTime())) {
+    return parsed.toISOString();
+  }
+
+  return new Date(0).toISOString();
+};
+
+const normalizeLimit = (limit?: number): number => {
+  if (!Number.isFinite(limit)) {
+    return 50;
+  }
+
+  return Math.max(0, Math.floor(limit!));
+};
+
+const encodeCursor = (index: number): string => `i:${index}`;
+
+const decodeCursor = (cursor?: string): number | null => {
+  if (!cursor) {
+    return null;
+  }
+
+  if (!cursor.startsWith('i:')) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(cursor.slice(2), 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return null;
+  }
+
+  return parsed;
+};
+
+const cloneSagaWithWindow = (record: SagaAggregateState, options?: RuntimeReadModelWindowRequest): RuntimeSagaReadModel => {
+  const view = cloneState(record);
+  if (!options?.recent) {
+    return view;
+  }
+
+  const transitionsLimit = normalizeLimit(options.recent.transitions ?? view.recent.transitions.length);
+  const eventsLimit = normalizeLimit(options.recent.events ?? view.recent.events.length);
+  const intentsLimit = normalizeLimit(options.recent.intents ?? view.recent.intents.length);
+  const activitiesLimit = normalizeLimit(options.recent.activities ?? view.recent.activities.length);
+
+  return {
+    ...view,
+    recent: {
+      transitions: view.recent.transitions.slice(0, transitionsLimit),
+      events: view.recent.events.slice(0, eventsLimit),
+      intents: view.recent.intents.slice(0, intentsLimit),
+      activities: view.recent.activities.slice(0, activitiesLimit)
+    }
+  };
+};
+
+const sortSagaLifecycleHistory = (entries: SagaLifecycleHistoryEntry[]): SagaLifecycleHistoryEntry[] =>
+  [...entries].sort((a, b) => {
+    const atOrder = a.recordedAt.localeCompare(b.recordedAt);
+    if (atOrder !== 0) {
+      return atOrder;
+    }
+
+    const versionOrder = a.transitionVersion - b.transitionVersion;
+    if (versionOrder !== 0) {
+      return versionOrder;
+    }
+
+    const kindOrder = sagaLifecycleKindRank[a.kind] - sagaLifecycleKindRank[b.kind];
+    if (kindOrder !== 0) {
+      return kindOrder;
+    }
+
+    return a.tieBreakerKey.localeCompare(b.tieBreakerKey);
+  });
+
+const sortIntentExecutionHistory = (entries: IntentExecutionLifecycleHistoryEntry[]): IntentExecutionLifecycleHistoryEntry[] =>
+  [...entries].sort((a, b) => {
+    const atOrder = a.recordedAt.localeCompare(b.recordedAt);
+    if (atOrder !== 0) {
+      return atOrder;
+    }
+
+    const executionOrder = a.executionId.localeCompare(b.executionId);
+    if (executionOrder !== 0) {
+      return executionOrder;
+    }
+
+    return a.sequence - b.sequence;
+  });
+
+const toSagaHistoryEntries = (record: SagaAggregateState): SagaLifecycleHistoryEntry[] => {
+  if (!record.id) {
+    return [];
+  }
+
+  const sagaId = record.id;
+  const entries: SagaLifecycleHistoryEntry[] = [];
+
+  for (const eventRecord of record.recent.events) {
+    entries.push({
+      sagaId,
+      transitionVersion: record.transitionVersion,
+      kind: 'source_event_observed',
+      recordedAt: toIso8601(eventRecord.observedAt),
+      tieBreakerKey: `event:${eventRecord.eventId ?? eventRecord.eventType}`,
+      record: cloneState(eventRecord)
+    });
+  }
+
+  for (const transitionRecord of record.recent.transitions) {
+    entries.push({
+      sagaId,
+      transitionVersion: record.transitionVersion,
+      kind: 'state_transition_recorded',
+      recordedAt: toIso8601(transitionRecord.transitionAt),
+      tieBreakerKey: `transition:${transitionRecord.fromState}->${transitionRecord.toState}`,
+      record: cloneState(transitionRecord)
+    });
+  }
+
+  for (const intentRecord of record.recent.intents) {
+    entries.push({
+      sagaId,
+      transitionVersion: record.transitionVersion,
+      kind: 'intent_lifecycle_recorded',
+      recordedAt: toIso8601(intentRecord.recordedAt),
+      tieBreakerKey: `intent:${intentRecord.intentId}:${intentRecord.stage}`,
+      record: cloneState(intentRecord)
+    });
+  }
+
+  for (const activityRecord of record.recent.activities) {
+    entries.push({
+      sagaId,
+      transitionVersion: record.transitionVersion,
+      kind: 'activity_lifecycle_recorded',
+      recordedAt: toIso8601(activityRecord.recordedAt),
+      tieBreakerKey: `activity:${activityRecord.activityId}:${activityRecord.stage}`,
+      record: cloneState(activityRecord)
+    });
+  }
+
+  return sortSagaLifecycleHistory(entries);
+};
+
+const deriveIntentLifecycleEntries = (
+  previous: IntentExecutionProjectionRecord | null,
+  current: IntentExecutionProjectionRecord,
+  sequence: number
+): IntentExecutionLifecycleHistoryEntry[] => {
+  if (!previous) {
+    return [
+      {
+        executionId: current.id,
+        sagaId: current.sagaId,
+        intentId: current.intentId,
+        sequence,
+        recordedAt: toIso8601(current.createdAt),
+        kind: 'created',
+        previous: null,
+        current: cloneState(current)
+      }
+    ];
+  }
+
+  const entries: IntentExecutionLifecycleHistoryEntry[] = [];
+  let localSequence = sequence;
+
+  if (previous.status !== current.status) {
+    entries.push({
+      executionId: current.id,
+      sagaId: current.sagaId,
+      intentId: current.intentId,
+      sequence: localSequence,
+      recordedAt: toIso8601(current.updatedAt),
+      kind: 'status_changed',
+      previous: cloneState(previous),
+      current: cloneState(current)
+    });
+    localSequence += 1;
+  }
+
+  if (previous.attempt !== current.attempt) {
+    entries.push({
+      executionId: current.id,
+      sagaId: current.sagaId,
+      intentId: current.intentId,
+      sequence: localSequence,
+      recordedAt: toIso8601(current.updatedAt),
+      kind: 'attempt_changed',
+      previous: cloneState(previous),
+      current: cloneState(current)
+    });
+    localSequence += 1;
+  }
+
+  if (JSON.stringify(previous.responseRef) !== JSON.stringify(current.responseRef) && current.responseRef) {
+    entries.push({
+      executionId: current.id,
+      sagaId: current.sagaId,
+      intentId: current.intentId,
+      sequence: localSequence,
+      recordedAt: toIso8601(current.updatedAt),
+      kind: 'response_ref_recorded',
+      previous: cloneState(previous),
+      current: cloneState(current)
+    });
+    localSequence += 1;
+  }
+
+  if (JSON.stringify(previous.metadata ?? null) !== JSON.stringify(current.metadata ?? null)) {
+    entries.push({
+      executionId: current.id,
+      sagaId: current.sagaId,
+      intentId: current.intentId,
+      sequence: localSequence,
+      recordedAt: toIso8601(current.updatedAt),
+      kind: 'metadata_changed',
+      previous: cloneState(previous),
+      current: cloneState(current)
+    });
+  }
+
+  return entries;
+};
+
+export function createRuntimeAuditLifecycleReadModel(): RuntimeAuditLifecycleReadModel {
+  const sagas = new Map<string, SagaAggregateState>();
+  const sagaHistory = new Map<string, SagaLifecycleHistoryEntry[]>();
+  const executions = new Map<string, IntentExecutionProjectionRecord>();
+  const executionHistory = new Map<string, IntentExecutionLifecycleHistoryEntry[]>();
+  const executionSequence = new Map<string, number>();
+
+  return {
+    upsertSaga(record) {
+      if (!record.id) {
+        return;
+      }
+
+      const normalized = cloneState(record);
+      sagas.set(record.id, normalized);
+      sagaHistory.set(record.id, toSagaHistoryEntries(normalized));
+    },
+    upsertIntentExecution(record) {
+      const normalized = cloneState(record);
+      const previous = executions.get(record.id) ?? null;
+      executions.set(record.id, normalized);
+
+      const sequence = (executionSequence.get(record.id) ?? 1);
+      const entries = deriveIntentLifecycleEntries(previous, normalized, sequence);
+      if (entries.length === 0) {
+        return;
+      }
+
+      executionSequence.set(record.id, sequence + entries.length);
+      executionHistory.set(record.id, sortIntentExecutionHistory([...(executionHistory.get(record.id) ?? []), ...entries]));
+    },
+    getSagaById(id, options) {
+      const found = sagas.get(id);
+      if (!found) {
+        return null;
+      }
+
+      return cloneSagaWithWindow(found, options);
+    },
+    getIntentExecutionById(id) {
+      const found = executions.get(id);
+      return found ? cloneState(found) : null;
+    },
+    queryIntentExecutions(query: RuntimeIntentExecutionQuery): RuntimeIntentExecutionQueryResult {
+      const filtered = [...executions.values()]
+        .filter((entry) => entry.sagaId === query.sagaId)
+        .filter((entry) => !query.statuses || query.statuses.includes(entry.status))
+        .sort((a, b) => {
+          const updatedAtOrder = b.updatedAt.localeCompare(a.updatedAt);
+          if (updatedAtOrder !== 0) {
+            return updatedAtOrder;
+          }
+
+          return a.id.localeCompare(b.id);
+        });
+
+      const limit = normalizeLimit(query.limit);
+      const start = decodeCursor(query.cursor) ?? 0;
+      const items = filtered.slice(start, start + limit).map((entry) => cloneState(entry));
+      const nextIndex = start + items.length;
+
+      return {
+        items,
+        nextCursor: nextIndex < filtered.length ? encodeCursor(nextIndex) : undefined
+      };
+    },
+    querySagaLifecycleHistory(query) {
+      const entries = sagaHistory.get(query.sagaId) ?? [];
+      const limit = normalizeLimit(query.limit);
+      const start = decodeCursor(query.cursor) ?? 0;
+      const items = entries.slice(start, start + limit).map((entry) => cloneState(entry));
+      const nextIndex = start + items.length;
+
+      return {
+        items,
+        nextCursor: nextIndex < entries.length ? encodeCursor(nextIndex) : undefined
+      };
+    },
+    queryIntentExecutionLifecycleHistory(query) {
+      const candidates = query.executionId
+        ? (executionHistory.get(query.executionId) ?? [])
+        : [...executionHistory.values()].flat();
+
+      const filtered = candidates
+        .filter((entry) => !query.sagaId || entry.sagaId === query.sagaId)
+        .sort((a, b) => {
+          const atOrder = a.recordedAt.localeCompare(b.recordedAt);
+          if (atOrder !== 0) {
+            return atOrder;
+          }
+
+          const executionOrder = a.executionId.localeCompare(b.executionId);
+          if (executionOrder !== 0) {
+            return executionOrder;
+          }
+
+          return a.sequence - b.sequence;
+        });
+
+      const limit = normalizeLimit(query.limit);
+      const start = decodeCursor(query.cursor) ?? 0;
+      const items = filtered.slice(start, start + limit).map((entry) => cloneState(entry));
+      const nextIndex = start + items.length;
+
+      return {
+        items,
+        nextCursor: nextIndex < filtered.length ? encodeCursor(nextIndex) : undefined
+      };
+    }
+  };
+}

--- a/packages/saga-runtime/src/runtimeObservabilityContracts.ts
+++ b/packages/saga-runtime/src/runtimeObservabilityContracts.ts
@@ -1,0 +1,149 @@
+import type {
+  IntentExecutionProjectionRecord,
+  SagaAggregateState,
+  SagaRecentWindowLimits
+} from './SagaAggregate';
+
+export type RuntimeTelemetryLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export type RuntimeTelemetryKind =
+  | 'saga.lifecycle'
+  | 'saga.transition'
+  | 'source_event.observed'
+  | 'intent.lifecycle'
+  | 'intent.execution'
+  | 'activity.lifecycle'
+  | 'scheduler.trigger'
+  | 'scheduler.misfire'
+  | 'dispatch.attempt'
+  | 'dispatch.response'
+  | 'runtime.invariant';
+
+export interface RuntimeTelemetryContext {
+  sagaId?: string;
+  sagaType?: string;
+  intentId?: string;
+  executionId?: string;
+  activityId?: string;
+  triggerKey?: string;
+  correlationId?: string;
+  causationId?: string;
+  tenantId?: string;
+  sequence?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface RuntimeTelemetryRecord {
+  kind: RuntimeTelemetryKind;
+  level: RuntimeTelemetryLevel;
+  occurredAt: string;
+  message?: string;
+  context: RuntimeTelemetryContext;
+  attributes?: Record<string, unknown>;
+}
+
+export interface RuntimeTelemetryPublisherContract {
+  publish(record: RuntimeTelemetryRecord): void | Promise<void>;
+  publishBatch?(records: RuntimeTelemetryRecord[]): void | Promise<void>;
+}
+
+export type RuntimeAuditCategory =
+  | 'command'
+  | 'event'
+  | 'projection'
+  | 'scheduler'
+  | 'invariant'
+  | 'dispatch';
+
+export interface RuntimeAuditActor {
+  type: 'system' | 'user' | 'service';
+  id: string;
+  displayName?: string;
+}
+
+export interface RuntimeAuditReference {
+  type: 'saga' | 'intent_execution' | 'activity' | 'trigger' | 'event' | 'command';
+  id: string;
+  version?: number;
+}
+
+export interface RuntimeAuditRecord {
+  auditId: string;
+  category: RuntimeAuditCategory;
+  action: string;
+  recordedAt: string;
+  sagaId: string;
+  intentExecutionId?: string;
+  correlationId?: string;
+  causationId?: string;
+  actor?: RuntimeAuditActor;
+  before?: unknown;
+  after?: unknown;
+  diff?: Record<string, unknown>;
+  references?: RuntimeAuditReference[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface RuntimeAuditCursor {
+  recordedAt: string;
+  auditId: string;
+}
+
+export interface RuntimeAuditQuery {
+  sagaId?: string;
+  intentExecutionId?: string;
+  categories?: RuntimeAuditCategory[];
+  actions?: string[];
+  fromRecordedAt?: string;
+  toRecordedAt?: string;
+  cursor?: RuntimeAuditCursor;
+  limit?: number;
+}
+
+export interface RuntimeAuditQueryResult {
+  items: RuntimeAuditRecord[];
+  nextCursor?: RuntimeAuditCursor;
+  totalApproximate?: number;
+}
+
+export interface RuntimeAuditWriterContract {
+  append(record: RuntimeAuditRecord): void | Promise<void>;
+  appendBatch?(records: RuntimeAuditRecord[]): void | Promise<void>;
+}
+
+export interface RuntimeAuditReaderContract {
+  query(query: RuntimeAuditQuery): RuntimeAuditQueryResult | Promise<RuntimeAuditQueryResult>;
+  getByAuditId(auditId: string): RuntimeAuditRecord | null | Promise<RuntimeAuditRecord | null>;
+}
+
+export type RuntimeSagaReadModel = SagaAggregateState;
+
+export type RuntimeIntentExecutionReadModel = IntentExecutionProjectionRecord;
+
+export interface RuntimeReadModelWindowRequest {
+  recent?: Partial<SagaRecentWindowLimits>;
+}
+
+export interface RuntimeIntentExecutionQuery {
+  sagaId: string;
+  statuses?: RuntimeIntentExecutionReadModel['status'][];
+  limit?: number;
+  cursor?: string;
+}
+
+export interface RuntimeIntentExecutionQueryResult {
+  items: RuntimeIntentExecutionReadModel[];
+  nextCursor?: string;
+}
+
+export interface RuntimeReadModelContract {
+  getSagaById(id: string, options?: RuntimeReadModelWindowRequest): RuntimeSagaReadModel | null | Promise<RuntimeSagaReadModel | null>;
+  getIntentExecutionById(id: string): RuntimeIntentExecutionReadModel | null | Promise<RuntimeIntentExecutionReadModel | null>;
+  queryIntentExecutions(query: RuntimeIntentExecutionQuery): RuntimeIntentExecutionQueryResult | Promise<RuntimeIntentExecutionQueryResult>;
+}
+
+export interface RuntimeObservabilityReadApiContract {
+  telemetry: RuntimeTelemetryPublisherContract;
+  audit: RuntimeAuditReaderContract & RuntimeAuditWriterContract;
+  readModel: RuntimeReadModelContract;
+}

--- a/packages/saga-runtime/src/sagaExecutionBridge.ts
+++ b/packages/saga-runtime/src/sagaExecutionBridge.ts
@@ -1,0 +1,379 @@
+declare const require: (id: string) => any;
+
+const sagaPackage = require('@redemeine/saga');
+const runSagaHandler = sagaPackage.runSagaHandler as (
+  state: unknown,
+  event: unknown,
+  handler: (...args: unknown[]) => unknown,
+  metadata: SagaIntentMetadata,
+  responseHandlers?: SagaResponseHandlerTokenBindings,
+  plugins?: readonly unknown[]
+) => Promise<{ state: unknown; intents: SagaIntent[] }>;
+import {
+  createReferenceAdaptersV1,
+  runReferenceAdapterFlowV1,
+  type SagaIntent as RuntimeSagaIntent,
+  type SagaRuntimeReferenceAdapters,
+  type SagaRuntimeReferenceFlowResult,
+  type SagaSchedulerTriggerPolicyContract
+} from './referenceAdapters';
+import {
+  createSagaAggregate,
+  type SagaAggregate,
+  type SagaAggregateState
+} from './SagaAggregate';
+
+interface SagaIntentMetadata {
+  readonly sagaId: string;
+  readonly correlationId: string;
+  readonly causationId: string;
+}
+
+type SagaIntent = RuntimeSagaIntent;
+
+export type SagaResponseHandlerTokenBindings = Record<string, { phase: 'response' | 'error' | 'retry' }>;
+
+export interface SagaDefinitionLike<TState> {
+  readonly sagaType: string;
+  readonly initialState: () => TState;
+  readonly responseHandlers: Record<string, unknown>;
+  readonly errorHandlers: Record<string, unknown>;
+  readonly retryHandlers: Record<string, unknown>;
+  readonly handlers: Array<{
+    readonly aggregateType: string;
+    readonly handlers: Record<string, (...args: unknown[]) => unknown>;
+  }>;
+}
+
+export interface SagaBridgeDomainEvent<TPayload = unknown> {
+  readonly type: string;
+  readonly payload: TPayload;
+  readonly aggregateType?: string;
+  readonly aggregateId?: string;
+  readonly sequence?: number;
+  readonly eventId?: string;
+  readonly correlationId?: string;
+  readonly causationId?: string;
+  readonly occurredAt?: string;
+  readonly metadata?: Record<string, unknown>;
+}
+
+export interface SagaExecutionBridgeDispatchInput<TPayload = unknown> {
+  readonly sagaId: string;
+  readonly event: SagaBridgeDomainEvent<TPayload>;
+  readonly sagaType?: string;
+  readonly intentMetadata?: Partial<SagaIntentMetadata>;
+  readonly schedulerPolicy?: SagaSchedulerTriggerPolicyContract;
+  readonly nowIso?: string;
+}
+
+export interface SagaExecutionBridgeDispatchResult<TState> {
+  readonly sagaId: string;
+  readonly handled: boolean;
+  readonly matchedHandlers: readonly string[];
+  readonly intents: readonly SagaIntent[];
+  readonly adapterResults: readonly SagaRuntimeReferenceFlowResult[];
+  readonly sagaState: TState | undefined;
+  readonly aggregateState: SagaAggregateState;
+}
+
+export interface CreateSagaExecutionBridgeOptions<TState> {
+  readonly definition: SagaDefinitionLike<TState>;
+  readonly runtimePlugins?: readonly unknown[];
+  readonly sagaAggregate?: SagaAggregate;
+  readonly adapters?: SagaRuntimeReferenceAdapters;
+  readonly getSagaState?: (sagaId: string) => TState | undefined;
+  readonly setSagaState?: (sagaId: string, state: TState) => void;
+  readonly getAggregateState?: (sagaId: string) => SagaAggregateState | undefined;
+  readonly setAggregateState?: (sagaId: string, state: SagaAggregateState) => void;
+}
+
+type RuntimeSagaHandler<TState> = (
+  state: TState,
+  event: unknown,
+  ctx: unknown
+) => unknown;
+
+type RuntimeHandlerMatch<TState> = {
+  readonly key: string;
+  readonly handler: RuntimeSagaHandler<TState>;
+};
+
+const createTokenBindings = (
+  definition: SagaDefinitionLike<unknown>
+): SagaResponseHandlerTokenBindings => {
+  const bindings: Record<string, { phase: 'response' | 'error' | 'retry' }> = {};
+
+  for (const token of Object.keys(definition.responseHandlers ?? {})) {
+    bindings[token] = { phase: 'response' };
+  }
+
+  for (const token of Object.keys(definition.errorHandlers ?? {})) {
+    bindings[token] = { phase: 'error' };
+  }
+
+  for (const token of Object.keys(definition.retryHandlers ?? {})) {
+    bindings[token] = { phase: 'retry' };
+  }
+
+  return bindings;
+};
+
+const toCamelCase = (value: string): string => value.replace(/_([a-z])/g, (_, letter: string) => letter.toUpperCase());
+
+const resolveAggregateType = (event: SagaBridgeDomainEvent): string | undefined => {
+  if (event.aggregateType) {
+    return event.aggregateType;
+  }
+
+  const [aggregateType] = event.type.split('.');
+  return aggregateType;
+};
+
+const resolveHandlerKeys = (eventType: string, aggregateType?: string): readonly string[] => {
+  const keys = new Set<string>();
+  keys.add(eventType);
+
+  const parts = eventType.split('.');
+  if (parts.length >= 3 && parts[parts.length - 1] === 'event') {
+    const normalized = parts[parts.length - 2] ?? eventType;
+    keys.add(normalized);
+    keys.add(toCamelCase(normalized));
+  }
+
+  if (aggregateType && eventType.startsWith(`${aggregateType}.`) && eventType.endsWith('.event')) {
+    const normalized = eventType.slice(aggregateType.length + 1, -'.event'.length);
+    keys.add(normalized);
+    keys.add(toCamelCase(normalized));
+  }
+
+  return Array.from(keys);
+};
+
+const isSideEffectIntent = (intent: SagaIntent): boolean => (
+  intent.type === 'plugin-one-way'
+  || intent.type === 'plugin-request'
+  || intent.type === 'run-activity'
+);
+
+export function createSagaExecutionBridge<TState>(
+  options: CreateSagaExecutionBridgeOptions<TState>
+): {
+  readonly adapters: SagaRuntimeReferenceAdapters;
+  getSagaState: (sagaId: string) => TState | undefined;
+  getAggregateState: (sagaId: string) => SagaAggregateState;
+  dispatch: (input: SagaExecutionBridgeDispatchInput) => Promise<SagaExecutionBridgeDispatchResult<TState>>;
+} {
+  const sagaAggregate = options.sagaAggregate ?? createSagaAggregate({ aggregateName: 'saga' });
+  const adapters = options.adapters ?? createReferenceAdaptersV1();
+  const tokenBindings = createTokenBindings(options.definition as SagaDefinitionLike<unknown>);
+
+  const sagaStateById = new Map<string, TState>();
+  const aggregateStateById = new Map<string, SagaAggregateState>();
+  const intentSequenceBySaga = new Map<string, number>();
+
+  const getSagaState = (sagaId: string): TState | undefined => sagaStateById.get(sagaId) ?? options.getSagaState?.(sagaId);
+
+  const setSagaState = (sagaId: string, state: TState): void => {
+    sagaStateById.set(sagaId, state);
+    options.setSagaState?.(sagaId, state);
+  };
+
+  const getAggregateState = (sagaId: string): SagaAggregateState => {
+    return aggregateStateById.get(sagaId)
+      ?? options.getAggregateState?.(sagaId)
+      ?? sagaAggregate.initialState;
+  };
+
+  const setAggregateState = (sagaId: string, state: SagaAggregateState): void => {
+    aggregateStateById.set(sagaId, state);
+    options.setAggregateState?.(sagaId, state);
+  };
+
+  const applyAggregateCommand = (sagaId: string, command: { type: string; payload: unknown }): SagaAggregateState => {
+    const currentState = getAggregateState(sagaId);
+    const events = sagaAggregate.process(currentState, command);
+
+    let nextState = currentState;
+    for (const event of events) {
+      nextState = sagaAggregate.apply(nextState, event);
+    }
+
+    setAggregateState(sagaId, nextState);
+    return nextState;
+  };
+
+  const ensureAggregateInstance = (sagaId: string, sagaType: string): SagaAggregateState => {
+    const current = getAggregateState(sagaId);
+    if (current.id) {
+      return current;
+    }
+
+    return applyAggregateCommand(
+      sagaId,
+      sagaAggregate.commandCreators.createInstance({
+        id: sagaId,
+        sagaType,
+        createdAt: new Date().toISOString()
+      })
+    );
+  };
+
+  const nextIntentId = (sagaId: string): string => {
+    const next = (intentSequenceBySaga.get(sagaId) ?? 0) + 1;
+    intentSequenceBySaga.set(sagaId, next);
+    return `${sagaId}:intent:${next}`;
+  };
+
+  const resolveMetadata = (
+    sagaId: string,
+    event: SagaBridgeDomainEvent,
+    override?: Partial<SagaIntentMetadata>
+  ): SagaIntentMetadata => ({
+    sagaId: override?.sagaId ?? sagaId,
+    correlationId: override?.correlationId
+      ?? event.correlationId
+      ?? (typeof event.metadata?.correlationId === 'string' ? event.metadata.correlationId : undefined)
+      ?? `${sagaId}:correlation`,
+    causationId: override?.causationId
+      ?? event.causationId
+      ?? event.eventId
+      ?? (typeof event.metadata?.eventId === 'string' ? event.metadata.eventId : undefined)
+      ?? `${sagaId}:causation`
+  });
+
+  const resolveMatches = (event: SagaBridgeDomainEvent): readonly RuntimeHandlerMatch<TState>[] => {
+    const aggregateType = resolveAggregateType(event);
+    if (!aggregateType) {
+      return [];
+    }
+
+    const candidates = resolveHandlerKeys(event.type, aggregateType);
+    const matches: RuntimeHandlerMatch<TState>[] = [];
+
+    for (const group of options.definition.handlers) {
+      if (group.aggregateType !== aggregateType) {
+        continue;
+      }
+
+      for (const key of candidates) {
+        const handler = group.handlers[key] as RuntimeSagaHandler<TState> | undefined;
+        if (!handler) {
+          continue;
+        }
+
+        matches.push({ key, handler });
+      }
+    }
+
+    return matches;
+  };
+
+  return {
+    adapters,
+    getSagaState,
+    getAggregateState,
+    async dispatch(input): Promise<SagaExecutionBridgeDispatchResult<TState>> {
+      const matches = resolveMatches(input.event);
+      if (matches.length === 0) {
+        return {
+          sagaId: input.sagaId,
+          handled: false,
+          matchedHandlers: [],
+          intents: [],
+          adapterResults: [],
+          sagaState: getSagaState(input.sagaId),
+          aggregateState: getAggregateState(input.sagaId)
+        };
+      }
+
+      const metadata = resolveMetadata(input.sagaId, input.event, input.intentMetadata);
+      ensureAggregateInstance(input.sagaId, input.sagaType ?? options.definition.sagaType);
+
+      applyAggregateCommand(
+        input.sagaId,
+        sagaAggregate.commandCreators.observeSourceEvent({
+          eventType: input.event.type,
+          aggregateType: resolveAggregateType(input.event),
+          aggregateId: input.event.aggregateId,
+          eventId: input.event.eventId,
+          sequence: input.event.sequence,
+          correlationId: metadata.correlationId,
+          causationId: metadata.causationId,
+          observedAt: input.event.occurredAt,
+          payload: input.event.payload,
+          metadata: input.event.metadata
+        })
+      );
+
+      const intents: SagaIntent[] = [];
+      const adapterResults: SagaRuntimeReferenceFlowResult[] = [];
+      let state = getSagaState(input.sagaId) ?? options.definition.initialState();
+
+      for (const match of matches) {
+        const output = await runSagaHandler(
+          state,
+          input.event as any,
+          match.handler as any,
+          metadata,
+          tokenBindings,
+          options.runtimePlugins ?? []
+        );
+
+        state = output.state as TState;
+        setSagaState(input.sagaId, state);
+
+        intents.push(...output.intents);
+
+        const executionIdentityByIntentIndex = new Map<number, { executionId: string; intentId: string }>();
+
+        for (let intentIndex = 0; intentIndex < output.intents.length; intentIndex += 1) {
+          const intent = output.intents[intentIndex];
+          const lifecycleIntentId = nextIntentId(input.sagaId);
+
+          if (isSideEffectIntent(intent)) {
+            executionIdentityByIntentIndex.set(intentIndex, {
+              executionId: lifecycleIntentId,
+              intentId: lifecycleIntentId
+            });
+          }
+
+          applyAggregateCommand(
+            input.sagaId,
+            sagaAggregate.commandCreators.recordIntentLifecycle({
+              intentId: lifecycleIntentId,
+              intentType: intent.type,
+              stage: 'created',
+              recordedAt: new Date().toISOString(),
+              metadata: {
+                handler: match.key,
+                ...(intent.type === 'plugin-one-way' || intent.type === 'plugin-request'
+                  ? { pluginKey: intent.plugin_key, actionName: intent.action_name }
+                  : {})
+              }
+            })
+          );
+        }
+
+        const adapterResult = await runReferenceAdapterFlowV1(adapters, {
+          sagaId: input.sagaId,
+          intents: output.intents,
+          schedulerPolicy: input.schedulerPolicy,
+          nowIso: input.nowIso,
+          resolveExecutionIdentity: ({ intentIndex }) => executionIdentityByIntentIndex.get(intentIndex)
+        });
+        adapterResults.push(adapterResult);
+      }
+
+      return {
+        sagaId: input.sagaId,
+        handled: true,
+        matchedHandlers: matches.map((match) => match.key),
+        intents,
+        adapterResults,
+        sagaState: state,
+        aggregateState: getAggregateState(input.sagaId)
+      };
+    }
+  };
+}

--- a/packages/saga-runtime/src/schedulerPolicyEvaluator.ts
+++ b/packages/saga-runtime/src/schedulerPolicyEvaluator.ts
@@ -52,6 +52,7 @@ interface TenantRuntimeState {
   readonly fairnessWeight: number;
   readonly queue: SchedulerDecisionCandidate[];
   deficit: number;
+  skippedRounds: number;
   remainingRateLimit: number;
   selected: number;
   deferredRateLimited: number;
@@ -104,7 +105,16 @@ const compareCandidateRank = (left: SchedulerDecisionCandidate, right: Scheduler
   return left.sagaId.localeCompare(right.sagaId);
 };
 
-const compareTenantRuntimeState = (left: TenantRuntimeState, right: TenantRuntimeState): number => {
+const compareTenantRuntimeState = (
+  starvationThreshold: number
+) => (left: TenantRuntimeState, right: TenantRuntimeState): number => {
+  const leftStarved = left.skippedRounds >= starvationThreshold;
+  const rightStarved = right.skippedRounds >= starvationThreshold;
+
+  if (leftStarved !== rightStarved) {
+    return leftStarved ? -1 : 1;
+  }
+
   if (left.deficit !== right.deficit) {
     return right.deficit - left.deficit;
   }
@@ -152,6 +162,7 @@ export function evaluateSchedulerPolicy(
       fairnessWeight,
       queue: [],
       deficit: 0,
+      skippedRounds: 0,
       remainingRateLimit: typeof limit === 'number' ? Math.max(0, limit - consumed) : Number.POSITIVE_INFINITY,
       selected: 0,
       deferredRateLimited: 0
@@ -177,19 +188,25 @@ export function evaluateSchedulerPolicy(
       break;
     }
 
+    for (const state of eligible) {
+      state.skippedRounds += 1;
+    }
+
     let totalWeight = 0;
     for (const state of eligible) {
       totalWeight += state.fairnessWeight;
       state.deficit += state.fairnessWeight;
     }
 
-    eligible.sort(compareTenantRuntimeState);
+    const starvationThreshold = Math.max(2, eligible.length * 2);
+    eligible.sort(compareTenantRuntimeState(starvationThreshold));
     const winner = eligible[0];
     const next = winner.queue.shift();
     if (!next) {
       continue;
     }
 
+    winner.skippedRounds = 0;
     winner.remainingRateLimit -= 1;
     winner.selected += 1;
     winner.deficit -= totalWeight;

--- a/packages/saga-runtime/src/schedulerPolicyEvaluator.ts
+++ b/packages/saga-runtime/src/schedulerPolicyEvaluator.ts
@@ -1,0 +1,251 @@
+export interface SchedulerDecisionCandidate {
+  readonly id: string;
+  readonly sagaId: string;
+  readonly tenantId: string;
+  readonly runAt: string;
+  readonly priority: number;
+}
+
+export interface SchedulerTenantRateLimitSnapshot {
+  readonly limit: number;
+  readonly consumed?: number;
+}
+
+export interface SchedulerTenantPolicy {
+  readonly fairnessWeight?: number;
+  readonly rateLimit?: SchedulerTenantRateLimitSnapshot;
+}
+
+export interface SchedulerPolicyEvaluatorInput {
+  readonly candidates: readonly SchedulerDecisionCandidate[];
+  readonly maxDecisions: number;
+  readonly tenantPolicies?: Readonly<Record<string, SchedulerTenantPolicy>>;
+  readonly defaultTenantPolicy?: SchedulerTenantPolicy;
+}
+
+export type SchedulerDeferredReason = 'tenant_rate_limited' | 'global_capacity_exhausted';
+
+export interface SchedulerDecisionSelection {
+  readonly candidate: SchedulerDecisionCandidate;
+  readonly order: number;
+}
+
+export interface SchedulerDecisionDeferred {
+  readonly candidate: SchedulerDecisionCandidate;
+  readonly reason: SchedulerDeferredReason;
+}
+
+export interface SchedulerTenantDecisionSummary {
+  readonly selected: number;
+  readonly deferredRateLimited: number;
+  readonly remainingRateLimit: number;
+}
+
+export interface SchedulerPolicyEvaluationResult {
+  readonly selected: readonly SchedulerDecisionSelection[];
+  readonly deferred: readonly SchedulerDecisionDeferred[];
+  readonly tenantSummary: Readonly<Record<string, SchedulerTenantDecisionSummary>>;
+}
+
+interface TenantRuntimeState {
+  readonly tenantId: string;
+  readonly fairnessWeight: number;
+  readonly queue: SchedulerDecisionCandidate[];
+  deficit: number;
+  remainingRateLimit: number;
+  selected: number;
+  deferredRateLimited: number;
+}
+
+const DEFAULT_FAIRNESS_WEIGHT = 1;
+export const SCHEDULER_UNLIMITED_REMAINING_RATE_LIMIT = -1;
+
+const normalizePositiveInteger = (value: number | undefined, fallback: number): number => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return fallback;
+  }
+
+  const normalized = Math.floor(value);
+  return normalized > 0 ? normalized : fallback;
+};
+
+const normalizeNonNegativeInteger = (value: number | undefined, fallback: number): number => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return fallback;
+  }
+
+  const normalized = Math.floor(value);
+  return normalized >= 0 ? normalized : fallback;
+};
+
+const normalizeOptionalNonNegativeInteger = (value: number | undefined): number | undefined => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return undefined;
+  }
+
+  return Math.max(0, Math.floor(value));
+};
+
+const compareCandidateRank = (left: SchedulerDecisionCandidate, right: SchedulerDecisionCandidate): number => {
+  if (left.priority !== right.priority) {
+    return right.priority - left.priority;
+  }
+
+  const runAtCompare = left.runAt.localeCompare(right.runAt);
+  if (runAtCompare !== 0) {
+    return runAtCompare;
+  }
+
+  const idCompare = left.id.localeCompare(right.id);
+  if (idCompare !== 0) {
+    return idCompare;
+  }
+
+  return left.sagaId.localeCompare(right.sagaId);
+};
+
+const compareTenantRuntimeState = (left: TenantRuntimeState, right: TenantRuntimeState): number => {
+  if (left.deficit !== right.deficit) {
+    return right.deficit - left.deficit;
+  }
+
+  const leftTop = left.queue[0];
+  const rightTop = right.queue[0];
+
+  if (leftTop && rightTop) {
+    const topCompare = compareCandidateRank(leftTop, rightTop);
+    if (topCompare !== 0) {
+      return topCompare;
+    }
+  }
+
+  return left.tenantId.localeCompare(right.tenantId);
+};
+
+export function evaluateSchedulerPolicy(
+  input: SchedulerPolicyEvaluatorInput
+): SchedulerPolicyEvaluationResult {
+  const maxDecisions = normalizeNonNegativeInteger(input.maxDecisions, 0);
+
+  const tenantStateById = new Map<string, TenantRuntimeState>();
+
+  for (const candidate of input.candidates) {
+    const policy = input.tenantPolicies?.[candidate.tenantId];
+    const fallbackPolicy = input.defaultTenantPolicy;
+
+    const fairnessWeight = normalizePositiveInteger(
+      policy?.fairnessWeight ?? fallbackPolicy?.fairnessWeight,
+      DEFAULT_FAIRNESS_WEIGHT
+    );
+
+    const limit = normalizeOptionalNonNegativeInteger(
+      policy?.rateLimit?.limit ?? fallbackPolicy?.rateLimit?.limit
+    );
+
+    const consumed = normalizeNonNegativeInteger(
+      policy?.rateLimit?.consumed ?? fallbackPolicy?.rateLimit?.consumed,
+      0
+    );
+
+    const runtimeState = tenantStateById.get(candidate.tenantId) ?? {
+      tenantId: candidate.tenantId,
+      fairnessWeight,
+      queue: [],
+      deficit: 0,
+      remainingRateLimit: typeof limit === 'number' ? Math.max(0, limit - consumed) : Number.POSITIVE_INFINITY,
+      selected: 0,
+      deferredRateLimited: 0
+    };
+
+    runtimeState.queue.push(candidate);
+    tenantStateById.set(candidate.tenantId, runtimeState);
+  }
+
+  for (const state of tenantStateById.values()) {
+    state.queue.sort(compareCandidateRank);
+  }
+
+  const selected: SchedulerDecisionSelection[] = [];
+  const deferred: SchedulerDecisionDeferred[] = [];
+
+  while (selected.length < maxDecisions) {
+    const eligible = Array.from(tenantStateById.values()).filter(
+      (state) => state.queue.length > 0 && state.remainingRateLimit > 0
+    );
+
+    if (eligible.length === 0) {
+      break;
+    }
+
+    let totalWeight = 0;
+    for (const state of eligible) {
+      totalWeight += state.fairnessWeight;
+      state.deficit += state.fairnessWeight;
+    }
+
+    eligible.sort(compareTenantRuntimeState);
+    const winner = eligible[0];
+    const next = winner.queue.shift();
+    if (!next) {
+      continue;
+    }
+
+    winner.remainingRateLimit -= 1;
+    winner.selected += 1;
+    winner.deficit -= totalWeight;
+
+    selected.push({
+      candidate: next,
+      order: selected.length + 1
+    });
+  }
+
+  for (const state of tenantStateById.values()) {
+    const reason: SchedulerDeferredReason = state.remainingRateLimit <= 0
+      ? 'tenant_rate_limited'
+      : 'global_capacity_exhausted';
+
+    for (const candidate of state.queue) {
+      if (reason === 'tenant_rate_limited') {
+        state.deferredRateLimited += 1;
+      }
+
+      deferred.push({
+        candidate,
+        reason
+      });
+    }
+  }
+
+  deferred.sort((left, right) => {
+    const tenantCompare = left.candidate.tenantId.localeCompare(right.candidate.tenantId);
+    if (tenantCompare !== 0) {
+      return tenantCompare;
+    }
+
+    const candidateCompare = compareCandidateRank(left.candidate, right.candidate);
+    if (candidateCompare !== 0) {
+      return candidateCompare;
+    }
+
+    return left.reason.localeCompare(right.reason);
+  });
+
+  const tenantSummary = Object.fromEntries(
+    Array.from(tenantStateById.values())
+      .sort((left, right) => left.tenantId.localeCompare(right.tenantId))
+      .map((state) => [state.tenantId, {
+        selected: state.selected,
+        deferredRateLimited: state.deferredRateLimited,
+        remainingRateLimit: Number.isFinite(state.remainingRateLimit)
+          ? state.remainingRateLimit
+          : SCHEDULER_UNLIMITED_REMAINING_RATE_LIMIT
+      }])
+  );
+
+  return {
+    selected,
+    deferred,
+    tenantSummary
+  };
+}

--- a/packages/saga-runtime/test/fixtures/order-workflow-v1.fixture.ts
+++ b/packages/saga-runtime/test/fixtures/order-workflow-v1.fixture.ts
@@ -1,0 +1,236 @@
+declare const require: (id: string) => any;
+
+const sagaPackage = require('@redemeine/saga');
+
+const {
+  createSaga,
+  defineOneWay,
+  defineRequestResponse,
+  defineSagaPlugin
+} = sagaPackage as {
+  createSaga: <TState = unknown>(options: Record<string, unknown>) => any;
+  defineOneWay: <TBuild extends (...args: any[]) => unknown>(build: TBuild) => unknown;
+  defineRequestResponse: <TBuild extends (...args: any[]) => unknown>(build: TBuild) => unknown;
+  defineSagaPlugin: (manifest: Record<string, unknown>) => unknown;
+};
+
+export interface OrderWorkflowState {
+  progression: string[];
+  lastOrderId: string;
+}
+
+export interface OrderWorkflowScenario {
+  name: string;
+  sagaId: string;
+  expectedProgression: string[];
+  events: Array<{
+    type: string;
+    payload: Record<string, unknown>;
+    expectedIntentTypes: string[];
+  }>;
+}
+
+export const PaymentsPlugin = defineSagaPlugin({
+  plugin_key: 'payments',
+  actions: {
+    authorize: defineRequestResponse((payload: { orderId: string; amount: number }) => payload)
+  }
+});
+
+export const InventoryPlugin = defineSagaPlugin({
+  plugin_key: 'inventory',
+  actions: {
+    reserve: defineRequestResponse((payload: { orderId: string; sku: string; quantity: number }) => payload)
+  }
+});
+
+export const ShippingPlugin = defineSagaPlugin({
+  plugin_key: 'shipping',
+  actions: {
+    dispatch: defineOneWay((payload: { orderId: string; carrier: string }) => payload)
+  }
+});
+
+export const NotificationPlugin = defineSagaPlugin({
+  plugin_key: 'notifications',
+  actions: {
+    send: defineOneWay((payload: { orderId: string; template: string }) => payload)
+  }
+});
+
+export const createOrderWorkflowSaga = () => createSaga<OrderWorkflowState>({
+  identity: {
+    namespace: 'runtime',
+    name: 'order_workflow_v1',
+    version: 1
+  },
+  plugins: [PaymentsPlugin, InventoryPlugin, ShippingPlugin, NotificationPlugin] as const
+})
+  .initialState(() => ({ progression: [], lastOrderId: '' }))
+  .onResponses({
+    'payments.authorize.ok': () => undefined,
+    'inventory.reserve.ok': () => undefined
+  })
+  .onErrors({
+    'payments.authorize.failed': () => undefined,
+    'inventory.reserve.failed': () => undefined
+  })
+  .on({ __aggregateType: 'orders', pure: { eventProjectors: {} }, commandCreators: {} } as const, {
+    placed: (state: OrderWorkflowState, event: { payload: { orderId: string; amount: number; sku: string; quantity: number } }, ctx: any) => {
+      ctx.actions.inventory
+        .reserve({
+          orderId: event.payload.orderId,
+          sku: event.payload.sku,
+          quantity: event.payload.quantity
+        })
+        .onResponse(ctx.onResponse['inventory.reserve.ok'])
+        .onError(ctx.onError['inventory.reserve.failed']);
+
+      ctx.actions.payments
+        .authorize({ orderId: event.payload.orderId, amount: event.payload.amount })
+        .onResponse(ctx.onResponse['payments.authorize.ok'])
+        .onError(ctx.onError['payments.authorize.failed']);
+
+      state.progression.push('placed');
+      state.lastOrderId = event.payload.orderId;
+    },
+    authorized: (state: OrderWorkflowState, event: { payload: { orderId: string } }, ctx: any) => {
+      ctx.actions.core.runActivity('order.audit.prepare', () => ({
+        orderId: event.payload.orderId,
+        stage: 'authorized'
+      }));
+
+      ctx.actions.shipping.dispatch({
+        orderId: event.payload.orderId,
+        carrier: 'dhl'
+      });
+
+      state.progression.push('authorized');
+      state.lastOrderId = event.payload.orderId;
+    },
+    packed: (state: OrderWorkflowState, event: { payload: { orderId: string } }, ctx: any) => {
+      ctx.actions.core.schedule('delivery-followup', 60_000);
+      ctx.actions.notifications.send({ orderId: event.payload.orderId, template: 'packed' });
+
+      state.progression.push('packed');
+      state.lastOrderId = event.payload.orderId;
+    },
+    dispatched: (state: OrderWorkflowState, event: { payload: { orderId: string } }, ctx: any) => {
+      ctx.actions.notifications.send({ orderId: event.payload.orderId, template: 'dispatched' });
+
+      state.progression.push('dispatched');
+      state.lastOrderId = event.payload.orderId;
+    },
+    delivered: (state: OrderWorkflowState, event: { payload: { orderId: string } }, ctx: any) => {
+      ctx.actions.core.cancelSchedule('delivery-followup');
+      ctx.actions.notifications.send({ orderId: event.payload.orderId, template: 'delivered' });
+
+      state.progression.push('delivered');
+      state.lastOrderId = event.payload.orderId;
+    },
+    settled: (state: OrderWorkflowState, event: { payload: { orderId: string } }, ctx: any) => {
+      ctx.actions.core.runActivity('order.audit.finalize', () => ({
+        orderId: event.payload.orderId,
+        stage: 'settled'
+      }));
+
+      state.progression.push('settled');
+      state.lastOrderId = event.payload.orderId;
+    },
+    closed: (state: OrderWorkflowState, event: { payload: { orderId: string } }, ctx: any) => {
+      ctx.actions.notifications.send({ orderId: event.payload.orderId, template: 'closed' });
+
+      state.progression.push('closed');
+      state.lastOrderId = event.payload.orderId;
+    }
+  })
+  .build();
+
+export const orderWorkflowScenarios: readonly OrderWorkflowScenario[] = [
+  {
+    name: 'minimal 2-step checkout to authorization',
+    sagaId: 'order-workflow-2-step',
+    expectedProgression: ['placed', 'authorized'],
+    events: [
+      {
+        type: 'orders.placed.event',
+        payload: { orderId: 'order-2', amount: 4900, sku: 'sku-2', quantity: 1 },
+        expectedIntentTypes: ['plugin-request', 'plugin-request']
+      },
+      {
+        type: 'orders.authorized.event',
+        payload: { orderId: 'order-2' },
+        expectedIntentTypes: ['run-activity', 'plugin-one-way']
+      }
+    ]
+  },
+  {
+    name: 'mid-path 4-step fulfillment',
+    sagaId: 'order-workflow-4-step',
+    expectedProgression: ['placed', 'authorized', 'packed', 'dispatched'],
+    events: [
+      {
+        type: 'orders.placed.event',
+        payload: { orderId: 'order-4', amount: 8900, sku: 'sku-4', quantity: 2 },
+        expectedIntentTypes: ['plugin-request', 'plugin-request']
+      },
+      {
+        type: 'orders.authorized.event',
+        payload: { orderId: 'order-4' },
+        expectedIntentTypes: ['run-activity', 'plugin-one-way']
+      },
+      {
+        type: 'orders.packed.event',
+        payload: { orderId: 'order-4' },
+        expectedIntentTypes: ['schedule', 'plugin-one-way']
+      },
+      {
+        type: 'orders.dispatched.event',
+        payload: { orderId: 'order-4' },
+        expectedIntentTypes: ['plugin-one-way']
+      }
+    ]
+  },
+  {
+    name: 'extended 7-step order-to-close workflow',
+    sagaId: 'order-workflow-7-step',
+    expectedProgression: ['placed', 'authorized', 'packed', 'dispatched', 'delivered', 'settled', 'closed'],
+    events: [
+      {
+        type: 'orders.placed.event',
+        payload: { orderId: 'order-7', amount: 12900, sku: 'sku-7', quantity: 3 },
+        expectedIntentTypes: ['plugin-request', 'plugin-request']
+      },
+      {
+        type: 'orders.authorized.event',
+        payload: { orderId: 'order-7' },
+        expectedIntentTypes: ['run-activity', 'plugin-one-way']
+      },
+      {
+        type: 'orders.packed.event',
+        payload: { orderId: 'order-7' },
+        expectedIntentTypes: ['schedule', 'plugin-one-way']
+      },
+      {
+        type: 'orders.dispatched.event',
+        payload: { orderId: 'order-7' },
+        expectedIntentTypes: ['plugin-one-way']
+      },
+      {
+        type: 'orders.delivered.event',
+        payload: { orderId: 'order-7' },
+        expectedIntentTypes: ['cancel-schedule', 'plugin-one-way']
+      },
+      {
+        type: 'orders.settled.event',
+        payload: { orderId: 'order-7' },
+        expectedIntentTypes: ['run-activity']
+      },
+      {
+        type: 'orders.closed.event',
+        payload: { orderId: 'order-7' },
+        expectedIntentTypes: ['plugin-one-way']
+      }
+    ]
+  }
+];

--- a/packages/saga-runtime/test/inbound-router.test.ts
+++ b/packages/saga-runtime/test/inbound-router.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  createSagaAggregate,
+  createSagaInboundRouter,
+  SagaTransitionInvariantError,
+  type SagaAggregateState
+} from '../src';
+
+const isoAt = (secondsOffset: number) => new Date(Date.UTC(2026, 0, 1, 0, 0, secondsOffset)).toISOString();
+
+const createDeferred = () => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+
+  return { promise, resolve };
+};
+
+describe('saga inbound router', () => {
+  it('serializes inbound processing per saga in deterministic arrival order', async () => {
+    const aggregate = createSagaAggregate({ aggregateName: 'saga' });
+    const gate = createDeferred();
+    const observedOrder: string[] = [];
+
+    const router = createSagaInboundRouter({
+      aggregate,
+      beforeProcess: async (input) => {
+        observedOrder.push(`start:${input.command.type}`);
+        if (input.command.type === 'saga.create_instance.command') {
+          await gate.promise;
+        }
+        observedOrder.push(`end:${input.command.type}`);
+      }
+    });
+
+    const sagaId = 'saga-serial-1';
+
+    const createPromise = router.route({
+      sagaId,
+      command: aggregate.commandCreators.createInstance({
+        id: sagaId,
+        sagaType: 'shipping',
+        createdAt: isoAt(1)
+      })
+    });
+
+    const observePromise = router.route({
+      sagaId,
+      command: aggregate.commandCreators.observeSourceEvent({
+        eventType: 'order.created.event',
+        observedAt: isoAt(2)
+      })
+    });
+
+    const transitionPromise = router.route({
+      sagaId,
+      command: aggregate.commandCreators.recordStateTransition({
+        fromState: 'active',
+        toState: 'completed',
+        transitionAt: isoAt(3)
+      })
+    });
+
+    gate.resolve();
+
+    const [createResult, observeResult, transitionResult] = await Promise.all([
+      createPromise,
+      observePromise,
+      transitionPromise
+    ]);
+
+    expect(observedOrder).toEqual([
+      'start:saga.create_instance.command',
+      'end:saga.create_instance.command',
+      'start:saga.observe_source_event.command',
+      'end:saga.observe_source_event.command',
+      'start:saga.record_state_transition.command',
+      'end:saga.record_state_transition.command'
+    ]);
+
+    expect(createResult.sagaSequence).toBe(1);
+    expect(observeResult.sagaSequence).toBe(2);
+    expect(transitionResult.sagaSequence).toBe(3);
+    expect([createResult.inboundSequence, observeResult.inboundSequence, transitionResult.inboundSequence]).toEqual([1, 2, 3]);
+
+    const finalState = router.getState(sagaId) as SagaAggregateState;
+    expect(finalState.lifecycleState).toBe('completed');
+    expect(finalState.transitionVersion).toBe(3);
+    expect(finalState.totals.observedEvents).toBe(1);
+    expect(finalState.totals.transitions).toBe(1);
+  });
+
+  it('keeps strict single-flight scoped per saga id by default', async () => {
+    const aggregate = createSagaAggregate({ aggregateName: 'saga' });
+    const gate = createDeferred();
+    const starts: string[] = [];
+
+    const router = createSagaInboundRouter({
+      aggregate,
+      beforeProcess: async (input) => {
+        starts.push(`${input.sagaId}:${input.command.type}`);
+        if (input.sagaId === 'saga-a') {
+          await gate.promise;
+        }
+      }
+    });
+
+    const sagaA = router.route({
+      sagaId: 'saga-a',
+      command: aggregate.commandCreators.createInstance({ id: 'saga-a', sagaType: 'shipping', createdAt: isoAt(1) })
+    });
+
+    const sagaB = router.route({
+      sagaId: 'saga-b',
+      command: aggregate.commandCreators.createInstance({ id: 'saga-b', sagaType: 'shipping', createdAt: isoAt(2) })
+    });
+
+    const sagaBResult = await sagaB;
+    expect(sagaBResult.sagaId).toBe('saga-b');
+    expect(starts).toContain('saga-b:saga.create_instance.command');
+
+    gate.resolve();
+    await sagaA;
+  });
+
+  it('propagates SagaAggregate invariant rejections through serialized routing', async () => {
+    const aggregate = createSagaAggregate({ aggregateName: 'saga' });
+    const router = createSagaInboundRouter({ aggregate });
+    const sagaId = 'saga-invariant-1';
+
+    await router.route({
+      sagaId,
+      command: aggregate.commandCreators.createInstance({ id: sagaId, sagaType: 'shipping', createdAt: isoAt(1) })
+    });
+
+    const duplicateCreate = router.route({
+      sagaId,
+      command: aggregate.commandCreators.createInstance({ id: sagaId, sagaType: 'shipping', createdAt: isoAt(2) })
+    });
+
+    try {
+      await duplicateCreate;
+      throw new Error('expected duplicate create to reject');
+    } catch (error) {
+      expect(error).toBeInstanceOf(SagaTransitionInvariantError);
+      expect(error).toMatchObject({
+        code: 'saga_instance_already_created',
+        details: {
+          command: 'createInstance',
+          sagaId
+        }
+      });
+    }
+  });
+});

--- a/packages/saga-runtime/test/inbound-router.test.ts
+++ b/packages/saga-runtime/test/inbound-router.test.ts
@@ -124,6 +124,94 @@ describe('saga inbound router', () => {
     await sagaA;
   });
 
+  it('supports configurable arrival_order waiting policy', async () => {
+    const aggregate = createSagaAggregate({ aggregateName: 'saga' });
+    const observedOrder: string[] = [];
+
+    const router = createSagaInboundRouter({
+      aggregate,
+      resolveWaitingPolicy: () => 'arrival_order',
+      beforeProcess: (input) => {
+        observedOrder.push(input.command.type);
+      }
+    });
+
+    const sagaId = 'saga-arrival-order-1';
+    const createResult = await router.route({
+      sagaId,
+      command: aggregate.commandCreators.createInstance({ id: sagaId, sagaType: 'shipping', createdAt: isoAt(1) }),
+      coordination: { stepId: 'fan-in', barrierSize: 2 }
+    });
+
+    const observeResult = await router.route({
+      sagaId,
+      command: aggregate.commandCreators.observeSourceEvent({ eventType: 'order.created.event', observedAt: isoAt(2) }),
+      coordination: { stepId: 'fan-in', barrierSize: 2 }
+    });
+
+    expect(observedOrder).toEqual([
+      'saga.create_instance.command',
+      'saga.observe_source_event.command'
+    ]);
+    expect(createResult.sagaSequence).toBe(1);
+    expect(observeResult.sagaSequence).toBe(2);
+  });
+
+  it('supports barrier_gated waiting policy for coordinated fan-in', async () => {
+    const aggregate = createSagaAggregate({ aggregateName: 'saga' });
+    const observedOrder: string[] = [];
+
+    const router = createSagaInboundRouter({
+      aggregate,
+      resolveWaitingPolicy: () => 'barrier_gated',
+      beforeProcess: (input) => {
+        observedOrder.push(input.command.type);
+      }
+    });
+
+    const sagaId = 'saga-barrier-1';
+    const first = router.route({
+      sagaId,
+      command: aggregate.commandCreators.createInstance({ id: sagaId, sagaType: 'shipping', createdAt: isoAt(1) }),
+      coordination: { stepId: 'shipping-fan-in', barrierSize: 2 }
+    });
+
+    await Promise.resolve();
+    expect(observedOrder).toEqual([]);
+
+    const second = router.route({
+      sagaId,
+      command: aggregate.commandCreators.observeSourceEvent({ eventType: 'order.created.event', observedAt: isoAt(2) }),
+      coordination: { stepId: 'shipping-fan-in', barrierSize: 2 }
+    });
+
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+    expect(observedOrder).toEqual([
+      'saga.create_instance.command',
+      'saga.observe_source_event.command'
+    ]);
+    expect([firstResult.inboundSequence, secondResult.inboundSequence]).toEqual([1, 2]);
+  });
+
+  it('rejects barrier_gated policy when coordination step id is missing', async () => {
+    const aggregate = createSagaAggregate({ aggregateName: 'saga' });
+    const router = createSagaInboundRouter({
+      aggregate,
+      resolveWaitingPolicy: () => 'barrier_gated'
+    });
+
+    await expect(
+      router.route({
+        sagaId: 'saga-barrier-missing-step',
+        command: aggregate.commandCreators.createInstance({
+          id: 'saga-barrier-missing-step',
+          sagaType: 'shipping',
+          createdAt: isoAt(1)
+        })
+      })
+    ).rejects.toThrow('barrier_gated waiting policy requires coordination.stepId');
+  });
+
   it('propagates SagaAggregate invariant rejections through serialized routing', async () => {
     const aggregate = createSagaAggregate({ aggregateName: 'saga' });
     const router = createSagaInboundRouter({ aggregate });

--- a/packages/saga-runtime/test/order-workflow-v1.e2e.test.ts
+++ b/packages/saga-runtime/test/order-workflow-v1.e2e.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  createReferenceAdaptersV1,
+  createRuntimeAuditLifecycleReadModel,
+  createSagaExecutionBridge,
+  type SagaIntent
+} from '../src';
+import {
+  createOrderWorkflowSaga,
+  InventoryPlugin,
+  NotificationPlugin,
+  orderWorkflowScenarios,
+  PaymentsPlugin,
+  ShippingPlugin,
+  type OrderWorkflowScenario,
+  type OrderWorkflowState
+} from './fixtures/order-workflow-v1.fixture';
+
+const isoAt = (secondsOffset: number) => new Date(Date.UTC(2026, 0, 1, 0, 0, secondsOffset)).toISOString();
+
+const sideEffectIntentTypes = new Set<SagaIntent['type']>(['plugin-one-way', 'plugin-request', 'run-activity']);
+
+const countSideEffects = (intentTypes: readonly string[]): number => intentTypes
+  .filter((intentType) => sideEffectIntentTypes.has(intentType as SagaIntent['type']))
+  .length;
+
+const runScenario = async (scenario: OrderWorkflowScenario) => {
+  const adapters = createReferenceAdaptersV1();
+  const bridge = createSagaExecutionBridge<OrderWorkflowState>({
+    definition: createOrderWorkflowSaga(),
+    adapters,
+    runtimePlugins: [PaymentsPlugin, InventoryPlugin, ShippingPlugin, NotificationPlugin] as const
+  });
+
+  const dispatchResults = [] as Array<Awaited<ReturnType<typeof bridge.dispatch>>>;
+
+  for (let eventIndex = 0; eventIndex < scenario.events.length; eventIndex += 1) {
+    const event = scenario.events[eventIndex];
+    const result = await bridge.dispatch({
+      sagaId: scenario.sagaId,
+      event: {
+        ...event,
+        aggregateType: 'orders',
+        aggregateId: String(event.payload.orderId),
+        eventId: `${scenario.sagaId}:evt:${eventIndex + 1}`,
+        occurredAt: isoAt(eventIndex + 1)
+      },
+      nowIso: isoAt(eventIndex + 2)
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.intents.map((intent) => intent.type)).toEqual(event.expectedIntentTypes);
+    expect(result.adapterResults).toHaveLength(1);
+    expect(result.adapterResults[0]?.persistedExecutions).toHaveLength(countSideEffects(event.expectedIntentTypes));
+
+    dispatchResults.push(result);
+  }
+
+  return {
+    adapters,
+    bridge,
+    dispatchResults
+  };
+};
+
+describe('order workflow runtime v1 e2e', () => {
+  for (const scenario of orderWorkflowScenarios) {
+    it(`validates progression, intents, and audit behavior for ${scenario.name}`, async () => {
+      const { adapters, bridge } = await runScenario(scenario);
+
+      const sagaState = bridge.getSagaState(scenario.sagaId);
+      expect(sagaState).toEqual({
+        progression: scenario.expectedProgression,
+        lastOrderId: String(scenario.events[scenario.events.length - 1]?.payload.orderId)
+      });
+
+      const expectedTotalIntents = scenario.events.reduce(
+        (sum, event) => sum + event.expectedIntentTypes.length,
+        0
+      );
+      const expectedTotalExecutions = scenario.events.reduce(
+        (sum, event) => sum + countSideEffects(event.expectedIntentTypes),
+        0
+      );
+
+      const aggregateState = bridge.getAggregateState(scenario.sagaId);
+      expect(aggregateState.totals.observedEvents).toBe(scenario.events.length);
+      expect(aggregateState.totals.intents).toBe(expectedTotalIntents);
+
+      const persistedExecutions = adapters.persistence.listIntentExecutionsBySagaId(scenario.sagaId);
+      expect(persistedExecutions).toHaveLength(expectedTotalExecutions);
+      expect(persistedExecutions.every((entry) => entry.status === 'succeeded')).toBe(true);
+
+      const readModel = createRuntimeAuditLifecycleReadModel();
+      readModel.upsertSaga(aggregateState);
+      for (const execution of persistedExecutions) {
+        readModel.upsertIntentExecution(execution);
+      }
+
+      const sagaHistory = readModel.querySagaLifecycleHistory({
+        sagaId: scenario.sagaId,
+        limit: 500
+      });
+
+      expect(sagaHistory.items.filter((entry) => entry.kind === 'source_event_observed')).toHaveLength(scenario.events.length);
+      expect(sagaHistory.items.filter((entry) => entry.kind === 'intent_lifecycle_recorded')).toHaveLength(expectedTotalIntents);
+
+      const executionHistory = readModel.queryIntentExecutionLifecycleHistory({
+        sagaId: scenario.sagaId,
+        limit: 500
+      });
+      const executionIds = new Set(persistedExecutions.map((entry) => entry.id));
+
+      for (const executionId of executionIds) {
+        const entries = executionHistory.items.filter((entry) => entry.executionId === executionId);
+        expect(entries.map((entry) => entry.kind)).toContain('created');
+      }
+
+      const scheduled = adapters.scheduler.listScheduled().map((entry) => entry.id);
+      if (scenario.expectedProgression.includes('packed') && !scenario.expectedProgression.includes('delivered')) {
+        expect(scheduled).toEqual(['delivery-followup']);
+      }
+      if (scenario.expectedProgression.includes('delivered')) {
+        expect(scheduled).toEqual([]);
+      }
+    });
+  }
+});

--- a/packages/saga-runtime/test/reference-adapters.integration.test.ts
+++ b/packages/saga-runtime/test/reference-adapters.integration.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  createReferenceAdaptersV1,
+  createInMemoryPersistencePluginV1,
+  createInMemorySchedulerPluginV1,
+  createInMemorySideEffectsPluginV1,
+  createInMemoryTelemetryPluginV1,
+  runReferenceAdapterFlowV1,
+  type SagaIntent
+} from '../src/referenceAdapters';
+
+const metadata = {
+  sagaId: 'saga-777',
+  correlationId: 'corr-777',
+  causationId: 'cause-777'
+} as const;
+
+describe('reference adapters v1 integration', () => {
+  it('provides in-memory persistence adapters with projection interfaces', () => {
+    const persistence = createInMemoryPersistencePluginV1();
+
+    persistence.sagaProjection.upsert({
+      id: 'saga-777',
+      sagaType: 'order_workflow',
+      lifecycleState: 'active',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      transitionVersion: 1,
+      totals: {
+        transitions: 0,
+        observedEvents: 0,
+        intents: 0,
+        activities: 0
+      },
+      recent: {
+        transitions: [],
+        events: [],
+        intents: [],
+        activities: []
+      }
+    });
+
+    persistence.intentExecutionProjection.upsert({
+      id: 'exec-1',
+      sagaId: 'saga-777',
+      intentId: 'plugin-request:1',
+      status: 'in_progress',
+      attempt: 1,
+      retryPolicySnapshot: null,
+      responseRef: null,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z'
+    });
+
+    expect(persistence.sagaProjection.getById('saga-777')?.lifecycleState).toBe('active');
+    expect(persistence.listIntentExecutionsBySagaId('saga-777')).toHaveLength(1);
+  });
+
+  it('schedules and drains due triggers with scheduler policy', () => {
+    const scheduler = createInMemorySchedulerPluginV1();
+
+    scheduler.schedule({
+      id: 'trigger-a',
+      sagaId: 'saga-777',
+      runAt: '2026-01-01T00:00:01.000Z',
+      policy: {
+        restart: { mode: 'graceful', reason: 'overlap' },
+        misfire: { mode: 'catch_up_bounded', maxCatchUpCount: 2 }
+      }
+    });
+
+    scheduler.schedule({
+      id: 'trigger-b',
+      sagaId: 'saga-777',
+      runAt: '2026-01-01T00:00:03.000Z'
+    });
+
+    expect(scheduler.listScheduled().map((entry) => entry.id)).toEqual(['trigger-a', 'trigger-b']);
+    expect(scheduler.drainDue('2026-01-01T00:00:02.000Z').map((entry) => entry.id)).toEqual(['trigger-a']);
+    expect(scheduler.listScheduled().map((entry) => entry.id)).toEqual(['trigger-b']);
+  });
+
+  it('executes side effects and captures handled intents', async () => {
+    const sideEffects = createInMemorySideEffectsPluginV1();
+
+    const pluginOneWay = await sideEffects.execute({
+      type: 'plugin-one-way',
+      plugin_key: 'payments',
+      action_name: 'notify',
+      action_kind: 'void',
+      execution_payload: { orderId: 'order-1' },
+      metadata
+    });
+
+    const pluginRequest = await sideEffects.execute({
+      type: 'plugin-request',
+      plugin_key: 'payments',
+      action_name: 'authorize',
+      action_kind: 'request_response',
+      execution_payload: { amount: 123 },
+      routing_metadata: {
+        response_handler_key: 'payments.authorize.ok',
+        error_handler_key: 'payments.authorize.failed',
+        handler_data: { orderId: 'order-1' }
+      },
+      metadata
+    });
+
+    const activity = await sideEffects.execute({
+      type: 'run-activity',
+      name: 'reserve-stock',
+      closure: () => ({ reserved: true }),
+      metadata
+    });
+
+    expect(pluginOneWay.status).toBe('succeeded');
+    expect(pluginRequest.responseRef?.responseKey).toBe('payments.authorize');
+    expect(activity.output).toEqual({ reserved: true });
+    expect(sideEffects.listHandled()).toHaveLength(3);
+  });
+
+  it('records telemetry counters and events', () => {
+    const telemetry = createInMemoryTelemetryPluginV1();
+
+    telemetry.count('saga.intent.received');
+    telemetry.count('saga.intent.received', 2);
+    telemetry.event('saga.intent.executed', { status: 'succeeded' });
+
+    const snapshot = telemetry.snapshot();
+    expect(snapshot.counters['saga.intent.received']).toBe(3);
+    expect(snapshot.events[0]?.name).toBe('saga.intent.executed');
+  });
+
+  it('runs reference flow end-to-end across persistence scheduler side-effects telemetry', async () => {
+    const adapters = createReferenceAdaptersV1();
+    const intents: SagaIntent[] = [
+      {
+        type: 'schedule',
+        id: 'wake-up',
+        delay: 500,
+        metadata
+      },
+      {
+        type: 'plugin-request',
+        plugin_key: 'billing',
+        action_name: 'charge',
+        action_kind: 'request_response',
+        execution_payload: { amount: 1900 },
+        routing_metadata: {
+          response_handler_key: 'billing.charge.ok',
+          error_handler_key: 'billing.charge.failed',
+          handler_data: { paymentId: 'pay-1' }
+        },
+        metadata
+      },
+      {
+        type: 'plugin-one-way',
+        plugin_key: 'email',
+        action_name: 'sendReceipt',
+        action_kind: 'void',
+        execution_payload: { orderId: 'order-777' },
+        metadata
+      },
+      {
+        type: 'run-activity',
+        name: 'enrich-order',
+        closure: () => ({ enriched: true }),
+        metadata
+      },
+      {
+        type: 'cancel-schedule',
+        id: 'wake-up',
+        metadata
+      }
+    ];
+
+    const result = await runReferenceAdapterFlowV1(adapters, {
+      sagaId: 'saga-777',
+      intents,
+      nowIso: '2026-01-01T00:00:00.000Z',
+      schedulerPolicy: {
+        restart: { mode: 'force', reason: 'overlap' },
+        misfire: { mode: 'latest_only' }
+      }
+    });
+
+    expect(result.processedIntents).toBe(5);
+    expect(result.scheduledTriggerIds).toEqual(['wake-up']);
+    expect(result.persistedExecutions).toHaveLength(3);
+
+    const persisted = adapters.persistence.listIntentExecutionsBySagaId('saga-777');
+    expect(persisted).toHaveLength(3);
+    expect(persisted.every((entry) => entry.status === 'succeeded')).toBe(true);
+
+    expect(adapters.scheduler.listScheduled()).toHaveLength(0);
+
+    const telemetry = adapters.telemetry.snapshot();
+    expect(telemetry.counters['saga.intent.received']).toBe(5);
+    expect(telemetry.counters['saga.intent.executed']).toBe(3);
+    expect(telemetry.counters['saga.intent.scheduled']).toBe(1);
+    expect(telemetry.counters['saga.intent.cancelled_schedule']).toBe(1);
+  });
+});

--- a/packages/saga-runtime/test/reference-adapters.integration.test.ts
+++ b/packages/saga-runtime/test/reference-adapters.integration.test.ts
@@ -6,7 +6,8 @@ import {
   createInMemorySideEffectsPluginV1,
   createInMemoryTelemetryPluginV1,
   runReferenceAdapterFlowV1,
-  type SagaIntent
+  type SagaIntent,
+  type SagaRuntimeSideEffectResult
 } from '../src/referenceAdapters';
 
 const metadata = {
@@ -187,6 +188,7 @@ describe('reference adapters v1 integration', () => {
     expect(result.processedIntents).toBe(5);
     expect(result.scheduledTriggerIds).toEqual(['wake-up']);
     expect(result.persistedExecutions).toHaveLength(3);
+    expect(result.responseCorrelations).toHaveLength(3);
 
     const persisted = adapters.persistence.listIntentExecutionsBySagaId('saga-777');
     expect(persisted).toHaveLength(3);
@@ -199,5 +201,113 @@ describe('reference adapters v1 integration', () => {
     expect(telemetry.counters['saga.intent.executed']).toBe(3);
     expect(telemetry.counters['saga.intent.scheduled']).toBe(1);
     expect(telemetry.counters['saga.intent.cancelled_schedule']).toBe(1);
+  });
+
+  it('correlates concurrent outbound responses and failures by response reference', async () => {
+    const resolvers = new Map<string, (value: SagaRuntimeSideEffectResult) => void>();
+
+    const sideEffects = createInMemorySideEffectsPluginV1((intent) => new Promise((resolve) => {
+      const key = `${intent.type}:${intent.metadata.correlationId}`;
+      resolvers.set(key, resolve);
+    }));
+
+    const adapters = {
+      persistence: createInMemoryPersistencePluginV1(),
+      scheduler: createInMemorySchedulerPluginV1(),
+      sideEffects,
+      telemetry: createInMemoryTelemetryPluginV1()
+    };
+
+    const flow = runReferenceAdapterFlowV1(adapters, {
+      sagaId: 'saga-fanout-1',
+      nowIso: '2026-01-01T00:00:00.000Z',
+      intents: [
+        {
+          type: 'plugin-request',
+          plugin_key: 'payments',
+          action_name: 'authorize',
+          action_kind: 'request_response',
+          execution_payload: { amount: 100 },
+          routing_metadata: {
+            response_handler_key: 'payments.authorize.ok',
+            error_handler_key: 'payments.authorize.failed',
+            handler_data: { paymentId: 'pay-1' }
+          },
+          metadata: { ...metadata, correlationId: 'corr-a' }
+        },
+        {
+          type: 'plugin-request',
+          plugin_key: 'inventory',
+          action_name: 'reserve',
+          action_kind: 'request_response',
+          execution_payload: { sku: 'sku-1' },
+          routing_metadata: {
+            response_handler_key: 'inventory.reserve.ok',
+            error_handler_key: 'inventory.reserve.failed',
+            handler_data: { reservationId: 'res-1' }
+          },
+          metadata: { ...metadata, correlationId: 'corr-b' }
+        }
+      ]
+    });
+
+    await Promise.resolve();
+
+    resolvers.get('plugin-request:corr-b')?.({
+      status: 'failed',
+      responseRef: {
+        responseKey: 'inventory.reserve',
+        responseId: 'resp-b',
+        receivedAt: '2026-01-01T00:00:00.200Z'
+      },
+      error: 'inventory unavailable'
+    });
+
+    resolvers.get('plugin-request:corr-a')?.({
+      status: 'succeeded',
+      responseRef: {
+        responseKey: 'payments.authorize',
+        responseId: 'resp-a',
+        receivedAt: '2026-01-01T00:00:00.300Z'
+      }
+    });
+
+    const result = await flow;
+    expect(result.persistedExecutions).toHaveLength(2);
+    expect(result.responseCorrelations).toEqual([
+      {
+        executionId: 'saga-fanout-1:intent:1',
+        intentId: 'plugin-request:1',
+        status: 'succeeded',
+        responseRef: {
+          responseKey: 'payments.authorize',
+          responseId: 'resp-a',
+          receivedAt: '2026-01-01T00:00:00.300Z'
+        },
+        error: undefined
+      },
+      {
+        executionId: 'saga-fanout-1:intent:2',
+        intentId: 'plugin-request:2',
+        status: 'failed',
+        responseRef: {
+          responseKey: 'inventory.reserve',
+          responseId: 'resp-b',
+          receivedAt: '2026-01-01T00:00:00.200Z'
+        },
+        error: 'inventory unavailable'
+      }
+    ]);
+
+    const persisted = adapters.persistence.listIntentExecutionsBySagaId('saga-fanout-1');
+    expect(persisted).toHaveLength(2);
+    expect(persisted.find((entry) => entry.id === 'saga-fanout-1:intent:1')?.status).toBe('succeeded');
+    expect(persisted.find((entry) => entry.id === 'saga-fanout-1:intent:2')?.status).toBe('failed');
+    expect(persisted.find((entry) => entry.id === 'saga-fanout-1:intent:2')?.responseRef?.responseId).toBe('resp-b');
+
+    const telemetry = adapters.telemetry.snapshot();
+    expect(telemetry.counters['saga.intent.executed']).toBe(2);
+    expect(telemetry.counters['saga.intent.execution_succeeded']).toBe(1);
+    expect(telemetry.counters['saga.intent.execution_failed']).toBe(1);
   });
 });

--- a/packages/saga-runtime/test/reference-adapters.integration.test.ts
+++ b/packages/saga-runtime/test/reference-adapters.integration.test.ts
@@ -78,6 +78,163 @@ describe('reference adapters v1 integration', () => {
     expect(scheduler.listScheduled().map((entry) => entry.id)).toEqual(['trigger-a', 'trigger-b']);
     expect(scheduler.drainDue('2026-01-01T00:00:02.000Z').map((entry) => entry.id)).toEqual(['trigger-a']);
     expect(scheduler.listScheduled().map((entry) => entry.id)).toEqual(['trigger-b']);
+    expect(scheduler.listPolicyOutcomes()).toEqual([
+      expect.objectContaining({
+        triggerId: 'trigger-a',
+        outcome: expect.objectContaining({
+          misfireMode: 'catch_up_bounded',
+          wasMisfire: true,
+          dueCount: 1,
+          executedCount: 1,
+          skippedCount: 0,
+          restartMode: 'graceful',
+          restartReason: 'overlap'
+        })
+      })
+    ]);
+  });
+
+  it('applies catch_up_all by replaying all due interval occurrences deterministically', () => {
+    const scheduler = createInMemorySchedulerPluginV1();
+
+    scheduler.schedule({
+      id: 'trigger-catch-all',
+      sagaId: 'saga-777',
+      runAt: '2026-01-01T00:00:01.000Z',
+      metadata: { intervalMs: 1000 },
+      policy: {
+        restart: { mode: 'force', reason: 'restart for overlap' },
+        misfire: { mode: 'catch_up_all' }
+      }
+    });
+
+    const drained = scheduler.drainDue('2026-01-01T00:00:04.000Z');
+    expect(drained.map((entry) => entry.id)).toEqual([
+      'trigger-catch-all:exec:1',
+      'trigger-catch-all:exec:2',
+      'trigger-catch-all:exec:3',
+      'trigger-catch-all:exec:4'
+    ]);
+    expect(drained.map((entry) => entry.execution?.scheduledFor)).toEqual([
+      '2026-01-01T00:00:01.000Z',
+      '2026-01-01T00:00:02.000Z',
+      '2026-01-01T00:00:03.000Z',
+      '2026-01-01T00:00:04.000Z'
+    ]);
+    expect(scheduler.listScheduled().map((entry) => entry.id)).toEqual(['trigger-catch-all']);
+    expect(scheduler.listScheduled()[0]?.runAt).toBe('2026-01-01T00:00:05.000Z');
+    expect(scheduler.listPolicyOutcomes()).toEqual([
+      expect.objectContaining({
+        triggerId: 'trigger-catch-all',
+        outcome: expect.objectContaining({
+          misfireMode: 'catch_up_all',
+          wasMisfire: true,
+          dueCount: 4,
+          executedCount: 4,
+          skippedCount: 0,
+          restartMode: 'force',
+          restartReason: 'restart for overlap',
+          nextRunAt: '2026-01-01T00:00:05.000Z'
+        })
+      })
+    ]);
+  });
+
+  it('applies catch_up_bounded by limiting replay to configured maximum', () => {
+    const scheduler = createInMemorySchedulerPluginV1();
+
+    scheduler.schedule({
+      id: 'trigger-catch-bounded',
+      sagaId: 'saga-777',
+      runAt: '2026-01-01T00:00:01.000Z',
+      metadata: { intervalMs: 1000 },
+      policy: {
+        misfire: { mode: 'catch_up_bounded', maxCatchUpCount: 2 }
+      }
+    });
+
+    const drained = scheduler.drainDue('2026-01-01T00:00:04.000Z');
+    expect(drained.map((entry) => entry.id)).toEqual([
+      'trigger-catch-bounded:exec:1',
+      'trigger-catch-bounded:exec:2'
+    ]);
+    expect(drained.map((entry) => entry.execution?.scheduledFor)).toEqual([
+      '2026-01-01T00:00:01.000Z',
+      '2026-01-01T00:00:02.000Z'
+    ]);
+    expect(scheduler.listPolicyOutcomes()).toEqual([
+      expect.objectContaining({
+        triggerId: 'trigger-catch-bounded',
+        outcome: expect.objectContaining({
+          misfireMode: 'catch_up_bounded',
+          dueCount: 4,
+          executedCount: 2,
+          skippedCount: 2,
+          nextRunAt: '2026-01-01T00:00:05.000Z'
+        })
+      })
+    ]);
+  });
+
+  it('applies latest_only by executing only the latest due occurrence', () => {
+    const scheduler = createInMemorySchedulerPluginV1();
+
+    scheduler.schedule({
+      id: 'trigger-latest-only',
+      sagaId: 'saga-777',
+      runAt: '2026-01-01T00:00:01.000Z',
+      metadata: { intervalMs: 1000 },
+      policy: {
+        misfire: { mode: 'latest_only' }
+      }
+    });
+
+    const drained = scheduler.drainDue('2026-01-01T00:00:04.000Z');
+    expect(drained.map((entry) => entry.id)).toEqual(['trigger-latest-only']);
+    expect(drained.map((entry) => entry.execution?.scheduledFor)).toEqual(['2026-01-01T00:00:04.000Z']);
+    expect(scheduler.listPolicyOutcomes()).toEqual([
+      expect.objectContaining({
+        triggerId: 'trigger-latest-only',
+        outcome: expect.objectContaining({
+          misfireMode: 'latest_only',
+          dueCount: 4,
+          executedCount: 1,
+          skippedCount: 3,
+          nextRunAt: '2026-01-01T00:00:05.000Z'
+        })
+      })
+    ]);
+  });
+
+  it('applies skip_until_next by dropping due occurrences and advancing schedule', () => {
+    const scheduler = createInMemorySchedulerPluginV1();
+
+    scheduler.schedule({
+      id: 'trigger-skip-next',
+      sagaId: 'saga-777',
+      runAt: '2026-01-01T00:00:01.000Z',
+      metadata: { intervalMs: 1000 },
+      policy: {
+        misfire: { mode: 'skip_until_next' }
+      }
+    });
+
+    const drained = scheduler.drainDue('2026-01-01T00:00:04.000Z');
+    expect(drained).toEqual([]);
+    expect(scheduler.listScheduled().map((entry) => entry.id)).toEqual(['trigger-skip-next']);
+    expect(scheduler.listScheduled()[0]?.runAt).toBe('2026-01-01T00:00:05.000Z');
+    expect(scheduler.listPolicyOutcomes()).toEqual([
+      expect.objectContaining({
+        triggerId: 'trigger-skip-next',
+        outcome: expect.objectContaining({
+          misfireMode: 'skip_until_next',
+          dueCount: 4,
+          executedCount: 0,
+          skippedCount: 4,
+          nextRunAt: '2026-01-01T00:00:05.000Z'
+        })
+      })
+    ]);
   });
 
   it('executes side effects and captures handled intents', async () => {

--- a/packages/saga-runtime/test/reliability-delivery-modes.integration.test.ts
+++ b/packages/saga-runtime/test/reliability-delivery-modes.integration.test.ts
@@ -1,0 +1,323 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  createInMemoryPersistencePluginV1,
+  createInMemorySchedulerPluginV1,
+  createInMemorySideEffectsPluginV1,
+  createInMemoryTelemetryPluginV1,
+  runReferenceAdapterFlowV1,
+  type SagaPluginRequestIntent,
+  type SagaRuntimeReferenceAdapters
+} from '../src/referenceAdapters';
+
+type DeliveryMode = 'at_least_once' | 'effectively_once';
+type FaultOutcome = 'succeeded' | 'failed';
+
+interface ReliabilityTransition {
+  readonly stage: 'received' | 'dispatched' | 'succeeded' | 'failed' | 'retry_scheduled' | 'deduped' | 'dead_lettered';
+  readonly executionId: string;
+  readonly attempt: number;
+  readonly mode: DeliveryMode;
+  readonly reason: 'initial' | 'retry' | 'redelivery';
+}
+
+interface DeadLetterRecord {
+  readonly executionId: string;
+  readonly attempts: number;
+  readonly mode: DeliveryMode;
+}
+
+interface DeliveryResult {
+  readonly executionId: string;
+  readonly attempt: number;
+  readonly shouldRetry: boolean;
+  readonly deduped: boolean;
+}
+
+const metadata = {
+  sagaId: 'saga-reliability-1',
+  correlationId: 'corr-reliability-1',
+  causationId: 'cause-reliability-1'
+} as const;
+
+const createIntent = (): SagaPluginRequestIntent => ({
+  type: 'plugin-request',
+  plugin_key: 'payments',
+  action_name: 'authorize',
+  action_kind: 'request_response',
+  execution_payload: { amount: 1900 },
+  routing_metadata: {
+    response_handler_key: 'payments.authorize.ok',
+    error_handler_key: 'payments.authorize.failed',
+    handler_data: { orderId: 'order-777' }
+  },
+  metadata
+});
+
+const createReliabilityHarness = (mode: DeliveryMode, faultPlan: readonly FaultOutcome[], maxAttempts = 2) => {
+  const plannedFaults = [...faultPlan];
+  const transitions: ReliabilityTransition[] = [];
+  const deadLetters: DeadLetterRecord[] = [];
+  const attemptsByExecutionId = new Map<string, number>();
+  const deliveryCountByLogicalIntent = new Map<string, number>();
+  const handledExecutionIds: string[] = [];
+
+  const adapters: SagaRuntimeReferenceAdapters = {
+    persistence: createInMemoryPersistencePluginV1(),
+    scheduler: createInMemorySchedulerPluginV1(),
+    telemetry: createInMemoryTelemetryPluginV1(),
+    sideEffects: createInMemorySideEffectsPluginV1(() => {
+      const outcome = plannedFaults.shift() ?? 'succeeded';
+      if (outcome === 'failed') {
+        return {
+          status: 'failed',
+          error: 'fault-injected: simulated transport timeout'
+        };
+      }
+
+      return {
+        status: 'succeeded',
+        responseRef: {
+          responseKey: 'payments.authorize',
+          responseId: `resp-${handledExecutionIds.length + 1}`,
+          receivedAt: '2026-01-01T00:00:01.000Z'
+        }
+      };
+    })
+  };
+
+  const logicalIntentKey = (sagaId: string, intent: SagaPluginRequestIntent): string => (
+    `${sagaId}:${intent.plugin_key}.${intent.action_name}:${intent.metadata.correlationId}`
+  );
+
+  const stableExecutionId = (sagaId: string, intent: SagaPluginRequestIntent): string => (
+    `${logicalIntentKey(sagaId, intent)}:execution`
+  );
+
+  const nextExecutionIdentity = (sagaId: string, intent: SagaPluginRequestIntent): { executionId: string; intentId: string } => {
+    const key = logicalIntentKey(sagaId, intent);
+    if (mode === 'effectively_once') {
+      const executionId = stableExecutionId(sagaId, intent);
+      return {
+        executionId,
+        intentId: executionId
+      };
+    }
+
+    const deliveryCount = (deliveryCountByLogicalIntent.get(key) ?? 0) + 1;
+    deliveryCountByLogicalIntent.set(key, deliveryCount);
+    const executionId = `${stableExecutionId(sagaId, intent)}:delivery:${deliveryCount}`;
+    return {
+      executionId,
+      intentId: executionId
+    };
+  };
+
+  const deliver = async (
+    sagaId: string,
+    intent: SagaPluginRequestIntent,
+    reason: 'initial' | 'retry' | 'redelivery'
+  ): Promise<DeliveryResult> => {
+    const effectiveExecutionId = stableExecutionId(sagaId, intent);
+    const currentAttempt = attemptsByExecutionId.get(effectiveExecutionId) ?? 0;
+    transitions.push({
+      stage: 'received',
+      executionId: effectiveExecutionId,
+      attempt: currentAttempt + 1,
+      mode,
+      reason
+    });
+
+    if (mode === 'effectively_once') {
+      const existing = adapters.persistence.intentExecutionProjection.getById(effectiveExecutionId);
+      if (existing?.status === 'succeeded') {
+        transitions.push({
+          stage: 'deduped',
+          executionId: effectiveExecutionId,
+          attempt: currentAttempt,
+          mode,
+          reason
+        });
+        return {
+          executionId: effectiveExecutionId,
+          attempt: currentAttempt,
+          shouldRetry: false,
+          deduped: true
+        };
+      }
+    }
+
+    const identity = nextExecutionIdentity(sagaId, intent);
+    transitions.push({
+      stage: 'dispatched',
+      executionId: identity.executionId,
+      attempt: currentAttempt + 1,
+      mode,
+      reason
+    });
+
+    handledExecutionIds.push(identity.executionId);
+
+    const result = await runReferenceAdapterFlowV1(adapters, {
+      sagaId,
+      intents: [intent],
+      nowIso: '2026-01-01T00:00:00.000Z',
+      resolveExecutionIdentity: () => identity
+    });
+
+    const status = result.responseCorrelations[0]?.status;
+    const attempt = currentAttempt + 1;
+    attemptsByExecutionId.set(effectiveExecutionId, attempt);
+
+    if (status === 'failed') {
+      transitions.push({
+        stage: 'failed',
+        executionId: identity.executionId,
+        attempt,
+        mode,
+        reason
+      });
+
+      if (attempt >= maxAttempts) {
+        transitions.push({
+          stage: 'dead_lettered',
+          executionId: identity.executionId,
+          attempt,
+          mode,
+          reason
+        });
+        deadLetters.push({
+          executionId: identity.executionId,
+          attempts: attempt,
+          mode
+        });
+        return {
+          executionId: identity.executionId,
+          attempt,
+          shouldRetry: false,
+          deduped: false
+        };
+      }
+
+      transitions.push({
+        stage: 'retry_scheduled',
+        executionId: identity.executionId,
+        attempt,
+        mode,
+        reason
+      });
+      return {
+        executionId: identity.executionId,
+        attempt,
+        shouldRetry: true,
+        deduped: false
+      };
+    }
+
+    transitions.push({
+      stage: 'succeeded',
+      executionId: identity.executionId,
+      attempt,
+      mode,
+      reason
+    });
+    return {
+      executionId: identity.executionId,
+      attempt,
+      shouldRetry: false,
+      deduped: false
+    };
+  };
+
+  const listPersisted = () => adapters.persistence.listIntentExecutionsBySagaId(metadata.sagaId);
+
+  return {
+    adapters,
+    deliver,
+    listPersisted,
+    transitions,
+    deadLetters,
+    handledExecutionIds
+  };
+};
+
+describe('reliability validation: delivery modes and idempotency boundary', () => {
+  it('distinguishes at_least_once from effectively_once on success redelivery', async () => {
+    const atLeastOnce = createReliabilityHarness('at_least_once', ['succeeded', 'succeeded']);
+    const effectivelyOnce = createReliabilityHarness('effectively_once', ['succeeded', 'succeeded']);
+
+    await atLeastOnce.deliver(metadata.sagaId, createIntent(), 'initial');
+    await atLeastOnce.deliver(metadata.sagaId, createIntent(), 'redelivery');
+
+    await effectivelyOnce.deliver(metadata.sagaId, createIntent(), 'initial');
+    const deduped = await effectivelyOnce.deliver(metadata.sagaId, createIntent(), 'redelivery');
+
+    expect(atLeastOnce.adapters.sideEffects.listHandled()).toHaveLength(2);
+    expect(atLeastOnce.listPersisted().map((record) => record.id)).toEqual([
+      `${metadata.sagaId}:payments.authorize:${metadata.correlationId}:execution:delivery:1`,
+      `${metadata.sagaId}:payments.authorize:${metadata.correlationId}:execution:delivery:2`
+    ]);
+
+    expect(effectivelyOnce.adapters.sideEffects.listHandled()).toHaveLength(1);
+    expect(effectivelyOnce.listPersisted().map((record) => record.id)).toEqual([
+      `${metadata.sagaId}:payments.authorize:${metadata.correlationId}:execution`
+    ]);
+    expect(deduped.deduped).toBe(true);
+    expect(effectivelyOnce.transitions).toContainEqual(
+      expect.objectContaining({ stage: 'deduped', mode: 'effectively_once', reason: 'redelivery' })
+    );
+  });
+
+  it('records deterministic retry then dead-letter transitions under fault injection', async () => {
+    const runScenario = async (mode: DeliveryMode) => {
+      const harness = createReliabilityHarness(mode, ['failed', 'failed'], 2);
+      const intent = createIntent();
+
+      let nextReason: 'initial' | 'retry' = 'initial';
+      let outcome = await harness.deliver(metadata.sagaId, intent, nextReason);
+
+      while (outcome.shouldRetry) {
+        nextReason = 'retry';
+        outcome = await harness.deliver(metadata.sagaId, intent, nextReason);
+      }
+
+      return harness;
+    };
+
+    const atLeastOnce = await runScenario('at_least_once');
+    const effectivelyOnce = await runScenario('effectively_once');
+
+    for (const harness of [atLeastOnce, effectivelyOnce]) {
+      expect(harness.deadLetters).toHaveLength(1);
+      expect(harness.transitions.map((entry) => entry.stage)).toEqual([
+        'received',
+        'dispatched',
+        'failed',
+        'retry_scheduled',
+        'received',
+        'dispatched',
+        'failed',
+        'dead_lettered'
+      ]);
+    }
+
+    expect(atLeastOnce.listPersisted()).toHaveLength(2);
+    expect(effectivelyOnce.listPersisted()).toHaveLength(1);
+    expect(effectivelyOnce.listPersisted()[0]?.status).toBe('failed');
+  });
+
+  it('keeps retry/redelivery execution counts observable in telemetry counters', async () => {
+    const atLeastOnce = createReliabilityHarness('at_least_once', ['failed', 'succeeded', 'succeeded'], 3);
+
+    const first = await atLeastOnce.deliver(metadata.sagaId, createIntent(), 'initial');
+    if (first.shouldRetry) {
+      await atLeastOnce.deliver(metadata.sagaId, createIntent(), 'retry');
+    }
+    await atLeastOnce.deliver(metadata.sagaId, createIntent(), 'redelivery');
+
+    const counters = atLeastOnce.adapters.telemetry.snapshot().counters;
+    expect(counters['saga.intent.received']).toBe(3);
+    expect(counters['saga.intent.executed']).toBe(3);
+    expect(counters['saga.intent.execution_failed']).toBe(1);
+    expect(counters['saga.intent.execution_succeeded']).toBe(2);
+  });
+});

--- a/packages/saga-runtime/test/runtime-audit-projections.test.ts
+++ b/packages/saga-runtime/test/runtime-audit-projections.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  createRuntimeAuditLifecycleReadModel,
+  type IntentExecutionProjectionRecord,
+  type SagaAggregateState
+} from '../src';
+
+const createSagaState = (): SagaAggregateState => ({
+  id: 'saga-1',
+  sagaType: 'order',
+  lifecycleState: 'active',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:03.000Z',
+  transitionVersion: 8,
+  totals: {
+    transitions: 1,
+    observedEvents: 1,
+    intents: 1,
+    activities: 1
+  },
+  recent: {
+    transitions: [
+      {
+        fromState: 'active',
+        toState: 'completed',
+        transitionAt: '2026-01-01T00:00:02.000Z'
+      }
+    ],
+    events: [
+      {
+        eventType: 'order.approved.event',
+        eventId: 'evt-1',
+        observedAt: '2026-01-01T00:00:02.000Z'
+      }
+    ],
+    intents: [
+      {
+        intentId: 'intent-1',
+        intentType: 'plugin-request',
+        stage: 'acknowledged',
+        executionId: 'exec-1',
+        recordedAt: '2026-01-01T00:00:02.000Z'
+      }
+    ],
+    activities: [
+      {
+        activityId: 'activity-1',
+        activityName: 'reserve-stock',
+        stage: 'succeeded',
+        recordedAt: '2026-01-01T00:00:02.000Z'
+      }
+    ]
+  }
+});
+
+const execution = (status: IntentExecutionProjectionRecord['status'], updatedAt: string): IntentExecutionProjectionRecord => ({
+  id: 'exec-1',
+  sagaId: 'saga-1',
+  intentId: 'intent-1',
+  status,
+  attempt: status === 'in_progress' ? 1 : 2,
+  retryPolicySnapshot: null,
+  responseRef: status === 'succeeded'
+    ? { responseKey: 'payments.charge', responseId: 'resp-1' }
+    : null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt,
+  metadata: status === 'succeeded' ? { terminal: true } : undefined
+});
+
+describe('runtime audit lifecycle read model', () => {
+  it('produces the same saga lifecycle history view regardless of input ordering', () => {
+    const readModelA = createRuntimeAuditLifecycleReadModel();
+    const readModelB = createRuntimeAuditLifecycleReadModel();
+
+    const stateA = createSagaState();
+    stateA.recent.events = [
+      {
+        eventType: 'order.created.event',
+        eventId: 'evt-2',
+        observedAt: '2026-01-01T00:00:01.000Z'
+      },
+      ...stateA.recent.events
+    ];
+    stateA.recent.transitions = [
+      {
+        fromState: 'idle',
+        toState: 'active',
+        transitionAt: '2026-01-01T00:00:01.000Z'
+      },
+      ...stateA.recent.transitions
+    ];
+    stateA.recent.intents = [
+      {
+        intentId: 'intent-0',
+        intentType: 'dispatch',
+        stage: 'created',
+        recordedAt: '2026-01-01T00:00:01.000Z'
+      },
+      ...stateA.recent.intents
+    ];
+    stateA.recent.activities = [
+      {
+        activityId: 'activity-0',
+        activityName: 'prepare',
+        stage: 'started',
+        recordedAt: '2026-01-01T00:00:01.000Z'
+      },
+      ...stateA.recent.activities
+    ];
+
+    const stateB = createSagaState();
+    stateB.recent.events = [...stateA.recent.events].reverse();
+    stateB.recent.transitions = [...stateA.recent.transitions].reverse();
+    stateB.recent.intents = [...stateA.recent.intents].reverse();
+    stateB.recent.activities = [...stateA.recent.activities].reverse();
+
+    readModelA.upsertSaga(stateA);
+    readModelB.upsertSaga(stateB);
+
+    const a = readModelA.querySagaLifecycleHistory({ sagaId: 'saga-1' });
+    const b = readModelB.querySagaLifecycleHistory({ sagaId: 'saga-1' });
+
+    expect(a.items).toEqual(b.items);
+  });
+
+  it('builds deterministic saga lifecycle history ordering', () => {
+    const readModel = createRuntimeAuditLifecycleReadModel();
+    readModel.upsertSaga(createSagaState());
+
+    const history = readModel.querySagaLifecycleHistory({ sagaId: 'saga-1' });
+
+    expect(history.items.map((entry) => entry.kind)).toEqual([
+      'source_event_observed',
+      'state_transition_recorded',
+      'intent_lifecycle_recorded',
+      'activity_lifecycle_recorded'
+    ]);
+    expect(history.items.every((entry) => entry.recordedAt === '2026-01-01T00:00:02.000Z')).toBe(true);
+  });
+
+  it('tracks deterministic intent execution lifecycle changes', () => {
+    const readModel = createRuntimeAuditLifecycleReadModel();
+
+    readModel.upsertIntentExecution(execution('in_progress', '2026-01-01T00:00:01.000Z'));
+    readModel.upsertIntentExecution(execution('succeeded', '2026-01-01T00:00:02.000Z'));
+
+    const history = readModel.queryIntentExecutionLifecycleHistory({ executionId: 'exec-1' });
+
+    expect(history.items.map((entry) => entry.kind)).toEqual([
+      'created',
+      'status_changed',
+      'attempt_changed',
+      'response_ref_recorded',
+      'metadata_changed'
+    ]);
+    expect(history.items.map((entry) => entry.sequence)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('supports deterministic pagination for lifecycle history and intent queries', async () => {
+    const readModel = createRuntimeAuditLifecycleReadModel();
+    readModel.upsertSaga(createSagaState());
+
+    readModel.upsertIntentExecution({
+      id: 'exec-a',
+      sagaId: 'saga-1',
+      intentId: 'intent-a',
+      status: 'failed',
+      attempt: 1,
+      retryPolicySnapshot: null,
+      responseRef: null,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:03.000Z'
+    });
+    readModel.upsertIntentExecution({
+      id: 'exec-b',
+      sagaId: 'saga-1',
+      intentId: 'intent-b',
+      status: 'in_progress',
+      attempt: 1,
+      retryPolicySnapshot: null,
+      responseRef: null,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:04.000Z'
+    });
+
+    const page1 = readModel.querySagaLifecycleHistory({ sagaId: 'saga-1', limit: 2 });
+    const page2 = readModel.querySagaLifecycleHistory({
+      sagaId: 'saga-1',
+      limit: 2,
+      cursor: page1.nextCursor
+    });
+
+    expect(page1.items).toHaveLength(2);
+    expect(page2.items).toHaveLength(2);
+    expect(page2.nextCursor).toBeUndefined();
+
+    const query = await readModel.queryIntentExecutions({
+      sagaId: 'saga-1',
+      statuses: ['in_progress', 'failed'],
+      limit: 1
+    });
+    const queryNext = await readModel.queryIntentExecutions({
+      sagaId: 'saga-1',
+      statuses: ['in_progress', 'failed'],
+      limit: 1,
+      cursor: query.nextCursor
+    });
+
+    expect(query.items[0]?.id).toBe('exec-b');
+    expect(queryNext.items[0]?.id).toBe('exec-a');
+  });
+});

--- a/packages/saga-runtime/test/runtime-contracts-structure.test.ts
+++ b/packages/saga-runtime/test/runtime-contracts-structure.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from '@jest/globals';
+import type {
+  SagaSchedulerTriggerPolicyContract,
+  SagaTriggerMisfirePolicy,
+  SagaTriggerStartContract
+} from '../src';
+
+describe('runtime contract structure', () => {
+  it('exports scheduler trigger restart and misfire policy contracts', () => {
+    const misfireModes: SagaTriggerMisfirePolicy[] = [
+      { mode: 'catch_up_all' },
+      { mode: 'catch_up_bounded', maxCatchUpCount: 3 },
+      { mode: 'latest_only' },
+      { mode: 'skip_until_next' }
+    ];
+
+    const schedulerPolicy: SagaSchedulerTriggerPolicyContract = {
+      restart: { mode: 'force', reason: 'overlap' },
+      misfire: misfireModes[1]
+    };
+
+    const trigger: SagaTriggerStartContract = {
+      schedulerPolicy
+    };
+
+    expect(misfireModes.map((mode) => mode.mode)).toEqual([
+      'catch_up_all',
+      'catch_up_bounded',
+      'latest_only',
+      'skip_until_next'
+    ]);
+    expect(trigger.schedulerPolicy?.restart?.mode).toBe('force');
+    expect(trigger.schedulerPolicy?.misfire?.mode).toBe('catch_up_bounded');
+  });
+});

--- a/packages/saga-runtime/test/runtime-observability-contracts.test.ts
+++ b/packages/saga-runtime/test/runtime-observability-contracts.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from '@jest/globals';
+import type {
+  RuntimeAuditQuery,
+  RuntimeAuditQueryResult,
+  RuntimeAuditRecord,
+  RuntimeIntentExecutionQuery,
+  RuntimeIntentExecutionQueryResult,
+  RuntimeObservabilityReadApiContract,
+  RuntimeReadModelContract,
+  RuntimeTelemetryRecord
+} from '../src';
+
+describe('runtime observability/read API contracts', () => {
+  it('captures telemetry lifecycle payload shape', () => {
+    const telemetryRecord: RuntimeTelemetryRecord = {
+      kind: 'intent.execution',
+      level: 'info',
+      occurredAt: '2026-01-01T00:00:00.000Z',
+      message: 'intent execution status advanced',
+      context: {
+        sagaId: 'saga-123',
+        intentId: 'intent-42',
+        executionId: 'exec-7',
+        correlationId: 'corr-1',
+        sequence: 9
+      },
+      attributes: {
+        status: 'in_progress',
+        attempt: 2
+      }
+    };
+
+    expect(telemetryRecord.kind).toBe('intent.execution');
+    expect(telemetryRecord.level).toBe('info');
+    expect(telemetryRecord.context.executionId).toBe('exec-7');
+  });
+
+  it('captures audit write and read query shapes', () => {
+    const auditRecord: RuntimeAuditRecord = {
+      auditId: 'audit-100',
+      category: 'event',
+      action: 'saga.state_transitioned.event',
+      recordedAt: '2026-01-01T00:00:01.000Z',
+      sagaId: 'saga-123',
+      intentExecutionId: 'exec-7',
+      references: [
+        { type: 'saga', id: 'saga-123', version: 5 },
+        { type: 'intent_execution', id: 'exec-7' }
+      ],
+      metadata: {
+        source: 'runtime'
+      }
+    };
+
+    const query: RuntimeAuditQuery = {
+      sagaId: 'saga-123',
+      categories: ['event', 'projection'],
+      limit: 50,
+      cursor: {
+        recordedAt: '2026-01-01T00:00:00.000Z',
+        auditId: 'audit-99'
+      }
+    };
+
+    const queryResult: RuntimeAuditQueryResult = {
+      items: [auditRecord],
+      nextCursor: {
+        recordedAt: '2026-01-01T00:00:01.000Z',
+        auditId: 'audit-100'
+      },
+      totalApproximate: 1
+    };
+
+    expect(query.categories).toEqual(['event', 'projection']);
+    expect(queryResult.items[0]?.references?.[0]?.type).toBe('saga');
+    expect(queryResult.nextCursor?.auditId).toBe('audit-100');
+  });
+
+  it('captures read-model contract method signatures and response shapes', async () => {
+    const readModel: RuntimeReadModelContract = {
+      getSagaById: (_id, _options) => null,
+      getIntentExecutionById: (_id) => null,
+      queryIntentExecutions: (_query) => ({
+        items: [],
+        nextCursor: 'cursor-2'
+      })
+    };
+
+    const query: RuntimeIntentExecutionQuery = {
+      sagaId: 'saga-123',
+      statuses: ['in_progress', 'failed'],
+      limit: 25,
+      cursor: 'cursor-1'
+    };
+
+    const result = (await readModel.queryIntentExecutions(query)) as RuntimeIntentExecutionQueryResult;
+
+    expect(query.statuses).toEqual(['in_progress', 'failed']);
+    expect(result.items).toEqual([]);
+    expect(result.nextCursor).toBe('cursor-2');
+  });
+
+  it('composes telemetry, audit, and read model contracts in runtime API surface', () => {
+    const contract: RuntimeObservabilityReadApiContract = {
+      telemetry: {
+        publish: () => undefined
+      },
+      audit: {
+        append: () => undefined,
+        query: () => ({ items: [] }),
+        getByAuditId: () => null
+      },
+      readModel: {
+        getSagaById: () => null,
+        getIntentExecutionById: () => null,
+        queryIntentExecutions: () => ({ items: [] })
+      }
+    };
+
+    expect(typeof contract.telemetry.publish).toBe('function');
+    expect(typeof contract.audit.query).toBe('function');
+    expect(typeof contract.readModel.queryIntentExecutions).toBe('function');
+  });
+});

--- a/packages/saga-runtime/test/saga-aggregate-structure.test.ts
+++ b/packages/saga-runtime/test/saga-aggregate-structure.test.ts
@@ -115,7 +115,7 @@ describe('createSagaAggregate structure contracts', () => {
         aggregate.process(
           state,
           aggregate.commandCreators.recordStateTransition({
-            fromState: `state-${i - 1}`,
+            fromState: state.lifecycleState,
             toState: `state-${i}`,
             transitionAt: isoAt(i * 10)
           })

--- a/packages/saga-runtime/test/saga-aggregate-structure.test.ts
+++ b/packages/saga-runtime/test/saga-aggregate-structure.test.ts
@@ -49,7 +49,7 @@ describe('createSagaAggregate structure contracts', () => {
     const createEvent = aggregate.process(
       state,
       aggregate.commandCreators.createInstance({
-        sagaId: 'saga-1',
+        id: 'saga-1',
         sagaType: 'shipping',
         createdAt: createdAtInput
       })
@@ -105,7 +105,7 @@ describe('createSagaAggregate structure contracts', () => {
       aggregate.initialState,
       aggregate.process(
         aggregate.initialState,
-        aggregate.commandCreators.createInstance({ sagaId: 'saga-1', sagaType: 'shipping', createdAt: isoAt(0) })
+        aggregate.commandCreators.createInstance({ id: 'saga-1', sagaType: 'shipping', createdAt: isoAt(0) })
       )[0]
     );
 

--- a/packages/saga-runtime/test/saga-aggregate-transition-invariants.test.ts
+++ b/packages/saga-runtime/test/saga-aggregate-transition-invariants.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from '@jest/globals';
+import { createSagaAggregate, SagaTransitionInvariantError, type SagaAggregateState } from '../src/createSagaAggregate';
+
+const isoAt = (secondsOffset: number) => new Date(Date.UTC(2026, 0, 1, 0, 0, secondsOffset)).toISOString();
+
+const expectInvariant = (
+  execute: () => unknown,
+  code: SagaTransitionInvariantError['code'],
+  details: Record<string, unknown>
+) => {
+  try {
+    execute();
+    throw new Error('expected invariant rejection');
+  } catch (error) {
+    expect(error).toBeInstanceOf(SagaTransitionInvariantError);
+    const invariant = error as SagaTransitionInvariantError;
+    expect(invariant.code).toBe(code);
+    expect(invariant.details).toMatchObject(details);
+  }
+};
+
+describe('saga aggregate transition invariants', () => {
+  it('rejects transition and observation commands before instance creation', () => {
+    const aggregate = createSagaAggregate({ aggregateName: 'saga' });
+    const state = aggregate.initialState;
+
+    expectInvariant(
+      () => aggregate.process(state, aggregate.commandCreators.recordStateTransition({ fromState: 'idle', toState: 'active' })),
+      'saga_instance_not_created',
+      { command: 'recordStateTransition', currentState: 'idle', transitionVersion: 0 }
+    );
+
+    expectInvariant(
+      () => aggregate.process(state, aggregate.commandCreators.observeSourceEvent({ eventType: 'order.created.event' })),
+      'saga_instance_not_created',
+      { command: 'observeSourceEvent', currentState: 'idle', transitionVersion: 0 }
+    );
+  });
+
+  it('rejects duplicate createInstance invocations', () => {
+    const aggregate = createSagaAggregate({ aggregateName: 'saga' });
+
+    const created = aggregate.process(
+      aggregate.initialState,
+      aggregate.commandCreators.createInstance({ id: 'saga-1', sagaType: 'shipping', createdAt: isoAt(1) })
+    )[0];
+
+    const state = aggregate.apply(aggregate.initialState, created);
+
+    expectInvariant(
+      () => aggregate.process(state, aggregate.commandCreators.createInstance({ id: 'saga-1', sagaType: 'shipping', createdAt: isoAt(2) })),
+      'saga_instance_already_created',
+      { command: 'createInstance', sagaId: 'saga-1', currentState: 'active' }
+    );
+  });
+
+  it('rejects invalid sequencing: fromState mismatch, noop transitions, and post-terminal transitions', () => {
+    const aggregate = createSagaAggregate({ aggregateName: 'saga' });
+
+    let state: SagaAggregateState = aggregate.apply(
+      aggregate.initialState,
+      aggregate.process(
+        aggregate.initialState,
+        aggregate.commandCreators.createInstance({ id: 'saga-1', sagaType: 'shipping', createdAt: isoAt(1) })
+      )[0]
+    );
+
+    expectInvariant(
+      () => aggregate.process(state, aggregate.commandCreators.recordStateTransition({ fromState: 'idle', toState: 'completed' })),
+      'saga_transition_from_state_mismatch',
+      { command: 'recordStateTransition', sagaId: 'saga-1', currentState: 'active', fromState: 'idle', toState: 'completed' }
+    );
+
+    expectInvariant(
+      () => aggregate.process(state, aggregate.commandCreators.recordStateTransition({ fromState: 'active', toState: 'active' })),
+      'saga_transition_noop',
+      { command: 'recordStateTransition', sagaId: 'saga-1', currentState: 'active', fromState: 'active', toState: 'active' }
+    );
+
+    const completedEvent = aggregate.process(
+      state,
+      aggregate.commandCreators.recordStateTransition({ fromState: 'active', toState: 'completed', transitionAt: isoAt(5) })
+    )[0];
+    state = aggregate.apply(state, completedEvent);
+
+    expectInvariant(
+      () => aggregate.process(state, aggregate.commandCreators.recordStateTransition({ fromState: 'completed', toState: 'failed' })),
+      'saga_transition_from_terminal_state',
+      { command: 'recordStateTransition', sagaId: 'saga-1', currentState: 'completed', fromState: 'completed', toState: 'failed' }
+    );
+  });
+});

--- a/packages/saga-runtime/test/saga-execution-bridge.integration.test.ts
+++ b/packages/saga-runtime/test/saga-execution-bridge.integration.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  createSagaExecutionBridge,
+  createReferenceAdaptersV1,
+  type SagaAggregateState
+} from '../src';
+
+declare const require: (id: string) => any;
+
+const sagaPackage = require('@redemeine/saga');
+
+const {
+  createSaga,
+  defineOneWay,
+  defineRequestResponse,
+  defineSagaPlugin
+} = sagaPackage as {
+  createSaga: <TState = unknown>(options: Record<string, unknown>) => any;
+  defineOneWay: <TBuild extends (...args: any[]) => unknown>(build: TBuild) => unknown;
+  defineRequestResponse: <TBuild extends (...args: any[]) => unknown>(build: TBuild) => unknown;
+  defineSagaPlugin: (manifest: Record<string, unknown>) => unknown;
+};
+
+const OrderAggregate = {
+  __aggregateType: 'orders',
+  pure: {
+    eventProjectors: {
+      started: (
+        _state: unknown,
+        _event: {
+          payload: { orderId: string; amount: number; customerId: string };
+        }
+      ) => undefined
+    }
+  },
+  commandCreators: {}
+} as const;
+
+const PaymentsPlugin = defineSagaPlugin({
+  plugin_key: 'payments',
+  actions: {
+    authorize: defineRequestResponse((payload: { orderId: string; amount: number }) => payload)
+  }
+});
+
+const TelemetryPlugin = defineSagaPlugin({
+  plugin_key: 'telemetry',
+  actions: {
+    record: defineOneWay((payload: { name: string; customerId: string }) => payload)
+  }
+});
+
+const createBridgeSaga = () => createSaga({
+  identity: {
+    namespace: 'runtime',
+    name: 'bridge_contract',
+    version: 1
+  },
+  plugins: [PaymentsPlugin, TelemetryPlugin] as const
+})
+  .initialState(() => ({ attempts: 0, lastOrderId: '' }))
+  .onResponses({
+    'payments.authorize.ok': () => undefined
+  })
+  .onErrors({
+    'payments.authorize.failed': () => undefined
+  })
+  .on(OrderAggregate, {
+    started: (state: { attempts: number; lastOrderId: string }, event: { payload: { orderId: string; amount: number; customerId: string } }, ctx: any) => {
+      ctx.actions.payments
+        .authorize({ orderId: event.payload.orderId, amount: event.payload.amount })
+        .onResponse(ctx.onResponse['payments.authorize.ok'])
+        .onError(ctx.onError['payments.authorize.failed']);
+
+      ctx.actions.telemetry.record({
+        name: 'order.started',
+        customerId: event.payload.customerId
+      });
+
+      state.attempts += 1;
+      state.lastOrderId = event.payload.orderId;
+    }
+  })
+  .build();
+
+describe('saga execution bridge integration', () => {
+  it('bridges SagaAggregate orchestration with SagaInstance handlers and plugin contracts', async () => {
+    const definition = createBridgeSaga();
+    const adapters = createReferenceAdaptersV1();
+    const bridge = createSagaExecutionBridge({
+      definition,
+      adapters,
+      runtimePlugins: [PaymentsPlugin, TelemetryPlugin] as const
+    });
+
+    const result = await bridge.dispatch({
+      sagaId: 'saga-bridge-1',
+      event: {
+        type: 'orders.started.event',
+        payload: {
+          orderId: 'order-1',
+          amount: 1900,
+          customerId: 'customer-7'
+        },
+        aggregateType: 'orders',
+        aggregateId: 'order-1',
+        eventId: 'evt-1',
+        occurredAt: '2026-01-01T00:00:00.000Z'
+      },
+      nowIso: '2026-01-01T00:00:01.000Z'
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.matchedHandlers).toEqual(['started']);
+    expect(result.sagaState).toEqual({ attempts: 1, lastOrderId: 'order-1' });
+    expect(result.intents.map((intent) => intent.type)).toEqual(['plugin-request', 'plugin-one-way']);
+
+    expect(result.adapterResults).toHaveLength(1);
+    expect(result.adapterResults[0]).toMatchObject({
+      processedIntents: 2,
+      persistedExecutions: ['saga-bridge-1:intent:1', 'saga-bridge-1:intent:2']
+    });
+
+    expect(adapters.sideEffects.listHandled()).toHaveLength(2);
+    expect(adapters.sideEffects.listHandled()[0]).toMatchObject({
+      type: 'plugin-request',
+      plugin_key: 'payments',
+      action_name: 'authorize',
+      routing_metadata: {
+        response_handler_key: 'payments.authorize.ok',
+        error_handler_key: 'payments.authorize.failed'
+      }
+    });
+    expect(adapters.sideEffects.listHandled()[1]).toMatchObject({
+      type: 'plugin-one-way',
+      plugin_key: 'telemetry',
+      action_name: 'record'
+    });
+
+    const aggregateState = bridge.getAggregateState('saga-bridge-1') as SagaAggregateState;
+    expect(aggregateState.id).toBe('saga-bridge-1');
+    expect(aggregateState.totals.observedEvents).toBe(1);
+    expect(aggregateState.totals.intents).toBe(2);
+    expect(aggregateState.recent.intents.map((entry) => entry.intentType).sort()).toEqual([
+      'plugin-one-way',
+      'plugin-request'
+    ]);
+  });
+
+  it('returns deterministic no-op result when no saga handler matches', async () => {
+    const definition = createBridgeSaga();
+    const bridge = createSagaExecutionBridge({
+      definition,
+      runtimePlugins: [PaymentsPlugin, TelemetryPlugin] as const
+    });
+
+    const result = await bridge.dispatch({
+      sagaId: 'saga-bridge-unmatched',
+      event: {
+        type: 'inventory.adjusted.event',
+        payload: { id: 'inv-1' },
+        aggregateType: 'inventory'
+      }
+    });
+
+    expect(result.handled).toBe(false);
+    expect(result.matchedHandlers).toEqual([]);
+    expect(result.intents).toEqual([]);
+    expect(result.adapterResults).toEqual([]);
+    expect(result.sagaState).toBeUndefined();
+    expect(result.aggregateState.id).toBeNull();
+  });
+
+  it('keeps execution ids monotonic across repeated dispatches and traceable to aggregate lifecycle ids', async () => {
+    const definition = createBridgeSaga();
+    const adapters = createReferenceAdaptersV1();
+    const bridge = createSagaExecutionBridge({
+      definition,
+      adapters,
+      runtimePlugins: [PaymentsPlugin, TelemetryPlugin] as const
+    });
+
+    const first = await bridge.dispatch({
+      sagaId: 'saga-bridge-repeat',
+      event: {
+        type: 'orders.started.event',
+        payload: { orderId: 'order-a', amount: 100, customerId: 'customer-1' },
+        aggregateType: 'orders',
+        aggregateId: 'order-a',
+        eventId: 'evt-a'
+      }
+    });
+
+    const second = await bridge.dispatch({
+      sagaId: 'saga-bridge-repeat',
+      event: {
+        type: 'orders.started.event',
+        payload: { orderId: 'order-b', amount: 200, customerId: 'customer-2' },
+        aggregateType: 'orders',
+        aggregateId: 'order-b',
+        eventId: 'evt-b'
+      }
+    });
+
+    expect(first.adapterResults[0]?.persistedExecutions).toEqual([
+      'saga-bridge-repeat:intent:1',
+      'saga-bridge-repeat:intent:2'
+    ]);
+    expect(second.adapterResults[0]?.persistedExecutions).toEqual([
+      'saga-bridge-repeat:intent:3',
+      'saga-bridge-repeat:intent:4'
+    ]);
+
+    const persisted = adapters.persistence.listIntentExecutionsBySagaId('saga-bridge-repeat');
+    const persistedIds = persisted
+      .map((entry) => entry.id)
+      .sort((a, b) => a.localeCompare(b));
+
+    expect(persistedIds).toEqual([
+      'saga-bridge-repeat:intent:1',
+      'saga-bridge-repeat:intent:2',
+      'saga-bridge-repeat:intent:3',
+      'saga-bridge-repeat:intent:4'
+    ]);
+
+    const aggregateState = bridge.getAggregateState('saga-bridge-repeat');
+    const lifecycleIds = aggregateState.recent.intents
+      .map((entry) => entry.intentId)
+      .sort((a, b) => a.localeCompare(b));
+
+    expect(lifecycleIds).toEqual(persistedIds);
+    expect(aggregateState.totals.intents).toBe(4);
+  });
+});

--- a/packages/saga-runtime/test/saga-runtime-domain-contracts.test.ts
+++ b/packages/saga-runtime/test/saga-runtime-domain-contracts.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from '@jest/globals';
+import type {
+  IntentExecution,
+  IntentExecutionCreateCommandPayload,
+  IntentExecutionMarkTerminalCommandPayload,
+  IntentExecutionProjection,
+  IntentExecutionRecordAttemptCommandPayload,
+  IntentExecutionRecordResponseRefCommandPayload,
+  IntentExecutionResponseRef,
+  IntentExecutionRetryPolicySnapshot,
+  IntentExecutionStatus,
+  SagaAggregateProjection,
+  SagaCreateInstanceCommandPayload,
+  SagaIntentLifecycleRecord
+} from '../src/SagaAggregate';
+
+describe('saga-runtime v1 domain contract types', () => {
+  it('uses id as saga aggregate identity in create payload', () => {
+    const createPayload: SagaCreateInstanceCommandPayload = {
+      id: 'saga-123',
+      sagaType: 'order_fulfillment'
+    };
+
+    expect(createPayload.id).toBe('saga-123');
+    expect('sagaId' in (createPayload as unknown as Record<string, unknown>)).toBe(false);
+  });
+
+  it('keeps intent execution retryPolicy snapshot and responseRef fields', () => {
+    const retryPolicySnapshot: IntentExecutionRetryPolicySnapshot = {
+      maxAttempts: 5,
+      initialDelayMs: 100,
+      maxDelayMs: 1000,
+      backoffMultiplier: 2
+    };
+
+    const responseRef: IntentExecutionResponseRef = {
+      responseKey: 'dispatch_result',
+      responseId: 'resp-7'
+    };
+
+    const intentExecution: IntentExecution = {
+      id: 'exec-1',
+      sagaId: 'saga-123',
+      intentId: 'intent-42',
+      status: 'in_progress',
+      attempt: 2,
+      retryPolicySnapshot,
+      responseRef,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:01.000Z'
+    };
+
+    expect(intentExecution.retryPolicySnapshot?.maxAttempts).toBe(5);
+    expect(intentExecution.responseRef?.responseId).toBe('resp-7');
+  });
+
+  it('keeps command payload contracts without top-level discriminators', () => {
+    const createPayload: IntentExecutionCreateCommandPayload = {
+      id: 'exec-1',
+      sagaId: 'saga-123',
+      intentId: 'intent-42'
+    };
+
+    const attemptPayload: IntentExecutionRecordAttemptCommandPayload = {
+      id: 'exec-1',
+      attempt: 3,
+      status: 'in_progress'
+    };
+
+    const responsePayload: IntentExecutionRecordResponseRefCommandPayload = {
+      id: 'exec-1',
+      responseRef: {
+        responseKey: 'payment',
+        responseId: 'resp-22'
+      }
+    };
+
+    const terminalPayload: IntentExecutionMarkTerminalCommandPayload = {
+      id: 'exec-1',
+      status: 'succeeded'
+    };
+
+    for (const payload of [createPayload, attemptPayload, responsePayload, terminalPayload]) {
+      expect('type' in (payload as unknown as Record<string, unknown>)).toBe(false);
+      expect('kind' in (payload as unknown as Record<string, unknown>)).toBe(false);
+    }
+  });
+
+  it('uses snake_case status values for intent execution lifecycle enums', () => {
+    const inProgress: IntentExecutionStatus = 'in_progress';
+    const timedOut: IntentExecutionStatus = 'timed_out';
+
+    expect(inProgress).toBe('in_progress');
+    expect(timedOut).toBe('timed_out');
+  });
+
+  it('allows projection interfaces keyed by aggregate identity id', () => {
+    const sagaProjection: SagaAggregateProjection = {
+      getById: (_id) => null,
+      upsert: () => undefined
+    };
+
+    const executionProjection: IntentExecutionProjection = {
+      getById: (_id) => null,
+      upsert: () => undefined
+    };
+
+    expect(sagaProjection.getById('saga-123')).toBeNull();
+    expect(executionProjection.getById('exec-1')).toBeNull();
+  });
+
+  it('supports responseRef and retryPolicySnapshot on saga intent lifecycle records', () => {
+    const lifecycleRecord: SagaIntentLifecycleRecord = {
+      intentId: 'intent-42',
+      intentType: 'dispatch',
+      stage: 'acknowledged',
+      executionId: 'exec-1',
+      retryPolicySnapshot: { maxAttempts: 4 },
+      responseRef: { responseKey: 'inventory', responseId: 'resp-44' },
+      recordedAt: '2026-01-01T00:00:02.000Z'
+    };
+
+    expect(lifecycleRecord.executionId).toBe('exec-1');
+    expect(lifecycleRecord.retryPolicySnapshot?.maxAttempts).toBe(4);
+    expect(lifecycleRecord.responseRef?.responseKey).toBe('inventory');
+  });
+});

--- a/packages/saga-runtime/test/scheduler-policy-evaluator.test.ts
+++ b/packages/saga-runtime/test/scheduler-policy-evaluator.test.ts
@@ -144,4 +144,30 @@ describe('scheduler policy evaluator', () => {
       }
     ]);
   });
+
+  it('enforces anti-starvation across tenants under weighted fairness pressure', () => {
+    const hotCandidates = Array.from({ length: 12 }, (_, index) =>
+      candidate(`h-${index + 1}`, 'tenant-hot', 100 - index, `2026-01-01T00:00:${String(index + 1).padStart(2, '0')}.000Z`)
+    );
+    const coldCandidates = Array.from({ length: 4 }, (_, index) =>
+      candidate(`c-${index + 1}`, 'tenant-cold', 10 - index, `2026-01-01T00:01:${String(index + 1).padStart(2, '0')}.000Z`)
+    );
+
+    const result = evaluateSchedulerPolicy({
+      maxDecisions: 8,
+      candidates: [...hotCandidates, ...coldCandidates],
+      tenantPolicies: {
+        'tenant-hot': { fairnessWeight: 100, rateLimit: { limit: 100 } },
+        'tenant-cold': { fairnessWeight: 1, rateLimit: { limit: 100 } }
+      }
+    });
+
+    const selectedByTenant = result.selected.reduce<Record<string, number>>((acc, entry) => {
+      acc[entry.candidate.tenantId] = (acc[entry.candidate.tenantId] ?? 0) + 1;
+      return acc;
+    }, {});
+
+    expect(selectedByTenant['tenant-cold']).toBeGreaterThanOrEqual(1);
+    expect(result.selected.some((entry) => entry.candidate.tenantId === 'tenant-cold')).toBe(true);
+  });
 });

--- a/packages/saga-runtime/test/scheduler-policy-evaluator.test.ts
+++ b/packages/saga-runtime/test/scheduler-policy-evaluator.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  evaluateSchedulerPolicy,
+  SCHEDULER_UNLIMITED_REMAINING_RATE_LIMIT,
+  type SchedulerDecisionCandidate
+} from '../src/schedulerPolicyEvaluator';
+
+const candidate = (
+  id: string,
+  tenantId: string,
+  priority: number,
+  runAt: string,
+  sagaId = `${tenantId}-${id}`
+): SchedulerDecisionCandidate => ({
+  id,
+  tenantId,
+  priority,
+  runAt,
+  sagaId
+});
+
+describe('scheduler policy evaluator', () => {
+  it('produces deterministic tenant-fair ordering while honoring per-tenant priority', () => {
+    const result = evaluateSchedulerPolicy({
+      maxDecisions: 4,
+      candidates: [
+        candidate('a-1', 'tenant-a', 100, '2026-01-01T00:00:01.000Z'),
+        candidate('a-2', 'tenant-a', 1, '2026-01-01T00:00:02.000Z'),
+        candidate('b-1', 'tenant-b', 50, '2026-01-01T00:00:01.000Z'),
+        candidate('b-2', 'tenant-b', 49, '2026-01-01T00:00:02.000Z')
+      ],
+      tenantPolicies: {
+        'tenant-a': { fairnessWeight: 1 },
+        'tenant-b': { fairnessWeight: 1 }
+      }
+    });
+
+    expect(result.selected.map((entry) => entry.candidate.id)).toEqual(['a-1', 'b-1', 'b-2', 'a-2']);
+    expect(result.selected.map((entry) => entry.order)).toEqual([1, 2, 3, 4]);
+    expect(result.deferred).toHaveLength(0);
+    expect(result.tenantSummary).toEqual({
+      'tenant-a': {
+        selected: 2,
+        deferredRateLimited: 0,
+        remainingRateLimit: SCHEDULER_UNLIMITED_REMAINING_RATE_LIMIT
+      },
+      'tenant-b': {
+        selected: 2,
+        deferredRateLimited: 0,
+        remainingRateLimit: SCHEDULER_UNLIMITED_REMAINING_RATE_LIMIT
+      }
+    });
+  });
+
+  it('treats explicit rateLimit.limit=0 as hard zero capacity and defers deterministically', () => {
+    const result = evaluateSchedulerPolicy({
+      maxDecisions: 2,
+      candidates: [
+        candidate('z-1', 'tenant-z', 100, '2026-01-01T00:00:01.000Z'),
+        candidate('a-1', 'tenant-a', 10, '2026-01-01T00:00:01.000Z')
+      ],
+      tenantPolicies: {
+        'tenant-z': {
+          fairnessWeight: 1,
+          rateLimit: { limit: 0 }
+        },
+        'tenant-a': {
+          fairnessWeight: 1,
+          rateLimit: { limit: 1 }
+        }
+      }
+    });
+
+    expect(result.selected.map((entry) => entry.candidate.id)).toEqual(['a-1']);
+    expect(result.deferred).toEqual([
+      {
+        candidate: expect.objectContaining({ id: 'z-1', tenantId: 'tenant-z' }),
+        reason: 'tenant_rate_limited'
+      }
+    ]);
+    expect(result.tenantSummary).toEqual({
+      'tenant-a': {
+        selected: 1,
+        deferredRateLimited: 0,
+        remainingRateLimit: 0
+      },
+      'tenant-z': {
+        selected: 0,
+        deferredRateLimited: 1,
+        remainingRateLimit: 0
+      }
+    });
+  });
+
+  it('marks remaining candidates as tenant_rate_limited when quota is exhausted', () => {
+    const result = evaluateSchedulerPolicy({
+      maxDecisions: 5,
+      candidates: [
+        candidate('a-1', 'tenant-a', 10, '2026-01-01T00:00:01.000Z'),
+        candidate('a-2', 'tenant-a', 9, '2026-01-01T00:00:02.000Z'),
+        candidate('b-1', 'tenant-b', 5, '2026-01-01T00:00:01.000Z')
+      ],
+      tenantPolicies: {
+        'tenant-a': {
+          fairnessWeight: 1,
+          rateLimit: { limit: 1 }
+        },
+        'tenant-b': {
+          fairnessWeight: 1,
+          rateLimit: { limit: 5 }
+        }
+      }
+    });
+
+    expect(result.selected.map((entry) => entry.candidate.id)).toEqual(['a-1', 'b-1']);
+    expect(result.deferred).toEqual([
+      {
+        candidate: expect.objectContaining({ id: 'a-2', tenantId: 'tenant-a' }),
+        reason: 'tenant_rate_limited'
+      }
+    ]);
+    expect(result.tenantSummary['tenant-a']).toEqual({
+      selected: 1,
+      deferredRateLimited: 1,
+      remainingRateLimit: 0
+    });
+  });
+
+  it('marks unscheduled candidates as global_capacity_exhausted when maxDecisions is reached', () => {
+    const result = evaluateSchedulerPolicy({
+      maxDecisions: 2,
+      candidates: [
+        candidate('a-1', 'tenant-a', 10, '2026-01-01T00:00:01.000Z'),
+        candidate('b-1', 'tenant-b', 9, '2026-01-01T00:00:01.000Z'),
+        candidate('c-1', 'tenant-c', 8, '2026-01-01T00:00:01.000Z')
+      ]
+    });
+
+    expect(result.selected.map((entry) => entry.candidate.id)).toEqual(['a-1', 'b-1']);
+    expect(result.deferred).toEqual([
+      {
+        candidate: expect.objectContaining({ id: 'c-1', tenantId: 'tenant-c' }),
+        reason: 'global_capacity_exhausted'
+      }
+    ]);
+  });
+});

--- a/packages/saga-runtime/test/scheduler-scale-validation.harness.ts
+++ b/packages/saga-runtime/test/scheduler-scale-validation.harness.ts
@@ -1,0 +1,375 @@
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  evaluateSchedulerPolicy,
+  type SchedulerDecisionCandidate,
+  type SchedulerPolicyEvaluatorInput,
+  type SchedulerTenantPolicy
+} from '../src/schedulerPolicyEvaluator';
+
+interface TenantProfile {
+  readonly id: string;
+  readonly share: number;
+  readonly fairnessWeight: number;
+  readonly perMinuteRateLimit: number;
+  readonly basePriority: number;
+}
+
+interface TenantScaleStats {
+  arrived: number;
+  selected: number;
+  deferredRateLimited: number;
+  deferredGlobalCapacity: number;
+  maxConsecutiveBlockedMinutes: number;
+}
+
+interface ScaleValidationOptions {
+  readonly seed?: number;
+  readonly minutes?: number;
+  readonly baseArrivalsPerMinute?: number;
+  readonly maxDecisionsPerMinute?: number;
+}
+
+export interface ScaleValidationSummary {
+  readonly scenario: {
+    readonly seed: number;
+    readonly minutes: number;
+    readonly maxDecisionsPerMinute: number;
+    readonly baseArrivalsPerMinute: number;
+    readonly targetSagasPerDay: number;
+  };
+  readonly totals: {
+    readonly arrived: number;
+    readonly selected: number;
+    readonly deferredRateLimited: number;
+    readonly deferredGlobalCapacity: number;
+    readonly finalBacklog: number;
+    readonly projectedSagasPerDay: number;
+  };
+  readonly throughput: {
+    readonly minPerMinute: number;
+    readonly maxPerMinute: number;
+    readonly averagePerMinute: number;
+    readonly p50PerMinute: number;
+    readonly p95PerMinute: number;
+    readonly minutesAtOrAboveTargetRate: number;
+  };
+  readonly fairness: {
+    readonly tenantsWithArrivalsButNoSelection: readonly string[];
+    readonly worstBlockedTenant: {
+      readonly tenantId: string;
+      readonly maxConsecutiveBlockedMinutes: number;
+    };
+  };
+  readonly methodology: {
+    readonly model: string;
+    readonly workload: string;
+    readonly policyCoverage: readonly string[];
+  };
+  readonly tenantStats: Readonly<Record<string, TenantScaleStats>>;
+}
+
+const TARGET_SAGAS_PER_DAY = 200_000;
+const TARGET_PER_MINUTE = TARGET_SAGAS_PER_DAY / 1_440;
+const DEFAULT_SEED = 13;
+const DEFAULT_MINUTES = 1_440;
+const DEFAULT_BASE_ARRIVALS_PER_MINUTE = 160;
+const DEFAULT_MAX_DECISIONS_PER_MINUTE = 165;
+
+const TENANTS: readonly TenantProfile[] = [
+  { id: 'tenant-enterprise-a', share: 0.30, fairnessWeight: 7, perMinuteRateLimit: 58, basePriority: 95 },
+  { id: 'tenant-enterprise-b', share: 0.22, fairnessWeight: 5, perMinuteRateLimit: 45, basePriority: 90 },
+  { id: 'tenant-growth-a', share: 0.15, fairnessWeight: 3, perMinuteRateLimit: 30, basePriority: 75 },
+  { id: 'tenant-growth-b', share: 0.11, fairnessWeight: 2, perMinuteRateLimit: 23, basePriority: 70 },
+  { id: 'tenant-smb-a', share: 0.08, fairnessWeight: 1, perMinuteRateLimit: 13, basePriority: 55 },
+  { id: 'tenant-smb-b', share: 0.07, fairnessWeight: 1, perMinuteRateLimit: 11, basePriority: 52 },
+  { id: 'tenant-longtail-a', share: 0.04, fairnessWeight: 1, perMinuteRateLimit: 6, basePriority: 40 },
+  { id: 'tenant-longtail-b', share: 0.03, fairnessWeight: 1, perMinuteRateLimit: 5, basePriority: 38 }
+];
+
+const createSeededRandom = (seed: number): (() => number) => {
+  let state = seed >>> 0;
+  return () => {
+    state = ((state * 1_664_525) + 1_013_904_223) >>> 0;
+    return state / 4_294_967_296;
+  };
+};
+
+const percentile = (values: readonly number[], quantile: number): number => {
+  if (values.length === 0) {
+    return 0;
+  }
+
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.floor(quantile * (sorted.length - 1))));
+  return sorted[index] ?? 0;
+};
+
+const burstAdjustment = (tenantId: string, minute: number): number => {
+  if (tenantId === 'tenant-enterprise-a' && minute % 180 < 24) {
+    return 8;
+  }
+
+  if (tenantId === 'tenant-enterprise-b' && minute % 240 >= 45 && minute % 240 < 75) {
+    return 6;
+  }
+
+  if (tenantId.startsWith('tenant-longtail') && minute % 90 < 10) {
+    return 2;
+  }
+
+  return 0;
+};
+
+const globalSpikeMultiplier = (minute: number): number => {
+  const cycleMinute = minute % 360;
+  if (cycleMinute < 12) {
+    return 1.2;
+  }
+
+  return 1;
+};
+
+export function runSchedulerScaleValidation(
+  options: ScaleValidationOptions = {}
+): ScaleValidationSummary {
+  const seed = options.seed ?? DEFAULT_SEED;
+  const minutes = options.minutes ?? DEFAULT_MINUTES;
+  const baseArrivalsPerMinute = options.baseArrivalsPerMinute ?? DEFAULT_BASE_ARRIVALS_PER_MINUTE;
+  const maxDecisionsPerMinute = options.maxDecisionsPerMinute ?? DEFAULT_MAX_DECISIONS_PER_MINUTE;
+
+  const random = createSeededRandom(seed);
+  const startMs = Date.parse('2026-01-01T00:00:00.000Z');
+
+  const tenantPolicies: Record<string, SchedulerTenantPolicy> = Object.fromEntries(
+    TENANTS.map((tenant) => [tenant.id, {
+      fairnessWeight: tenant.fairnessWeight,
+      rateLimit: { limit: tenant.perMinuteRateLimit }
+    }])
+  );
+
+  const tenantStats: Record<string, TenantScaleStats> = Object.fromEntries(
+    TENANTS.map((tenant) => [tenant.id, {
+      arrived: 0,
+      selected: 0,
+      deferredRateLimited: 0,
+      deferredGlobalCapacity: 0,
+      maxConsecutiveBlockedMinutes: 0
+    }])
+  );
+
+  const blockedMinutes: Record<string, number> = Object.fromEntries(TENANTS.map((tenant) => [tenant.id, 0]));
+  const perMinuteSelected: number[] = [];
+
+  let pending: SchedulerDecisionCandidate[] = [];
+  let totalArrived = 0;
+  let totalSelected = 0;
+  let totalDeferredRateLimited = 0;
+  let totalDeferredGlobalCapacity = 0;
+  let globalSequence = 0;
+
+  for (let minute = 0; minute < minutes; minute += 1) {
+    const minuteStartMs = startMs + (minute * 60_000);
+    const arrivalsThisMinute: SchedulerDecisionCandidate[] = [];
+    const arrivalsByTenant: Record<string, number> = Object.fromEntries(TENANTS.map((tenant) => [tenant.id, 0]));
+
+    const spikeMultiplier = globalSpikeMultiplier(minute);
+
+    for (const tenant of TENANTS) {
+      const expected = baseArrivalsPerMinute * tenant.share * spikeMultiplier;
+      const jitter = Math.floor(random() * 7) - 3;
+      const burst = burstAdjustment(tenant.id, minute);
+      const arrivals = Math.max(0, Math.round(expected + jitter + burst));
+
+      arrivalsByTenant[tenant.id] = arrivals;
+      tenantStats[tenant.id].arrived += arrivals;
+      totalArrived += arrivals;
+
+      for (let index = 0; index < arrivals; index += 1) {
+        globalSequence += 1;
+        const runAtMs = minuteStartMs + (index * 30);
+        arrivalsThisMinute.push({
+          id: `cand-${minute}-${globalSequence}`,
+          sagaId: `saga-${tenant.id}-${globalSequence}`,
+          tenantId: tenant.id,
+          runAt: new Date(runAtMs).toISOString(),
+          priority: tenant.basePriority - Math.floor(random() * 6)
+        });
+      }
+    }
+
+    const backlogBefore = pending.reduce<Record<string, number>>((acc, candidate) => {
+      acc[candidate.tenantId] = (acc[candidate.tenantId] ?? 0) + 1;
+      return acc;
+    }, {});
+
+    const input: SchedulerPolicyEvaluatorInput = {
+      maxDecisions: maxDecisionsPerMinute,
+      candidates: [...pending, ...arrivalsThisMinute],
+      tenantPolicies
+    };
+
+    const result = evaluateSchedulerPolicy(input);
+    const selectedByTenant: Record<string, number> = Object.fromEntries(TENANTS.map((tenant) => [tenant.id, 0]));
+
+    for (const selection of result.selected) {
+      selectedByTenant[selection.candidate.tenantId] += 1;
+      tenantStats[selection.candidate.tenantId].selected += 1;
+      totalSelected += 1;
+    }
+
+    for (const deferred of result.deferred) {
+      if (deferred.reason === 'tenant_rate_limited') {
+        tenantStats[deferred.candidate.tenantId].deferredRateLimited += 1;
+        totalDeferredRateLimited += 1;
+      } else {
+        tenantStats[deferred.candidate.tenantId].deferredGlobalCapacity += 1;
+        totalDeferredGlobalCapacity += 1;
+      }
+    }
+
+    for (const tenant of TENANTS) {
+      const tenantId = tenant.id;
+      const hadDemand = (backlogBefore[tenantId] ?? 0) + (arrivalsByTenant[tenantId] ?? 0) > 0;
+      const gotSelection = (selectedByTenant[tenantId] ?? 0) > 0;
+
+      if (hadDemand && !gotSelection) {
+        blockedMinutes[tenantId] += 1;
+      } else {
+        blockedMinutes[tenantId] = 0;
+      }
+
+      tenantStats[tenantId].maxConsecutiveBlockedMinutes = Math.max(
+        tenantStats[tenantId].maxConsecutiveBlockedMinutes,
+        blockedMinutes[tenantId]
+      );
+    }
+
+    perMinuteSelected.push(result.selected.length);
+    pending = result.deferred.map((entry) => entry.candidate);
+  }
+
+  const selectedMin = perMinuteSelected.length > 0 ? Math.min(...perMinuteSelected) : 0;
+  const selectedMax = perMinuteSelected.length > 0 ? Math.max(...perMinuteSelected) : 0;
+  const selectedAverage = perMinuteSelected.length > 0
+    ? Number((perMinuteSelected.reduce((sum, value) => sum + value, 0) / perMinuteSelected.length).toFixed(2))
+    : 0;
+
+  const tenantsWithArrivalsButNoSelection = TENANTS
+    .filter((tenant) => tenantStats[tenant.id].arrived > 0 && tenantStats[tenant.id].selected === 0)
+    .map((tenant) => tenant.id);
+
+  const worstBlockedTenant = TENANTS
+    .map((tenant) => ({
+      tenantId: tenant.id,
+      maxConsecutiveBlockedMinutes: tenantStats[tenant.id].maxConsecutiveBlockedMinutes
+    }))
+    .sort((left, right) => right.maxConsecutiveBlockedMinutes - left.maxConsecutiveBlockedMinutes)[0];
+
+  return {
+    scenario: {
+      seed,
+      minutes,
+      maxDecisionsPerMinute,
+      baseArrivalsPerMinute,
+      targetSagasPerDay: TARGET_SAGAS_PER_DAY
+    },
+    totals: {
+      arrived: totalArrived,
+      selected: totalSelected,
+      deferredRateLimited: totalDeferredRateLimited,
+      deferredGlobalCapacity: totalDeferredGlobalCapacity,
+      finalBacklog: pending.length,
+      projectedSagasPerDay: Math.round(selectedAverage * 1_440)
+    },
+    throughput: {
+      minPerMinute: selectedMin,
+      maxPerMinute: selectedMax,
+      averagePerMinute: selectedAverage,
+      p50PerMinute: percentile(perMinuteSelected, 0.5),
+      p95PerMinute: percentile(perMinuteSelected, 0.95),
+      minutesAtOrAboveTargetRate: perMinuteSelected.filter((value) => value >= TARGET_PER_MINUTE).length
+    },
+    fairness: {
+      tenantsWithArrivalsButNoSelection,
+      worstBlockedTenant
+    },
+    methodology: {
+      model: 'Deterministic minute-level simulation with carry-over backlog and seeded pseudo-random arrivals',
+      workload: '8-tenant mixed profile, weighted shares, periodic bursts, and recurring global spikes',
+      policyCoverage: ['fairness_weight', 'tenant_rate_limit', 'global_capacity_limit', 'anti_starvation_rotation']
+    },
+    tenantStats
+  };
+}
+
+const formatNumber = (value: number): string => value.toLocaleString('en-US');
+
+export function toScaleValidationMarkdown(summary: ScaleValidationSummary): string {
+  const throughputCoverage = `${summary.throughput.minutesAtOrAboveTargetRate}/${summary.scenario.minutes}`;
+  const tenantRows = Object.entries(summary.tenantStats)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([tenantId, stats]) =>
+      `| ${tenantId} | ${formatNumber(stats.arrived)} | ${formatNumber(stats.selected)} | ${formatNumber(stats.deferredRateLimited)} | ${formatNumber(stats.deferredGlobalCapacity)} | ${stats.maxConsecutiveBlockedMinutes} |`
+    )
+    .join('\n');
+
+  return [
+    '# redemeine-b13 Scale Validation Report',
+    '',
+    '## Scenario',
+    `- Seed: ${summary.scenario.seed}`,
+    `- Horizon: ${summary.scenario.minutes} minutes (24h representative simulation)`,
+    `- Base arrivals/minute: ${summary.scenario.baseArrivalsPerMinute}`,
+    `- Scheduler max decisions/minute: ${summary.scenario.maxDecisionsPerMinute}`,
+    `- Target: ${formatNumber(summary.scenario.targetSagasPerDay)} sagas/day`,
+    '',
+    '## Throughput envelope',
+    `- Arrived: ${formatNumber(summary.totals.arrived)}`,
+    `- Selected (processed): ${formatNumber(summary.totals.selected)}`,
+    `- Projected sagas/day from average throughput: ${formatNumber(summary.totals.projectedSagasPerDay)}`,
+    `- Final backlog after horizon: ${formatNumber(summary.totals.finalBacklog)}`,
+    `- Throughput min/avg/p95/max per minute: ${summary.throughput.minPerMinute}/${summary.throughput.averagePerMinute}/${summary.throughput.p95PerMinute}/${summary.throughput.maxPerMinute}`,
+    `- Minutes at or above target rate (${TARGET_PER_MINUTE.toFixed(2)} per minute): ${throughputCoverage}`,
+    '',
+    '## Methodology',
+    `- Model: ${summary.methodology.model}`,
+    `- Workload: ${summary.methodology.workload}`,
+    `- Policy coverage: ${summary.methodology.policyCoverage.join(', ')}`,
+    '',
+    '## Policy behavior under load',
+    `- Deferred due to tenant rate limits: ${formatNumber(summary.totals.deferredRateLimited)}`,
+    `- Deferred due to global capacity: ${formatNumber(summary.totals.deferredGlobalCapacity)}`,
+    `- Tenants with arrivals but zero selections: ${summary.fairness.tenantsWithArrivalsButNoSelection.length === 0 ? 'none' : summary.fairness.tenantsWithArrivalsButNoSelection.join(', ')}`,
+    `- Worst blocked streak: ${summary.fairness.worstBlockedTenant.tenantId} (${summary.fairness.worstBlockedTenant.maxConsecutiveBlockedMinutes} consecutive minutes with demand but no selection)`,
+    '',
+    '## Per-tenant stats',
+    '| Tenant | Arrived | Selected | Deferred (rate-limited) | Deferred (global cap) | Max blocked streak (minutes) |',
+    '| --- | ---: | ---: | ---: | ---: | ---: |',
+    tenantRows,
+    ''
+  ].join('\n');
+}
+
+const parseArgValue = (args: readonly string[], flag: string): string | undefined => {
+  const index = args.findIndex((entry) => entry === flag);
+  if (index < 0) {
+    return undefined;
+  }
+
+  return args[index + 1];
+};
+
+if (import.meta.main) {
+  const args = process.argv.slice(2);
+  const summary = runSchedulerScaleValidation();
+
+  console.log(JSON.stringify(summary, null, 2));
+
+  const markdownPath = parseArgValue(args, '--markdown');
+  if (markdownPath) {
+    const markdown = toScaleValidationMarkdown(summary);
+    writeFileSync(resolve(markdownPath), markdown, 'utf8');
+    console.log(`Wrote scale validation markdown to ${resolve(markdownPath)}`);
+  }
+}

--- a/packages/saga/src/createSaga.ts
+++ b/packages/saga/src/createSaga.ts
@@ -999,8 +999,9 @@ function createPluginActionsContext(
 ): Record<string, Record<string, (...args: any[]) => unknown>> {
   const actionsContext: Record<string, Record<string, (...args: any[]) => unknown>> = Object.create(null);
 
-  for (const plugin of plugins) {
-    const pluginActions: Record<string, (...args: any[]) => unknown> = Object.create(null);
+  for (const plugin of composePluginManifestsWithPrecedence(plugins)) {
+    const pluginActions: Record<string, (...args: any[]) => unknown> =
+      actionsContext[plugin.plugin_key] ?? Object.create(null);
 
     for (const actionName of Object.keys(plugin.actions)) {
       const actionDescriptor = plugin.actions[actionName] as SagaPluginActionDescriptorWithHelperMetadata;
@@ -1087,6 +1088,32 @@ function createPluginActionsContext(
   }
 
   return actionsContext;
+}
+
+function composePluginManifestsWithPrecedence(plugins: SagaPluginManifestList): SagaPluginManifestList {
+  const composed = new Map<string, SagaPluginManifest>();
+
+  for (const plugin of plugins) {
+    const existing = composed.get(plugin.plugin_key);
+    if (existing === undefined) {
+      composed.set(plugin.plugin_key, {
+        ...plugin,
+        actions: { ...plugin.actions }
+      });
+      continue;
+    }
+
+    composed.set(plugin.plugin_key, {
+      ...existing,
+      ...plugin,
+      actions: {
+        ...existing.actions,
+        ...plugin.actions
+      }
+    });
+  }
+
+  return Array.from(composed.values());
 }
 
 function createResponseHandlerTokenNamespace<
@@ -1600,7 +1627,7 @@ function resolveSagaIdentity(options: CreateSagaOptions<SagaPluginManifestList>)
 function createSagaPluginRegistry<TPlugins extends SagaPluginManifestList>(
   plugins: TPlugins
 ): SagaPluginRegistryFromManifests<TPlugins> {
-  return plugins.map((plugin) => ({
+  return composePluginManifestsWithPrecedence(plugins).map((plugin) => ({
     plugin_key: plugin.plugin_key,
     plugin_kind: 'manifest',
     action_names: Object.keys(plugin.actions),

--- a/packages/saga/src/index.ts
+++ b/packages/saga/src/index.ts
@@ -107,6 +107,13 @@ export {
   type SagaStartPolicyRestart
 } from './startPolicy';
 export {
+  type SagaSchedulerTriggerPolicyContract,
+  type SagaTriggerMisfirePolicy,
+  type SagaTriggerMisfirePolicyCatchUpAll,
+  type SagaTriggerMisfirePolicyCatchUpBounded,
+  type SagaTriggerMisfirePolicyLatestOnly,
+  type SagaTriggerMisfirePolicySkipUntilNext,
+  type SagaTriggerRestartPolicy,
   type SagaTriggerStartContract
 } from './triggerContracts';
 export {

--- a/packages/saga/src/triggerContracts.ts
+++ b/packages/saga/src/triggerContracts.ts
@@ -1,5 +1,38 @@
 import type { SagaStartPolicy } from './startPolicy';
 
+export type SagaTriggerMisfirePolicy =
+  | SagaTriggerMisfirePolicyCatchUpAll
+  | SagaTriggerMisfirePolicyCatchUpBounded
+  | SagaTriggerMisfirePolicyLatestOnly
+  | SagaTriggerMisfirePolicySkipUntilNext;
+
+export interface SagaTriggerMisfirePolicyCatchUpAll {
+  readonly mode: 'catch_up_all';
+}
+
+export interface SagaTriggerMisfirePolicyCatchUpBounded {
+  readonly mode: 'catch_up_bounded';
+  readonly maxCatchUpCount: number;
+}
+
+export interface SagaTriggerMisfirePolicyLatestOnly {
+  readonly mode: 'latest_only';
+}
+
+export interface SagaTriggerMisfirePolicySkipUntilNext {
+  readonly mode: 'skip_until_next';
+}
+
+export interface SagaTriggerRestartPolicy {
+  readonly mode?: 'graceful' | 'force';
+  readonly reason?: string;
+}
+
+export interface SagaSchedulerTriggerPolicyContract {
+  readonly restart?: SagaTriggerRestartPolicy;
+  readonly misfire?: SagaTriggerMisfirePolicy;
+}
+
 /**
  * Shared trigger contract for saga-start definitions.
  *
@@ -8,4 +41,5 @@ import type { SagaStartPolicy } from './startPolicy';
  */
 export interface SagaTriggerStartContract {
   readonly startPolicy?: SagaStartPolicy;
+  readonly schedulerPolicy?: SagaSchedulerTriggerPolicyContract;
 }

--- a/packages/saga/test/plugin-registry-precedence.test.ts
+++ b/packages/saga/test/plugin-registry-precedence.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  createSaga,
+  defineOneWay,
+  defineSagaPlugin,
+  runSagaHandler,
+  type CanonicalSagaIdentityInput,
+  type SagaAggregateEventByName,
+  type SagaPluginOneWayIntent
+} from '../src';
+
+const REGISTRY_PRECEDENCE_IDENTITY: CanonicalSagaIdentityInput = {
+  namespace: 'plugins',
+  name: 'plugin_registry_precedence',
+  version: 1
+};
+
+const EventAggregate = {
+  __aggregateType: 'event',
+  pure: {
+    eventProjectors: {
+      received: (_state: unknown, _event: { payload: { id: string } }) => undefined
+    }
+  },
+  commandCreators: {}
+} as const;
+
+const HttpPluginV1 = defineSagaPlugin({
+  plugin_key: 'http',
+  version: '1.0.0',
+  actions: {
+    get: defineOneWay((url: string) => ({ url, source: 'v1' as const })),
+    post: defineOneWay((url: string) => ({ url, source: 'v1' as const }))
+  }
+});
+
+const HttpPluginV2 = defineSagaPlugin({
+  plugin_key: 'http',
+  version: '2.0.0',
+  actions: {
+    get: defineOneWay((url: string) => ({ url, source: 'v2' as const })),
+    put: defineOneWay((url: string) => ({ url, source: 'v2' as const }))
+  }
+});
+
+describe('plugin registry composition and precedence', () => {
+  it('composes duplicate plugin keys deterministically and uses last manifest override precedence', async () => {
+    const saga = createSaga({
+      identity: REGISTRY_PRECEDENCE_IDENTITY,
+      plugins: [HttpPluginV1, HttpPluginV2] as const
+    })
+      .initialState(() => ({ attempts: 0 }))
+      .on(EventAggregate, {
+        received: async (state, _event, ctx) => {
+          const httpActions = ctx.actions.http as unknown as {
+            get: (url: string) => SagaPluginOneWayIntent<'http', 'get', { url: string; source: 'v1' | 'v2' }>;
+            post: (url: string) => SagaPluginOneWayIntent<'http', 'post', { url: string; source: 'v1' | 'v2' }>;
+            put: (url: string) => SagaPluginOneWayIntent<'http', 'put', { url: string; source: 'v1' | 'v2' }>;
+          };
+
+          const getIntent = httpActions.get('https://example.com/get');
+          const postIntent = httpActions.post('https://example.com/post');
+          const putIntent = httpActions.put('https://example.com/put');
+
+          expect(getIntent.execution_payload.source).toBe('v2');
+          expect(postIntent.execution_payload.source).toBe('v1');
+          expect(putIntent.execution_payload.source).toBe('v2');
+
+          state.attempts += 1;
+        }
+      })
+      .build();
+
+    expect(saga.plugins).toEqual([
+      {
+        plugin_key: 'http',
+        plugin_kind: 'manifest',
+        action_names: ['get', 'post', 'put'],
+        version: '2.0.0'
+      }
+    ]);
+
+    const output = await runSagaHandler(
+      { attempts: 0 },
+      { type: 'event.received.event', payload: { id: 'evt-1' } } as SagaAggregateEventByName<typeof EventAggregate, 'received'>,
+      saga.handlers[0]!.handlers.received,
+      {
+        sagaId: 'saga-registry',
+        correlationId: 'corr-registry',
+        causationId: 'cause-registry'
+      },
+      {},
+      [HttpPluginV1, HttpPluginV2] as const
+    );
+
+    const oneWayIntents = output.intents as readonly SagaPluginOneWayIntent<'http', 'get' | 'post' | 'put', { url: string; source: 'v1' | 'v2' }>[];
+    expect(oneWayIntents).toHaveLength(3);
+    expect(oneWayIntents[0]).toMatchObject({ action_name: 'get', execution_payload: { source: 'v2' } });
+    expect(oneWayIntents[1]).toMatchObject({ action_name: 'post', execution_payload: { source: 'v1' } });
+    expect(oneWayIntents[2]).toMatchObject({ action_name: 'put', execution_payload: { source: 'v2' } });
+  });
+});

--- a/packages/saga/test/plugin-spi-conformance-harness.test.ts
+++ b/packages/saga/test/plugin-spi-conformance-harness.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  runSagaErrorHandler,
+  runSagaHandler,
+  runSagaResponseHandler,
+  type SagaIntent,
+  type SagaAggregateEventByName,
+  type SagaDefinition,
+  type TErrorToken,
+  type TResponseToken
+} from '../src/createSaga';
+import {
+  ConformanceAggregate,
+  EffectsPlugin,
+  PersistencePlugin,
+  SchedulerPlugin,
+  TelemetryPlugin,
+  buildTenantFixture,
+  conformanceEventForTenant,
+  createPluginSpiConformanceSaga,
+  pluginBindings,
+  type PluginSpiConformanceState
+} from './plugin-spi-conformance.fixtures';
+
+const asIntents = (intents: readonly SagaIntent[]) => intents as readonly Record<string, unknown>[];
+
+describe('plugin SPI conformance harness', () => {
+  it('validates persistence/scheduler/effects/telemetry action contract emission', async () => {
+    const saga = createPluginSpiConformanceSaga();
+    const tenant = buildTenantFixture('tenant-a');
+
+    const output = await runSagaHandler(
+      { attempts: 0 } as PluginSpiConformanceState,
+      conformanceEventForTenant(tenant.tenantId, 'workflow-a', 'cp-a'),
+      saga.handlers[0]!.handlers.started,
+      tenant.metadata,
+      pluginBindings,
+      [PersistencePlugin, SchedulerPlugin, EffectsPlugin, TelemetryPlugin] as const
+    );
+
+    expect(output.state.attempts).toBe(1);
+
+    const intents = asIntents(output.intents);
+    expect(intents).toHaveLength(4);
+
+    expect(intents[0]).toMatchObject({
+      type: 'plugin-request',
+      plugin_key: 'persistence',
+      action_name: 'saveState',
+      action_kind: 'request_response',
+      execution_payload: {
+        workflowId: 'workflow-a',
+        checkpoint: 'cp-a',
+        tenantId: tenant.tenantId,
+        consistency: 'strict'
+      },
+      routing_metadata: {
+        response_handler_key: 'persistence.save.ok',
+        error_handler_key: 'persistence.save.failed',
+        handler_data: {
+          tenantId: tenant.tenantId,
+          workflowId: 'workflow-a'
+        }
+      },
+      metadata: tenant.metadata
+    });
+
+    expect(intents[1]).toMatchObject({
+      type: 'plugin-one-way',
+      plugin_key: 'scheduler',
+      action_name: 'enqueue',
+      execution_payload: {
+        id: 'retry:workflow-a',
+        delayMs: 1_000,
+        tenantId: tenant.tenantId
+      },
+      metadata: tenant.metadata
+    });
+
+    expect(intents[2]).toMatchObject({
+      type: 'plugin-one-way',
+      plugin_key: 'effects',
+      action_name: 'emit',
+      execution_payload: {
+        type: 'notify',
+        payload: {
+          workflowId: 'workflow-a',
+          checkpoint: 'cp-a'
+        },
+        tenantId: tenant.tenantId
+      },
+      metadata: tenant.metadata
+    });
+
+    expect(intents[3]).toMatchObject({
+      type: 'plugin-one-way',
+      plugin_key: 'telemetry',
+      action_name: 'record',
+      execution_payload: {
+        name: 'conformance.started',
+        value: 1,
+        tenantId: tenant.tenantId
+      },
+      metadata: tenant.metadata
+    });
+  });
+
+  it('validates response-handler tenant context propagation semantics', async () => {
+    const saga = createPluginSpiConformanceSaga();
+    const tenant = buildTenantFixture('tenant-b');
+
+    const response = await runSagaResponseHandler({
+      definition: saga,
+      state: { attempts: 0 },
+      plugins: [PersistencePlugin, SchedulerPlugin, EffectsPlugin, TelemetryPlugin] as const,
+      envelope: {
+        token: 'persistence.save.ok' as TResponseToken<'persistence.save.ok'>,
+        payload: { persisted: true },
+        request: {
+          plugin_key: 'persistence',
+          action_name: 'saveState',
+          sagaId: tenant.metadata.sagaId,
+          correlationId: tenant.metadata.correlationId,
+          causationId: tenant.metadata.causationId
+        }
+      }
+    });
+
+    expect(response.ok).toBe(true);
+    if (!response.ok) {
+      return;
+    }
+
+    expect(response.output.state).toEqual({
+      attempts: 1,
+      lastResult: '[object Object]'
+    });
+
+    expect(response.output.intents).toEqual([
+      {
+        type: 'plugin-one-way',
+        plugin_key: 'scheduler',
+        action_name: 'enqueue',
+        action_kind: 'void',
+        execution_payload: {
+          id: 'next-step',
+          delayMs: 500,
+          tenantId: tenant.metadata.sagaId
+        },
+        metadata: tenant.metadata
+      }
+    ]);
+  });
+
+  it('validates error-handler tenant context propagation semantics', async () => {
+    const saga = createPluginSpiConformanceSaga();
+    const tenant = buildTenantFixture('tenant-c');
+
+    const failure = await runSagaErrorHandler({
+      definition: saga,
+      state: { attempts: 0 },
+      plugins: [PersistencePlugin, SchedulerPlugin, EffectsPlugin, TelemetryPlugin] as const,
+      envelope: {
+        token: 'persistence.save.failed' as TErrorToken<'persistence.save.failed'>,
+        error: { message: 'write-timeout' },
+        request: {
+          plugin_key: 'persistence',
+          action_name: 'saveState',
+          sagaId: tenant.metadata.sagaId,
+          correlationId: tenant.metadata.correlationId,
+          causationId: tenant.metadata.causationId
+        }
+      }
+    });
+
+    expect(failure.ok).toBe(true);
+    if (!failure.ok) {
+      return;
+    }
+
+    expect(failure.output.state).toEqual({
+      attempts: 1,
+      lastError: '[object Object]'
+    });
+
+    expect(failure.output.intents).toEqual([
+      {
+        type: 'plugin-one-way',
+        plugin_key: 'telemetry',
+        action_name: 'record',
+        action_kind: 'void',
+        execution_payload: {
+          name: 'persistence_failure',
+          value: 1,
+          tenantId: tenant.metadata.sagaId
+        },
+        metadata: tenant.metadata
+      }
+    ]);
+  });
+
+  it('validates executable handler failure semantics for undefined tokens', async () => {
+    const saga = createPluginSpiConformanceSaga();
+    const untypedSaga = saga as unknown as SagaDefinition<PluginSpiConformanceState, readonly [], any>;
+
+    const responseFailure = await runSagaResponseHandler({
+      definition: untypedSaga,
+      state: { attempts: 0 },
+      envelope: {
+        token: 'persistence.save.unknown' as unknown as TResponseToken<string>,
+        payload: { persisted: false },
+        request: {
+          plugin_key: 'persistence',
+          action_name: 'saveState'
+        }
+      }
+    });
+
+    expect(responseFailure).toEqual({
+      ok: false,
+      reason: 'token_not_defined',
+      token: 'persistence.save.unknown'
+    });
+
+    const errorFailure = await runSagaErrorHandler({
+      definition: untypedSaga,
+      state: { attempts: 0 },
+      envelope: {
+        token: 'persistence.save.unknown' as unknown as TErrorToken<string>,
+        error: { message: 'ignored' },
+        request: {
+          plugin_key: 'persistence',
+          action_name: 'saveState'
+        }
+      }
+    });
+
+    expect(errorFailure).toEqual({
+      ok: false,
+      reason: 'token_not_defined',
+      token: 'persistence.save.unknown'
+    });
+  });
+
+  it('keeps conformance aggregate payload contract stable', () => {
+    const event: SagaAggregateEventByName<typeof ConformanceAggregate, 'started'> = {
+      type: 'conformance.started.event',
+      payload: {
+        tenantId: 'tenant-stable',
+        workflowId: 'workflow-stable',
+        checkpoint: 'cp-stable'
+      }
+    };
+
+    expect(event.payload).toEqual({
+      tenantId: 'tenant-stable',
+      workflowId: 'workflow-stable',
+      checkpoint: 'cp-stable'
+    });
+  });
+});

--- a/packages/saga/test/plugin-spi-conformance.fixtures.ts
+++ b/packages/saga/test/plugin-spi-conformance.fixtures.ts
@@ -1,0 +1,170 @@
+import {
+  createSaga,
+  defineOneWay,
+  defineRequestResponse,
+  defineSagaPlugin,
+  type SagaAggregateEventByName,
+  type SagaIntentMetadata
+} from '../src/createSaga';
+import type { SagaIdentityInput as CanonicalSagaIdentityInput } from '../src/identity';
+
+export type PluginSpiConformanceState = {
+  attempts: number;
+  lastResult?: string;
+  lastError?: string;
+};
+
+export type TenantFixture = {
+  tenantId: string;
+  metadata: SagaIntentMetadata;
+};
+
+export const conformanceIdentity: CanonicalSagaIdentityInput = {
+  namespace: 'plugins',
+  name: 'spi_conformance_harness',
+  version: 1
+};
+
+export const ConformanceAggregate = {
+  __aggregateType: 'conformance',
+  pure: {
+    eventProjectors: {
+      started: (
+        _state: unknown,
+        _event: {
+          payload: { tenantId: string; workflowId: string; checkpoint: string };
+        }
+      ) => undefined
+    }
+  },
+  commandCreators: {}
+} as const;
+
+export const PersistencePlugin = defineSagaPlugin({
+  plugin_key: 'persistence',
+  actions: {
+    saveState: defineRequestResponse((record: { workflowId: string; checkpoint: string; tenantId: string }) => ({
+      ...record,
+      consistency: 'strict' as const
+    }))
+  }
+});
+
+export const SchedulerPlugin = defineSagaPlugin({
+  plugin_key: 'scheduler',
+  actions: {
+    enqueue: defineOneWay((job: { id: string; delayMs: number; tenantId: string }) => job)
+  }
+});
+
+export const EffectsPlugin = defineSagaPlugin({
+  plugin_key: 'effects',
+  actions: {
+    emit: defineOneWay((effect: { type: string; payload: Record<string, unknown>; tenantId: string }) => effect)
+  }
+});
+
+export const TelemetryPlugin = defineSagaPlugin({
+  plugin_key: 'telemetry',
+  actions: {
+    record: defineOneWay((metric: { name: string; value: number; tenantId: string }) => metric)
+  }
+});
+
+export const pluginBindings = {
+  'persistence.save.ok': { phase: 'response' },
+  'persistence.save.failed': { phase: 'error' },
+  'persistence.save.retry': { phase: 'retry' }
+} as const;
+
+export const buildTenantFixture = (tenantId: string): TenantFixture => ({
+  tenantId,
+  metadata: {
+    sagaId: `tenant:${tenantId}:saga:spi`,
+    correlationId: `tenant:${tenantId}:corr:spi`,
+    causationId: `tenant:${tenantId}:cause:spi`
+  }
+});
+
+export const conformanceEventForTenant = (
+  tenantId: string,
+  workflowId = 'workflow-1',
+  checkpoint = 'checkpoint-1'
+): SagaAggregateEventByName<typeof ConformanceAggregate, 'started'> => ({
+  type: 'conformance.started.event',
+  payload: {
+    tenantId,
+    workflowId,
+    checkpoint
+  }
+});
+
+export const createPluginSpiConformanceSaga = () => createSaga({
+  identity: conformanceIdentity,
+  plugins: [PersistencePlugin, SchedulerPlugin, EffectsPlugin, TelemetryPlugin] as const
+})
+  .initialState((): PluginSpiConformanceState => ({ attempts: 0 }))
+  .onResponses({
+    'persistence.save.ok': (state, response, ctx) => {
+      state.attempts += 1;
+      state.lastResult = String(response.payload);
+      ctx.actions.scheduler.enqueue({
+        id: 'next-step',
+        delayMs: 500,
+        tenantId: response.request.sagaId ?? 'unknown-tenant'
+      });
+    }
+  })
+  .onErrors({
+    'persistence.save.failed': (state, error, ctx) => {
+      state.attempts += 1;
+      state.lastError = String(error.error);
+      ctx.actions.telemetry.record({
+        name: 'persistence_failure',
+        value: 1,
+        tenantId: error.request.sagaId ?? 'unknown-tenant'
+      });
+    }
+  })
+  .onRetries({
+    'persistence.save.retry': () => undefined
+  })
+  .on(ConformanceAggregate, {
+    started: async (state, event, ctx) => {
+      const saveIntent = ctx.actions.persistence
+        .saveState({
+          workflowId: event.payload.workflowId,
+          checkpoint: event.payload.checkpoint,
+          tenantId: event.payload.tenantId
+        })
+        .withData({ tenantId: event.payload.tenantId, workflowId: event.payload.workflowId })
+        .onResponse(ctx.onResponse['persistence.save.ok'])
+        .onError(ctx.onError['persistence.save.failed']);
+
+      ctx.actions.scheduler.enqueue({
+        id: `retry:${event.payload.workflowId}`,
+        delayMs: 1_000,
+        tenantId: event.payload.tenantId
+      });
+
+      ctx.actions.effects.emit({
+        type: 'notify',
+        payload: {
+          workflowId: event.payload.workflowId,
+          checkpoint: event.payload.checkpoint
+        },
+        tenantId: event.payload.tenantId
+      });
+
+      ctx.actions.telemetry.record({
+        name: 'conformance.started',
+        value: 1,
+        tenantId: event.payload.tenantId
+      });
+
+      state.attempts += 1;
+
+      void saveIntent;
+    }
+  })
+  .build();

--- a/packages/saga/test/trigger-policy-contracts.test.ts
+++ b/packages/saga/test/trigger-policy-contracts.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from '@jest/globals';
+import type {
+  SagaSchedulerTriggerPolicyContract,
+  SagaTriggerMisfirePolicy,
+  SagaTriggerStartContract
+} from '../src/triggerContracts';
+
+describe('scheduler trigger policy contracts', () => {
+  it('supports misfire policy modes as stable discriminated unions', () => {
+    const catchUpAll: SagaTriggerMisfirePolicy = { mode: 'catch_up_all' };
+    const catchUpBounded: SagaTriggerMisfirePolicy = {
+      mode: 'catch_up_bounded',
+      maxCatchUpCount: 25
+    };
+    const latestOnly: SagaTriggerMisfirePolicy = { mode: 'latest_only' };
+    const skipUntilNext: SagaTriggerMisfirePolicy = { mode: 'skip_until_next' };
+
+    expect(catchUpAll.mode).toBe('catch_up_all');
+    expect(catchUpBounded.mode).toBe('catch_up_bounded');
+    expect(catchUpBounded.maxCatchUpCount).toBe(25);
+    expect(latestOnly.mode).toBe('latest_only');
+    expect(skipUntilNext.mode).toBe('skip_until_next');
+  });
+
+  it('allows optional restart and misfire policy contracts on trigger start contracts', () => {
+    const schedulerPolicy: SagaSchedulerTriggerPolicyContract = {
+      restart: {
+        mode: 'graceful',
+        reason: 'restart from trigger overlap'
+      },
+      misfire: {
+        mode: 'catch_up_bounded',
+        maxCatchUpCount: 10
+      }
+    };
+
+    const triggerContract: SagaTriggerStartContract = {
+      schedulerPolicy
+    };
+
+    expect(triggerContract.schedulerPolicy?.restart?.mode).toBe('graceful');
+    expect(triggerContract.schedulerPolicy?.misfire?.mode).toBe('catch_up_bounded');
+  });
+
+  it('rejects invalid policy shapes at compile time', () => {
+    // @ts-expect-error misfire mode must be one of the supported contract variants
+    const invalidMisfire: SagaTriggerMisfirePolicy = { mode: 'ignore' };
+
+    // @ts-expect-error catch_up_bounded requires maxCatchUpCount
+    const missingBound: SagaTriggerMisfirePolicy = { mode: 'catch_up_bounded' };
+
+    const contract: SagaTriggerStartContract = {
+      schedulerPolicy: {
+        // @ts-expect-error restart mode only accepts graceful|force
+        restart: { mode: 'soft' },
+        misfire: { mode: 'latest_only' }
+      }
+    };
+
+    void invalidMisfire;
+    void missingBound;
+    void contract;
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Finalized Epic **redemeine-8te** handoff on `feature/redemeine-8te` with all scoped child beads completed.
- Confirmed final wave integration for **redemeine-vpn** via commit `17bed54` and linked Beads + PR workflow.
- Epic and child closure states were transitioned through `in_review` and closed as **Done** in Beads.

## Beads
- Epic: `redemeine-8te`
- Draft PR: #25
- Final wave bead: `redemeine-vpn` (commit `17bed54`)

## Progress Checklist
- [x] redemeine-9dd
- [x] redemeine-c3p
- [x] redemeine-g74
- [x] redemeine-dtt
- [x] redemeine-88r
- [x] redemeine-p1s
- [x] redemeine-efj
- [x] redemeine-rvb
- [x] redemeine-dsk
- [x] redemeine-777
- [x] redemeine-u3w
- [x] redemeine-auj
- [x] redemeine-r04
- [x] redemeine-mbi
- [x] redemeine-06k
- [x] redemeine-1d7
- [x] redemeine-sfc
- [x] redemeine-tor
- [x] redemeine-ckb
- [x] redemeine-c6o
- [x] redemeine-b13
- [x] redemeine-t2v
- [x] redemeine-vpn

## Final Handoff Summary
- Final epic branch evidence for **redemeine-vpn**: `17bed54`.
- No incomplete child beads remain for Epic **redemeine-8te**.
- Release/deploy implication: runtime v1 epic scope is fully integrated on this feature branch and ready for final review/merge flow.