### PR TITLE
feat(projection): add afterEach hook for cross-cutting concerns

### DIFF
--- a/packages/projection-runtime-core/src/ProjectionDaemon.ts
+++ b/packages/projection-runtime-core/src/ProjectionDaemon.ts
@@ -310,6 +310,9 @@ export class ProjectionDaemon<TState = unknown> {
             if (handler) {
               handler(draft, event, context);
             }
+            if (projection.hooks?.afterEach) {
+              projection.hooks.afterEach(draft as TState, event);
+            }
           });
 
           for (const unsubscription of context.getUnsubscriptions()) {

--- a/packages/projection-runtime-core/src/createProjection.ts
+++ b/packages/projection-runtime-core/src/createProjection.ts
@@ -1,6 +1,12 @@
 import type { Draft } from 'immer';
 import { ProjectionEvent as BaseProjectionEvent } from './types';
 
+/** Hooks for cross-cutting projection concerns (e.g., metadata tracking) */
+export interface ProjectionHooks<TState> {
+  /** Runs after every event handler — receives mutable state and the raw event */
+  afterEach?: (state: TState, event: BaseProjectionEvent) => void;
+}
+
 /**
  * Event shape passed to projection handlers with narrowed payload type.
  */
@@ -179,6 +185,8 @@ export interface ProjectionDefinition<TState = unknown> {
   identity: (event: BaseProjectionEvent) => string | readonly string[];
   /** Subscriptions captured during projection definition */
   subscriptions: Array<{ aggregate: { aggregateType: string }; aggregateId: string }>;
+  /** Cross-cutting hooks that run around event handlers */
+  hooks?: ProjectionHooks<TState>;
 }
 
 /**
@@ -225,6 +233,11 @@ export interface ProjectionBuilder<TState> {
     aggregate: TAggregate,
     handlers: ProjectionHandlersForAggregate<TState, TAggregate>
   ): ProjectionBuilder<TState>;
+
+  /**
+   * Register cross-cutting hooks that run around event handlers
+   */
+  hooks(hooks: ProjectionHooks<TState>): ProjectionBuilder<TState>;
   
   /**
    * Build the final projection definition
@@ -242,6 +255,7 @@ class ProjectionBuilderImpl<TState> implements ProjectionBuilder<TState> {
   private _fromStream: ProjectionStreamDefinition<TState> | null = null;
   private _joinStreams: JoinStreamDefinition<TState>[] = [];
   private _reverseSubscribeStreams: ReverseSubscribeStreamDefinition<TState>[] = [];
+  private _hooks: ProjectionHooks<TState> = {};
 
   constructor(name: string, initialState: (id: string) => TState) {
     this._name = name;
@@ -323,6 +337,11 @@ class ProjectionBuilderImpl<TState> implements ProjectionBuilder<TState> {
     return this;
   }
 
+  hooks(hooks: ProjectionHooks<TState>): ProjectionBuilder<TState> {
+    this._hooks = { ...this._hooks, ...hooks };
+    return this;
+  }
+
   build(): ProjectionDefinition<TState> {
     if (!this._fromStream) {
       throw new Error(`Projection '${this._name}' must have at least one .from() stream`);
@@ -335,7 +354,8 @@ class ProjectionBuilderImpl<TState> implements ProjectionBuilder<TState> {
       reverseSubscribeStreams: this._reverseSubscribeStreams,
       initialState: this._initialState,
       identity: this._identity,
-      subscriptions: []
+      subscriptions: [],
+      hooks: this._hooks
     };
   }
 }

--- a/packages/projection-runtime-core/src/index.ts
+++ b/packages/projection-runtime-core/src/index.ts
@@ -32,7 +32,8 @@ export type {
   JoinStreamDefinition,
   ReverseSubscribeStreamDefinition,
   ProjectionDefinition,
-  ProjectionBuilder
+  ProjectionBuilder,
+  ProjectionHooks
 } from './createProjection';
 export { ProjectionDaemon } from './ProjectionDaemon';
 export type { ProjectionDaemonOptions, BatchStats } from './ProjectionDaemon';

--- a/packages/projection-runtime/src/ProjectionRuntimeProcessor.ts
+++ b/packages/projection-runtime/src/ProjectionRuntimeProcessor.ts
@@ -37,6 +37,9 @@ type RuntimeProjectionDefinition<TState extends PlainObject> = {
   }>;
   initialState: (documentId: string) => TState;
   identity: (event: ProjectionCommit) => string | readonly string[];
+  hooks?: {
+    afterEach?: (state: TState, event: ProjectionCommit) => void;
+  };
 };
 
 type ProjectionPersistenceContract<TState extends PlainObject> = ProjectionReadContract<TState> &
@@ -117,6 +120,10 @@ export class ProjectionRuntimeProcessor<TState extends PlainObject> {
         const context = this.createContext();
 
         handler(pending.state as never, commit as never, context);
+
+        if (this.options.projection.hooks?.afterEach) {
+          this.options.projection.hooks.afterEach(pending.state, commit);
+        }
 
         const subscriptions = context.getSubscriptions();
         for (const subscription of subscriptions) {

--- a/packages/projection/src/createProjection.ts
+++ b/packages/projection/src/createProjection.ts
@@ -2,6 +2,12 @@ import { ProjectionEvent as BaseProjectionEvent } from './types';
 
 type Draft<TState> = TState;
 
+/** Hooks for cross-cutting projection concerns (e.g., metadata tracking) */
+export interface ProjectionHooks<TState> {
+  /** Runs after every event handler — receives mutable state and the raw event */
+  afterEach?: (state: TState, event: BaseProjectionEvent) => void;
+}
+
 /**
  * Event shape passed to projection handlers with narrowed payload type.
  */
@@ -173,6 +179,8 @@ export interface ProjectionDefinition<TState = unknown> {
   identity: (event: BaseProjectionEvent) => string | readonly string[];
   /** Subscriptions captured during projection definition */
   subscriptions: Array<{ aggregate: { aggregateType: string }; aggregateId: string }>;
+  /** Cross-cutting hooks that run around event handlers */
+  hooks?: ProjectionHooks<TState>;
 }
 
 /**
@@ -213,6 +221,11 @@ export interface ProjectionBuilder<TState> {
   ): ProjectionBuilder<TState>;
   
   /**
+   * Register cross-cutting hooks that run around event handlers
+   */
+  hooks(hooks: ProjectionHooks<TState>): ProjectionBuilder<TState>;
+
+  /**
    * Build the final projection definition
    */
   build(): ProjectionDefinition<TState>;
@@ -227,6 +240,7 @@ class ProjectionBuilderImpl<TState> implements ProjectionBuilder<TState> {
   private _identity: (event: BaseProjectionEvent) => string | readonly string[];
   private _fromStream: ProjectionStreamDefinition<TState> | null = null;
   private _joinStreams: JoinStreamDefinition<TState>[] = [];
+  private _hooks: ProjectionHooks<TState> = {};
 
   constructor(name: string, initialState: (id: string) => TState) {
     this._name = name;
@@ -288,6 +302,11 @@ class ProjectionBuilderImpl<TState> implements ProjectionBuilder<TState> {
     return this;
   }
 
+  hooks(hooks: ProjectionHooks<TState>): ProjectionBuilder<TState> {
+    this._hooks = { ...this._hooks, ...hooks };
+    return this;
+  }
+
   build(): ProjectionDefinition<TState> {
     if (!this._fromStream) {
       throw new Error(`Projection '${this._name}' must have at least one .from() stream`);
@@ -299,7 +318,8 @@ class ProjectionBuilderImpl<TState> implements ProjectionBuilder<TState> {
       joinStreams: this._joinStreams,
       initialState: this._initialState,
       identity: this._identity,
-      subscriptions: []
+      subscriptions: [],
+      hooks: this._hooks
     };
   }
 }

--- a/packages/projection/src/index.ts
+++ b/packages/projection/src/index.ts
@@ -13,7 +13,8 @@ export type {
   ProjectionStreamDefinition,
   JoinStreamDefinition,
   ProjectionDefinition,
-  ProjectionBuilder
+  ProjectionBuilder,
+  ProjectionHooks
 } from './createProjection';
 export {
   reverseSemanticsContract,

--- a/packages/testing/src/testProjection.ts
+++ b/packages/testing/src/testProjection.ts
@@ -26,6 +26,9 @@ export interface TestProjectionDefinition<TState> {
     readonly handlers: Record<string, (state: Draft<TState>, event: TestProjectionEvent, ctx: TestProjectionContext) => void>;
   }[];
   readonly initialState: (documentId: string) => TState;
+  readonly hooks?: {
+    readonly afterEach?: (state: Draft<TState>, event: TestProjectionEvent) => void;
+  };
 }
 
 enablePatches();
@@ -139,6 +142,9 @@ export function testProjection<TState>(projection: TestProjectionDefinition<TSta
       const [nextState, patches] = produceWithPatches(state, (draft) => {
         if (handler) {
           handler(draft, event, context);
+        }
+        if (projection.hooks?.afterEach) {
+          projection.hooks.afterEach(draft, event);
         }
       });
 

--- a/packages/testing/test/test-projection-fixture.test.ts
+++ b/packages/testing/test/test-projection-fixture.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 import { createProjection } from '../../projection/src';
-import { testProjection } from '../src/testProjection';
-import type { TestProjectionEvent } from '../src/testProjection';
+import { testProjection, TestProjectionEvent } from '../src/testProjection';
 
 const invoiceAgg = {
   aggregateType: 'invoice' as const,
@@ -134,5 +133,47 @@ describe('testProjection fixture', () => {
       { op: 'add', path: ['shipments', 0], value: 'ord-1' },
       { op: 'add', path: ['shipments', 1], value: 'post' }
     ]);
+  });
+
+  it('invokes afterEach hook after handler', () => {
+    const testAgg = {
+      aggregateType: 'counter' as const,
+      pure: {
+        eventProjectors: {
+          incremented: (_state: unknown, _event: { payload: { amount: number } }) => {}
+        }
+      }
+    };
+
+    type CounterState = { count: number; hookCalled: boolean };
+
+    const projection = createProjection<CounterState>('counter-view', () => ({
+      count: 0,
+      hookCalled: false
+    }))
+      .hooks({
+        afterEach: (state) => {
+          state.hookCalled = true;
+        }
+      })
+      .from(testAgg, {
+        incremented: (state, event) => {
+          state.count += event.payload.amount;
+        }
+      })
+      .build();
+
+    const fixture = testProjection(projection);
+    const { state } = fixture.applyEvent({
+      aggregateType: 'counter',
+      aggregateId: 'c-1',
+      type: 'counter.incremented.event',
+      payload: { amount: 5 },
+      sequence: 1,
+      timestamp: '2026-04-20T10:00:00Z'
+    });
+
+    expect(state.count).toBe(5);
+    expect(state.hookCalled).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `ProjectionHooks<TState>` interface with `afterEach` callback
- Adds `.hooks()` method to the projection builder
- Invokes `afterEach` after every handler call across all three runtime processors

## Motivation

Legacy demeine projections use a wrapper function that applies cross-cutting concerns (`latestUpdateBy`, `version`, `changeDateTime`) after every event handler. In redemeine, there was no equivalent - each handler had to call `trackUpdate(state, event)` manually, which is repetitive and error-prone.

With `afterEach`, domains can declare metadata tracking once:

```ts
createProjection('attachment', initialState)
  .hooks({
    afterEach: (state, event) => {
      state.version++;
      state.latestUpdateBy = event.metadata?.principal ?? {};
    }
  })
  .from(attachment, { /* clean handlers - no boilerplate */ })
  .build()
```

## Implementation

- `packages/projection/src/createProjection.ts` - Type, builder interface + impl
- `packages/projection-runtime-core/src/ProjectionDaemon.ts` - Hook invocation inside `produce()`
- `packages/projection-runtime/src/ProjectionRuntimeProcessor.ts` - Hook invocation after handler
- `packages/testing/src/testProjection.ts` - Hook invocation in test fixture
- `packages/testing/test/test-projection-fixture.test.ts` - Verification test

## Design Decisions

- **Mutable state**: Unlike aggregate hooks (ReadonlyDeep), projection afterEach receives mutable state since the purpose IS to mutate cross-cutting fields
- **Same event shape**: Gets the same `ProjectionEvent` that handlers receive
- **Consistent with aggregate API**: `.hooks({})` on builder, merged with spread
- **Only afterEach for now**: No evidence of `beforeEach` need in 40+ legacy domains. Easy to add later.

## Verification

- `tsc --noEmit` passes for: projection, testing, projection-runtime, projection-runtime-core
- Test verifies hook is called after handler and can mutate state