### PR TITLE
docs: rework PR #27 on current main: defer carry-over scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,3 +381,12 @@ Depot End-to-End: An integration test successfully dispatches a Command, which e
 - Keep `SagaAggregate` as the authoritative write model, and consider adding a `createMirage`-style DX overlay/facade for bridge ergonomics without allowing invariant bypass.
 - Consider durable per-saga inbound inbox/queue semantics (persist-before-ack, idempotency keys, replay-safe drains) so queued inbound work survives server restarts.
 - Clarify the `referenceAdapters` API boundary by separating stable SPI contracts from in-memory reference implementations and test-harness surfaces.
+
+## Deferred PR27 rework follow-ups (tracked in beads)
+
+This scope is intentionally deferred and tracked in `bd` (no PR27 carry-over replay in this bead):
+
+- `redemeine-e47.5`: Saga-runtime durable inbox semantics (persist-before-ack)
+- `redemeine-e47.6`: Reintroduce `@redemeine/otel` package on current runtime
+- `redemeine-e47.7`: Restore trace-correlation continuity E2E coverage
+- `redemeine-e47.8`: Canonical inspection hook envelope parity


### PR DESCRIPTION
## Epic/Beads
- Epic: redemeine-e47
- Current bead: redemeine-e47.4
- Source traceability: redemeine-hwj, redemeine-1ps

## Scope decision
User-approved scope for this epic branch is narrowed to a README-only update that records deferred follow-up work in beads.

## Keep/Drop/Defer summary
- **Keep:** README update documenting deferred follow-up work.
- **Drop:** PR27 carry-over implementation/docs replay on this branch.
- **Defer:** redemeine-e47.5, redemeine-e47.6, redemeine-e47.7, redemeine-e47.8.

## Verification status
- Verification bead redemeine-e47.3 is erified.
- Change surface is README-only; no source code replay included.

## Child bead checklist
- [ ] redemeine-e47.1 — in_progress
- [x] redemeine-e47.2 — implemented
- [x] redemeine-e47.3 — verified
- [ ] redemeine-e47.4 — in_review