### PR TITLE
docs(architecture): preserve hwj epic architecture docs and @redemeine/otel package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -55,6 +55,10 @@
         "@redemeine/kernel": "workspace:*",
       },
     },
+    "packages/otel": {
+      "name": "@redemeine/otel",
+      "version": "0.1.0",
+    },
     "packages/projection": {
       "name": "@redemeine/projection",
       "version": "0.1.0",
@@ -354,6 +358,8 @@
     "@redemeine/kernel": ["@redemeine/kernel@workspace:packages/kernel"],
 
     "@redemeine/mirage": ["@redemeine/mirage@workspace:packages/mirage"],
+
+    "@redemeine/otel": ["@redemeine/otel@workspace:packages/otel"],
 
     "@redemeine/projection": ["@redemeine/projection@workspace:packages/projection"],
 

--- a/docs/architecture/aggregate-intent-plugin-capability-boundaries-v1.md
+++ b/docs/architecture/aggregate-intent-plugin-capability-boundaries-v1.md
@@ -1,0 +1,195 @@
+# AggregateIntent Plugin Capability Boundaries Policy (v1)
+
+**Bead:** `redemeine-tdh`  
+**Status:** Proposed-for-implementation contract  
+**Scope:** Safety boundaries for plugin actions reachable from `AggregateIntent` handlers
+
+---
+
+## 1) Goal
+
+Keep `AggregateIntent` deterministic, stream-local, and low-latency by default while still allowing controlled extensibility through plugins.
+
+This policy defines:
+- a capability declaration model,
+- a capability matrix,
+- compile-time + runtime enforcement points,
+- conformance tests for SDK/runtime,
+- explicit trust-model limits.
+
+---
+
+## 2) Core safety invariants
+
+`AggregateIntent` execution MUST preserve these invariants:
+
+1. **Stream-local default:** handlers operate on the current aggregate stream only.
+2. **No hidden orchestration:** cross-stream coordination and long-running workflows are not allowed in `AggregateIntent`.
+3. **Deterministic state transition:** aggregate state/resulting events must be replay-safe independent of plugin runtime timing.
+4. **Bounded side effects:** plugin usage in aggregate path is explicit, declared, and policy-checked.
+5. **Fail-closed on forbidden capabilities:** disallowed plugin actions reject before state mutation commit.
+
+If business logic needs cross-stream, request/response orchestration, compensation, timers, or external dependency coupling, it MUST escalate to `SagaIntent`.
+
+---
+
+## 3) Capability model
+
+Each plugin declares a manifest entry per action:
+
+- `pluginKey`
+- `actionName`
+- `capabilityClass` (from taxonomy below)
+- `interaction` (`fire_and_forget` or `request_response`)
+- `scope` (`stream_local`, `cross_stream`, `external_io`, `process_runtime`)
+- `determinism` (`deterministic`, `nondeterministic`)
+- `requiresEscalation` (boolean)
+- `defaultAggregatePolicy` (`allow`, `deny`, `allow_with_guard`)
+
+Host runtime computes effective permission from:
+1) plugin manifest,
+2) host policy (global),
+3) aggregate allowlist/denylist override (optional),
+4) execution mode (`AggregateIntent` vs `SagaIntent`).
+
+---
+
+## 4) Capability matrix (AggregateIntent safety)
+
+| Capability class | Example action | AggregateIntent | Conditions | Rationale |
+| --- | --- | --- | --- | --- |
+| `aggregate_dispatch_local` | dispatch command to same aggregate id/stream | **Allow** | command target must equal current stream identity | preserves stream locality |
+| `domain_validation_pure` | schema/guard evaluation with no IO | **Allow** | pure function only | deterministic |
+| `event_annotation_local` | attach metadata/audit tags to emitted events | **Allow with guard** | metadata size/key policy enforced | bounded write path |
+| `idempotency_lookup_local` | local deterministic key check | **Allow with guard** | local store only; no network | replay-safe guardrail |
+| `timer_schedule` | delayed callback/wakeup | **Deny** | escalate to SagaIntent | introduces orchestration/time coupling |
+| `cross_stream_dispatch` | command to different aggregate id/type | **Deny** | escalate to SagaIntent | breaks stream-local boundary |
+| `request_response` | outbound call expecting response | **Deny** | escalate to SagaIntent | non-deterministic roundtrip |
+| `external_io_http` | HTTP/gRPC/queue publish | **Deny** | escalate to SagaIntent | external side effects |
+| `integration_message_bus` | publish to broker/topic | **Deny** | escalate to SagaIntent | external/system coupling |
+| `filesystem_process_env` | fs/process/env access | **Deny** | never from AggregateIntent | host compromise surface |
+| `dynamic_code_execution` | eval/Function/vm execution | **Deny** | never | integrity/sandbox risk |
+| `policy_override_admin` | bypass capability checks | **Deny** | host-internal only | trust boundary protection |
+
+Policy default for unknown capability: **Deny**.
+
+---
+
+## 5) Enforcement points
+
+### A. Definition-time (SDK compile/build)
+
+1. **Manifest schema validation**
+   - Reject plugin registration if capability metadata missing/invalid.
+2. **Aggregate action typing constraints**
+   - Aggregate handler context exposes only capability-eligible action surface.
+   - Request/response or cross-stream builders are absent from aggregate context typings.
+3. **Static lint rule (recommended)**
+   - Flag prohibited API imports/usages in aggregate modules.
+
+### B. Registration-time (runtime boot)
+
+4. **Policy resolver preflight**
+   - Compute effective policy for every plugin action.
+   - Emit startup diagnostics for denied actions and escalation-required capabilities.
+5. **Fail-fast in strict mode**
+   - In strict policy mode, fail startup if aggregate-registered plugins include denied capabilities.
+
+### C. Dispatch-time (before append/commit)
+
+6. **Intent boundary guard**
+   - Every plugin action invocation from aggregate path passes through `CapabilityGuard`.
+7. **Scope validator**
+   - Enforce same-stream target for `aggregate_dispatch_local`.
+8. **Interaction validator**
+   - Reject `request_response` from aggregate context.
+9. **Determinism validator**
+   - Reject capabilities declared `nondeterministic` in aggregate path.
+
+### D. Post-dispatch observability
+
+10. **Audit event emission**
+    - Emit structured audit records for allow/deny decisions with policy reason.
+11. **Security telemetry**
+    - Increment counters for denied invocations by plugin/capability/reason.
+
+---
+
+## 6) Conformance test suite (required)
+
+### SDK conformance
+
+1. `plugin-manifest-requires-capability-metadata`
+   - missing capability fields => registration error.
+2. `aggregate-context-hides-disallowed-apis`
+   - compile-time assertion that aggregate handlers cannot access request/response APIs.
+3. `unknown-capability-default-deny`
+   - unknown class cannot be declared as implicitly allowed.
+
+### Runtime policy conformance
+
+4. `aggregate-allows-stream-local-dispatch`
+   - same-stream dispatch succeeds.
+5. `aggregate-denies-cross-stream-dispatch`
+   - target stream mismatch => denied with stable reason code.
+6. `aggregate-denies-request-response`
+   - interaction mode `request_response` => denied.
+7. `aggregate-denies-external-io`
+   - HTTP/broker/integration capability => denied.
+8. `aggregate-enforces-fail-closed`
+   - denied capability does not partially commit aggregate side effects.
+
+### Observability conformance
+
+9. `audit-event-on-capability-deny`
+   - denial emits audit record with bead/correlation identifiers.
+10. `metrics-tagged-by-plugin-capability-reason`
+   - denied counter dimensions present and stable.
+
+### Compatibility/escalation conformance
+
+11. `escalation-path-to-saga-intent`
+   - denied aggregate capability provides actionable escalation hint to SagaIntent.
+12. `policy-mode-strict-fails-startup`
+   - strict mode rejects invalid plugin registration at boot.
+
+---
+
+## 7) Trust model limits
+
+This policy is a **runtime boundary control**, not a full sandbox.
+
+Assumptions:
+1. Plugin code executes with host process privileges unless separately sandboxed by deployment.
+2. Capability checks protect framework entry points, not arbitrary host-language escape hatches.
+3. Malicious plugin packages can still attempt supply-chain or runtime abuse outside declared APIs.
+
+Limits (explicit):
+- No guarantee against arbitrary code execution if untrusted JS/TS plugins are loaded in-process.
+- No guarantee against exfiltration via side channels outside governed action APIs.
+- No OS/container isolation provided by this policy alone.
+
+Operational requirements:
+- Treat plugin packages as **trusted-by-admission** unless run in external sandbox/runtime.
+- Use package signing/allowlists and dependency scanning for supply-chain defense.
+- Prefer process isolation for untrusted third-party plugins.
+
+---
+
+## 8) Recommended implementation slices
+
+1. `CapabilityManifest` schema + validator.
+2. `CapabilityGuard` runtime gate in aggregate intent dispatch path.
+3. Aggregate context API narrowing (type-level and runtime-level).
+4. Structured deny reason codes + audit/metric adapters.
+5. Conformance suite wired into SDK/runtime CI.
+
+---
+
+## 9) Acceptance mapping for bead `redemeine-tdh`
+
+This design satisfies requested acceptance by providing:
+- **Capability matrix** (Section 4),
+- **Enforcement points** (Section 5),
+- **Conformance tests** (Section 6),
+- **Trust model limits** (Section 7).

--- a/docs/architecture/aggregate-vs-saga-intent-contract-v1.md
+++ b/docs/architecture/aggregate-vs-saga-intent-contract-v1.md
@@ -1,0 +1,343 @@
+﻿# AggregateIntent vs SagaIntent Contract and Routing (v1)
+
+- **Bead:** `redemeine-fa0`
+- **Status:** Architect handoff draft (implementation-ready)
+- **Scope:** Canonical intent split and routing policy between aggregate-local execution and saga/external orchestration.
+
+## 1) Goals and non-goals
+
+### Goals
+
+1. Define a canonical envelope shared by `AggregateIntent` and `SagaIntent`.
+2. Define capability boundaries so aggregate execution remains cheap, deterministic, and stream-local.
+3. Define deterministic routing/escalation rules from aggregate flow to saga runtime.
+4. Define idempotency keys and duplicate-handling expectations per intent class.
+5. Provide compatibility notes for current `@redemeine/mirage`, `@redemeine/saga`, and `@redemeine/saga-runtime` contracts.
+
+### Non-goals
+
+- Replacing current saga plugin-intent wire model in this wave.
+- Defining worker implementation internals (queue storage, lease strategy, scheduler backend).
+
+## 2) Intent model overview
+
+### `AggregateIntent` (push, stream-local automation)
+
+Use when work is bounded to the current aggregate stream and can complete in the aggregate command transaction (or immediate post-commit handoff) without cross-stream coordination.
+
+Properties:
+
+- low-latency / bounded execution
+- no long-running wait state
+- no external request-response requirement
+- no compensation workflow requirement
+
+### `SagaIntent` (pull/orchestration, cross-stream/external)
+
+Use when work needs orchestration semantics: external side effects, retries over time, compensation, schedule/wait, or multi-stream/cross-domain coordination.
+
+Properties:
+
+- execution lifecycle (`pending/in_progress/retrying/succeeded/failed/dead_letter`)
+- persisted orchestration state and correlation routing
+- explicit retry and escalation behavior
+
+## 3) Canonical envelope schema
+
+All intents (aggregate or saga) MUST carry this shared envelope:
+
+```ts
+export type IntentSchemaVersion = '1.0';
+
+export type IntentClass = 'aggregate' | 'saga';
+
+export interface CanonicalIntentEnvelopeV1<TPayload = unknown, TRoute = Record<string, unknown>> {
+  schemaVersion: IntentSchemaVersion; // '1.0'
+  intentClass: IntentClass;
+  intentType: string;                 // semantic name (e.g. 'dispatch', 'plugin-intent')
+
+  // identity
+  intentId: string;                   // stable per logical instruction
+  idempotencyKey: string;             // duplicate suppression key
+  emittedAt: string;                  // ISO-8601 UTC
+
+  // causality/correlation
+  correlationId: string;
+  causationId: string;
+  traceId?: string;
+  spanId?: string;
+
+  // origin scope
+  source: {
+    runtimePackage: string;           // '@redemeine/mirage' | '@redemeine/saga-runtime' | ...
+    aggregateId?: string;
+    aggregateType?: string;
+    sagaId?: string;
+    sagaType?: string;
+    commandType?: string;
+    eventType?: string;
+  };
+
+  payload: TPayload;
+  routing: TRoute;
+}
+```
+
+## 4) Specialization schemas
+
+### 4.1 AggregateIntent schema
+
+```ts
+export type AggregateIntentCapability =
+  | 'append_events'
+  | 'dispatch_local_command'
+  | 'enqueue_post_commit';
+
+export interface AggregateIntentV1<TPayload = unknown>
+  extends CanonicalIntentEnvelopeV1<TPayload, {
+    mode: 'inline' | 'post_commit';
+    targetStreamId: string;
+  }> {
+  intentClass: 'aggregate';
+  capabilities: readonly AggregateIntentCapability[];
+
+  // MUST remain stream-local
+  constraints: {
+    crossStream: false;
+    externalIo: false;
+    supportsCompensation: false;
+    maxExecutionMs?: number; // defensive budget for inline path
+  };
+}
+```
+
+Rules:
+
+- `crossStream=false` is mandatory.
+- External request-response is prohibited.
+- If required capability exceeds aggregate boundaries, router MUST escalate to `SagaIntent`.
+
+### 4.2 SagaIntent schema
+
+```ts
+export type SagaIntentCapability =
+  | 'dispatch'
+  | 'schedule'
+  | 'cancel_schedule'
+  | 'plugin_one_way'
+  | 'plugin_request_response'
+  | 'run_activity'
+  | 'compensate'
+  | 'cross_stream_coordination';
+
+export interface SagaIntentV1<TPayload = unknown>
+  extends CanonicalIntentEnvelopeV1<TPayload, {
+    executionMode: 'queued' | 'scheduled';
+    responseHandlerKey?: string;
+    errorHandlerKey?: string;
+    retryHandlerKey?: string;
+    handlerData?: unknown;
+  }> {
+  intentClass: 'saga';
+  capabilities: readonly SagaIntentCapability[];
+
+  orchestration: {
+    sagaId: string;
+    retryPolicy?: {
+      maxAttempts: number;
+      initialBackoffMs: number;
+      backoffCoefficient?: number;
+      maxBackoffMs?: number;
+    };
+    compensation?: readonly {
+      token: string;
+      payload: unknown;
+    }[];
+  };
+}
+```
+
+Rules:
+
+- `plugin_request_response`, `run_activity`, `compensate`, and `cross_stream_coordination` are saga-only.
+- Request-response intents MUST provide response + error routing handlers.
+- Saga runtime owns lifecycle transitions and retry/dead-letter decisions.
+
+## 5) Routing decision table
+
+Router input = canonical envelope + declared capabilities + execution hints.
+
+| Condition | Route | Why |
+|---|---|---|
+| Stream-local mutation only, no wait, no external IO | `AggregateIntent` inline | Keep command path cheap/deterministic |
+| Stream-local action but must run after commit | `AggregateIntent` post_commit | Maintain atomic append before side effects |
+| Requires external call with response correlation | `SagaIntent` (`plugin_request_response`) | Needs durable callback/error routing |
+| Requires retries beyond immediate command turn | `SagaIntent` | Needs persisted retry policy state |
+| Requires schedule/delay/wake-up | `SagaIntent` (`schedule`) | Needs scheduler integration |
+| Requires compensation/rollback semantics | `SagaIntent` (`compensate`) | Aggregate path has no compensation ledger |
+| Requires cross-stream or cross-aggregate coordination | `SagaIntent` (`cross_stream_coordination`) | Aggregate boundary intentionally local |
+| Aggregate policy/capability violation detected | Escalate to `SagaIntent` + emit inspection warning | Safe fallback preserving bounded aggregate contract |
+
+## 6) Escalation policy
+
+Escalation means transforming a rejected `AggregateIntent` candidate into a canonical `SagaIntent` while preserving causality.
+
+Escalation MUST:
+
+1. Preserve `intentId`, `correlationId`, and `causationId`.
+2. Recompute class-scoped `idempotencyKey` with saga namespace (see section 7).
+3. Emit inspection signal (recommended name):
+   - `inspection.intent.routing.escalated`
+4. Record `escalationReason` from the finite set:
+   - `cross_stream_required`
+   - `external_io_required`
+   - `response_correlation_required`
+   - `retry_window_required`
+   - `compensation_required`
+   - `policy_violation`
+
+Escalation MUST NOT happen for purely local operations where aggregate path is valid.
+
+## 7) Idempotency contract
+
+### 7.1 Key format
+
+```txt
+aggregate:{aggregateId}:{intentType}:{intentId}
+saga:{sagaId}:{intentType}:{intentId}:{attempt?}
+```
+
+Guidance:
+
+- Aggregate keys are stable across replays for the same logical intent.
+- Saga keys MAY include attempt discriminator for observability, but dedupe key for side effects SHOULD remain stable across retries when target endpoint supports idempotency.
+
+### 7.2 Duplicate handling
+
+- `AggregateIntent`:
+  - duplicate `idempotencyKey` in same stream/version window => no-op + informational inspection event.
+- `SagaIntent`:
+  - duplicate pending/in_progress key => collapse to existing execution record.
+  - duplicate after terminal success => return cached terminal outcome where possible.
+  - duplicate after terminal failure/dead-letter => require explicit re-drive key suffix or operator override.
+
+## 8) Compatibility notes with current runtime
+
+### 8.1 `@redemeine/saga` contract alignment
+
+Current `SagaIntent` shape in `packages/saga/src/createSaga.ts` is a unified `plugin-intent` model with metadata (`sagaId`, `correlationId`, `causationId`).
+
+Compatibility mapping:
+
+- `CanonicalIntentEnvelopeV1.intentClass='saga'` maps to existing `SagaIntent` union semantics.
+- Existing `routing_metadata` (`response_handler_key`, `error_handler_key`, `retry_handler_key`, `handler_data`) maps to `routing` in section 4.2.
+- Existing `retry_policy_override` and `compensation` map to `orchestration.retryPolicy` / `orchestration.compensation`.
+
+### 8.2 `@redemeine/saga-runtime` reference adapter alignment
+
+Current runtime intents include `dispatch`, `schedule`, `cancel-schedule`, `run-activity`, `plugin-one-way`, `plugin-request`.
+
+Compatibility note:
+
+- Canonical `SagaIntentCapability` is a superset vocabulary; current runtime intent `type` values remain valid wire forms for v1 migration.
+- Canonical envelope can be introduced as adapter layer without breaking existing reference adapter tests.
+
+### 8.3 `@redemeine/mirage` / aggregate path compatibility
+
+Current aggregate command routing is stream-centric and does not model long-running orchestration.
+
+Compatibility note:
+
+- `AggregateIntent` is additive as a formal contract around existing behavior.
+- No mandatory behavior change for current command processors until router enforcement is enabled.
+
+## 9) Backward/forward compatibility policy
+
+1. Additive optional fields in envelope/specializations are non-breaking.
+2. Required field additions require schema major bump (`1.x` -> `2.0`).
+3. During migration, dual-shape emission is allowed:
+   - existing runtime-native intent shape
+   - canonical envelope wrapper
+4. Toggle strategy:
+   - `intentContractMode = 'legacy' | 'dual' | 'canonical'`
+
+## 10) Examples
+
+### 10.1 Aggregate-local dispatch
+
+```json
+{
+  "schemaVersion": "1.0",
+  "intentClass": "aggregate",
+  "intentType": "dispatch_local_command",
+  "intentId": "i-1001",
+  "idempotencyKey": "aggregate:order-123:dispatch_local_command:i-1001",
+  "emittedAt": "2026-04-08T20:00:00Z",
+  "correlationId": "corr-1",
+  "causationId": "cmd-1",
+  "source": {
+    "runtimePackage": "@redemeine/mirage",
+    "aggregateId": "order-123",
+    "aggregateType": "Order"
+  },
+  "payload": { "command": "reserve_inventory", "sku": "SKU-1", "qty": 2 },
+  "routing": { "mode": "inline", "targetStreamId": "order-123" },
+  "capabilities": ["dispatch_local_command"],
+  "constraints": {
+    "crossStream": false,
+    "externalIo": false,
+    "supportsCompensation": false
+  }
+}
+```
+
+### 10.2 Escalated external request-response
+
+```json
+{
+  "schemaVersion": "1.0",
+  "intentClass": "saga",
+  "intentType": "plugin_request_response",
+  "intentId": "i-1001",
+  "idempotencyKey": "saga:saga-77:plugin_request_response:i-1001",
+  "emittedAt": "2026-04-08T20:00:01Z",
+  "correlationId": "corr-1",
+  "causationId": "cmd-1",
+  "source": {
+    "runtimePackage": "@redemeine/saga-runtime",
+    "aggregateId": "order-123",
+    "sagaId": "saga-77",
+    "sagaType": "order_fulfillment"
+  },
+  "payload": {
+    "plugin_key": "http",
+    "action_name": "get",
+    "execution_payload": { "url": "https://api.example.com/invoices/order-123" }
+  },
+  "routing": {
+    "executionMode": "queued",
+    "responseHandlerKey": "invoice.fetch.succeeded",
+    "errorHandlerKey": "invoice.fetch.failed",
+    "retryHandlerKey": "invoice.fetch.retry",
+    "handlerData": { "orderId": "order-123" }
+  },
+  "capabilities": ["plugin_request_response", "cross_stream_coordination"],
+  "orchestration": {
+    "sagaId": "saga-77",
+    "retryPolicy": { "maxAttempts": 5, "initialBackoffMs": 500, "backoffCoefficient": 2 }
+  }
+}
+```
+
+## 11) Acceptance criteria mapping (`redemeine-fa0`)
+
+- **Schemas:** Sections 3 and 4.
+- **Routing table:** Section 5.
+- **Idempotency/escalation rules:** Sections 6 and 7.
+- **Compatibility notes:** Section 8.
+
+## 12) Risks and assumptions
+
+- **Assumption:** aggregate pipeline remains strict stream-local execution boundary.
+- **Risk:** premature escalation may increase orchestration load; mitigate with explicit capability checks and metrics.
+- **Risk:** inconsistent idempotency behavior across plugins; mitigate with canonical key guidance and adapter conformance tests.

--- a/docs/architecture/cdc-relay-mq-inbox-durability-semantics.md
+++ b/docs/architecture/cdc-relay-mq-inbox-durability-semantics.md
@@ -1,0 +1,264 @@
+---
+title: CDC Relay to MQ and Inbox Durability Semantics
+last_updated: 2026-04-08
+status: proposed
+bead: redemeine-yvf
+ai_priority: high
+---
+
+# CDC Relay to MQ and Inbox Durability Semantics
+
+## 1. Goals and Scope
+
+Define the runtime contract for:
+
+1. **CDC relay publisher**: transforms durable commit feed envelopes into MQ fanout messages.
+2. **Inbox consumer**: persists messages before ack, deduplicates by delivery key, and applies idempotent handler execution.
+3. **Failure posture**: retry and DLQ policy for publish and consume paths.
+4. **Operability**: required metrics, alerts, and checkpoints.
+
+This architecture assumes the upstream durable commit feed contract from **redemeine-48z** (ULID cursor and ordered commit envelopes).
+
+---
+
+## 2. Contract Summary
+
+### 2.1 Canonical IDs and keys
+
+- `commit_id` (ULID): globally ordered commit identity.
+- `stream_id`: aggregate or partition stream identifier.
+- `event_index`: ordinal within commit envelope.
+- `message_id`: deterministic `sha256(commit_id + event_index + topic)`.
+- `dedupe_key`: equals `message_id` (stable across retries/replays).
+- `relay_cursor`: last durable commit_id successfully checkpointed by relay.
+- `consumer_checkpoint`: per consumer-group, highest *contiguously completed* inbox sequence.
+
+### 2.2 Delivery and processing guarantees
+
+- MQ transport: **at-least-once**.
+- Consumer handler effects: **effectively-once** via `persist-before-ack + dedupe + idempotent handler`.
+- Ordering:
+  - Preserved per partition key (`stream_id`) by broker partitioning.
+  - Not globally ordered across partitions.
+- Replay safety:
+  - Relay replay from cursor is safe due to deterministic message IDs.
+  - Consumer replay is safe due to inbox dedupe state.
+
+---
+
+## 3. Sequence Diagrams
+
+## 3.1 Publish path (CDC relay)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Feed as Durable Commit Feed
+    participant Relay as CDC Relay Worker
+    participant Outbox as Relay Publish Log/Checkpoint Store
+    participant MQ as Message Broker
+
+    Feed->>Relay: Poll commits after relay_cursor
+    Relay->>Relay: Build envelope + message_id/dedupe_key
+    Relay->>Outbox: reserve publish attempt(commit_id,event_index)
+    Relay->>MQ: Publish message (at-least-once)
+
+    alt publish success
+        MQ-->>Relay: broker ack(message_id)
+        Relay->>Outbox: mark published + attempt metadata
+        Relay->>Outbox: advance relay_cursor when commit fully published
+    else transient failure
+        MQ--xRelay: timeout/5xx/throttle
+        Relay->>Outbox: increment attempt, schedule retry(backoff+jitter)
+    else permanent failure
+        MQ--xRelay: schema reject/authz/not-found
+        Relay->>Outbox: mark poison_publish
+        Relay->>Outbox: move to relay DLQ topic + hold cursor gate for commit policy
+    end
+```
+
+### Publish checkpoints
+
+- **Checkpoint A (reservation)**: intent to publish is persisted before network call.
+- **Checkpoint B (broker ack)**: publish marked successful only after broker confirmation.
+- **Checkpoint C (cursor advance)**: relay cursor moves only when all messages in commit are either published or explicitly policy-handled.
+
+## 3.2 Consume path (inbox durability)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant MQ as Message Broker
+    participant C as Inbox Consumer
+    participant Inbox as Inbox Store
+    participant H as Domain Handler
+    participant CP as Consumer Checkpoint Store
+
+    MQ->>C: Deliver message(message_id,dedupe_key,payload)
+    C->>Inbox: Upsert inbox row by dedupe_key (received)
+
+    alt first-seen message
+        C->>Inbox: persist payload + metadata + received_at
+        C->>H: execute idempotent handler
+
+        alt handler success
+            H-->>C: ok
+            C->>Inbox: mark processed(success)
+            C->>CP: advance consumer_checkpoint (contiguous)
+            C->>MQ: ACK
+        else transient handler error
+            H--xC: retryable
+            C->>Inbox: mark failed_transient + next_attempt_at
+            C->>MQ: NACK/requeue (or visibility timeout)
+        else permanent handler error
+            H--xC: non-retryable/validation
+            C->>Inbox: mark dead_lettered + error_class
+            C->>MQ: ACK (after DLQ publish or broker DLQ routing)
+        end
+
+    else duplicate delivery
+        C->>Inbox: detect existing dedupe_key state
+        alt state == processed(success)
+            C->>MQ: ACK (no-op)
+        else state == failed_transient
+            C->>MQ: NACK/requeue according to policy
+        else state == dead_lettered
+            C->>MQ: ACK
+        end
+    end
+```
+
+### Consume checkpoints
+
+- **Checkpoint 1 (persist-before-ack)**: inbox row exists before any ACK.
+- **Checkpoint 2 (effect applied)**: handler success persisted before ACK.
+- **Checkpoint 3 (checkpoint advance)**: consumer checkpoint only after contiguous success window.
+
+---
+
+## 4. Retry and DLQ Policy
+
+## 4.1 Publisher (relay) policy
+
+- Classification:
+  - **Retryable**: network timeouts, broker unavailable, rate limit.
+  - **Non-retryable**: malformed envelope, authz denied, unknown topic.
+- Backoff: exponential with jitter, e.g. `base=500ms, factor=2, max=5m`.
+- Attempt budget: default `max_attempts=12` before DLQ.
+- DLQ payload must include:
+  - original envelope
+  - `commit_id`, `message_id`, attempt count
+  - error class + last error message + first/last failure timestamps
+
+## 4.2 Consumer (inbox) policy
+
+- Retryable handler errors: retry with capped exponential backoff and attempt counter stored in inbox row.
+- Permanent errors: mark dead-lettered and stop redelivery loop.
+- Poison heuristic: same dedupe_key failing with equivalent stack fingerprint beyond threshold triggers immediate DLQ.
+- Replay policy: operator can replay from DLQ by re-enqueueing same payload; dedupe prevents duplicate side effects if already completed.
+
+---
+
+## 5. Data Model (minimal)
+
+### 5.1 Relay publish log/checkpoint
+
+- `relay_publish_attempts`:
+  - PK `(commit_id, event_index, topic)`
+  - `message_id`, `status`, `attempt_count`, `next_attempt_at`, `last_error_class`, `updated_at`
+- `relay_cursor`:
+  - `relay_name`, `last_commit_id`, `updated_at`
+
+### 5.2 Inbox store
+
+- `inbox_messages`:
+  - PK `dedupe_key`
+  - `message_id`, `partition_key`, `payload_hash`, `status`
+  - `attempt_count`, `next_attempt_at`
+  - `received_at`, `processed_at`
+  - `error_class`, `error_fingerprint`, `dead_lettered_at`
+- `consumer_checkpoint`:
+  - PK `(consumer_group, shard)`
+  - `last_contiguous_sequence`, `last_message_id`, `updated_at`
+
+---
+
+## 6. Metrics and Alerts
+
+## 6.1 Relay metrics
+
+- Throughput:
+  - `cdc_relay_messages_published_total`
+  - `cdc_relay_publish_bytes_total`
+- Reliability:
+  - `cdc_relay_publish_failures_total{class}`
+  - `cdc_relay_retry_scheduled_total`
+  - `cdc_relay_dlq_total`
+- Lag:
+  - `cdc_relay_feed_lag_seconds` (feed head timestamp - relay cursor timestamp)
+  - `cdc_relay_oldest_unpublished_age_seconds`
+
+### Relay alerts
+
+- **Critical**: `cdc_relay_dlq_total` increase > threshold over 5m.
+- **High**: feed lag exceeds SLO (e.g. >120s for 10m).
+- **High**: zero publish throughput while feed has new commits for >5m.
+
+## 6.2 Consumer metrics
+
+- Flow:
+  - `inbox_messages_received_total`
+  - `inbox_messages_processed_total`
+  - `inbox_messages_acked_total`
+- Reliability:
+  - `inbox_handler_failures_total{class}`
+  - `inbox_retry_scheduled_total`
+  - `inbox_dead_lettered_total`
+  - `inbox_duplicates_total`
+- Latency/lag:
+  - `inbox_processing_latency_ms`
+  - `inbox_end_to_end_lag_seconds` (commit timestamp to processed_at)
+  - `consumer_checkpoint_stall_seconds`
+
+### Consumer alerts
+
+- **Critical**: dead-lettered rate spike above baseline for 10m.
+- **High**: checkpoint stall beyond threshold while queue depth grows.
+- **High**: retry queue age p95 exceeds configured max backoff window.
+- **Medium**: duplicate rate anomaly indicates potential redelivery storm.
+
+---
+
+## 7. Operational Runbook Semantics
+
+1. **Replay from relay cursor**: safe; deterministic message IDs permit duplicate suppression downstream.
+2. **Replay from consumer checkpoint**: safe if inbox store retained; dedupe_key prevents re-applying effects.
+3. **DLQ redrive**: only after error class reclassified or handler fix deployed.
+4. **Data retention**:
+   - Keep processed inbox rows for at least max replay horizon.
+   - Keep dedupe tombstones longer than broker redelivery retention.
+
+---
+
+## 8. Risks and Assumptions
+
+### Assumptions
+
+- Broker supports ACK/NACK or equivalent visibility semantics.
+- Consumers can write inbox state transactionally with handler side-effects (or enforce compensation when split).
+- Upstream commit envelopes include immutable commit timestamp and ULID commit_id.
+
+### Risks
+
+- Hot partition skew can stall contiguous checkpoint advancement.
+- Very long inbox retention may require archival strategy.
+- Cross-resource transaction gaps (inbox DB vs external side-effect target) require strict idempotency keys at integration boundaries.
+
+---
+
+## 9. Acceptance Mapping (redemeine-yvf)
+
+- Contract coverage: sections 2 and 5.
+- Sequence diagrams: sections 3.1 and 3.2.
+- Retry/DLQ policy: section 4.
+- Metrics/alerts: section 6.

--- a/docs/architecture/ci-dependency-vulnerability-automation-blueprint-redemeine-1uh.2.md
+++ b/docs/architecture/ci-dependency-vulnerability-automation-blueprint-redemeine-1uh.2.md
@@ -1,0 +1,150 @@
+# CI Hardening Wave 2 Blueprint: Dependency Automation + Vulnerability Scanning (redemeine-1uh.2)
+
+## Scope and objective
+
+This blueprint defines a production-ready dependency automation and vulnerability scanning strategy for the Redemeine Bun/npm monorepo and GitHub Actions dependencies. It is planning-only and intentionally scoped to Bead **redemeine-1uh.2**.
+
+## Desired outcomes
+
+1. Keep dependency drift low with predictable update cadence and bounded PR noise.
+2. Detect known vulnerabilities early in PR/CI and continuously on default branch.
+3. Enforce severity-based merge/release gates with clear exception policy.
+4. Provide explicit escalation ownership and remediation SLAs.
+
+## Recommended tooling stack
+
+- **Dependency automation:** Dependabot (native GitHub integration, low ops overhead)
+- **Application dependency vulnerability scanning:** `bun audit --json` plus `npm audit --audit-level` parity check for registry advisory coverage
+- **SCA + transitive and ecosystem coverage:** Trivy filesystem scan in CI (`trivy fs`) against lockfile + source
+- **GitHub Actions dependency scanning:** Dependabot `package-ecosystem: github-actions`
+- **Code scanning signal (optional-but-recommended):** CodeQL JavaScript workflow (separate bead if not already adopted)
+
+## Config artifacts to add
+
+### 1) `.github/dependabot.yml`
+
+Create a multi-ecosystem Dependabot config with grouped updates and bounded churn:
+
+- `package-ecosystem: npm`
+  - directories: `/`, `/website`, `/packages/*`
+  - schedule: weekly (Mon 05:00 UTC)
+  - open-pull-requests-limit: 10
+  - grouping:
+    - `dev-tooling` (eslint, typescript, jest, turbo, typedoc, tsx)
+    - `runtime-safe` (patch/minor runtime libs except high-risk packages)
+  - ignore:
+    - major updates for runtime-critical packages unless manually requested
+- `package-ecosystem: github-actions`
+  - directory: `/`
+  - schedule: weekly (Mon 05:15 UTC)
+  - open-pull-requests-limit: 5
+  - group all action bumps into one PR
+
+### 2) `.github/workflows/dependency-security.yml`
+
+A dedicated required workflow with stable check name `dependency-security-gate`.
+
+Triggers:
+- `pull_request` to `main`/`master`
+- `push` to `main`/`master`
+- `schedule` daily (e.g., 03:30 UTC)
+- `workflow_dispatch`
+
+Permissions (minimum):
+- `contents: read`
+- `security-events: write` only if uploading SARIF
+
+Core CI steps:
+1. checkout
+2. setup bun `1.3.11`
+3. `bun install --frozen-lockfile`
+4. `bun audit --json` (parsed for severity gate)
+5. `npm audit --audit-level=high --omit=dev` (runtime gate)
+6. `npm audit --audit-level=critical` (dev+runtime critical gate)
+7. `trivy fs --scanners vuln,secret --severity HIGH,CRITICAL --exit-code 1 --format sarif --output trivy.sarif .`
+8. upload SARIF artifact (if security-events enabled)
+
+## Severity thresholds and gate policy
+
+### Pull request merge gate
+
+Fail PR when any of these are true:
+- **Runtime dependencies**: any `HIGH` or `CRITICAL` vulnerability affecting lockfile-resolved dependency tree.
+- **Dev dependencies**: any `CRITICAL` vulnerability.
+- **GitHub Actions**: Dependabot flags a security update not yet merged and currently exploitable in active workflow.
+
+Warn-only on PR (non-blocking) for:
+- Dev dependency `HIGH` vulnerabilities with no fix available.
+- CVEs with disputed severity where EPSS + exploit maturity indicates low practical risk (requires documented exception).
+
+### Default branch and scheduled scans
+
+- Scheduled daily scan fails on **any HIGH/CRITICAL** regardless of dev/runtime split and opens/updates tracking bead automatically (future automation bead).
+- Release pipeline should block publish if unresolved runtime HIGH/CRITICAL exists at release commit.
+
+## Update cadence and merge strategy
+
+- **Security updates:** daily checks, auto-open PRs immediately.
+- **Routine updates:** weekly grouped PRs.
+- **Automerge allowed only for:**
+  - patch-level dev-tooling updates,
+  - CI-only/GitHub Action patch updates,
+  - passing required CI + dependency-security-gate.
+- **No automerge:**
+  - runtime major updates,
+  - any update touching lockfile + runtime package with known breaking history,
+  - any PR containing vulnerability suppressions/exceptions.
+
+## Noise-control policy
+
+- Group low-risk updates by domain (`dev-tooling`, `github-actions`).
+- Cap open Dependabot PRs per ecosystem.
+- Prefer single daily security workflow run plus PR-triggered checks to avoid duplicate alerts.
+- Deduplicate advisories by CVE/GHSA and package path before creating remediation work.
+
+## Escalation workflow and ownership
+
+### Roles
+
+- **Primary owner:** on-call maintainer for repository security triage.
+- **Secondary owner:** package/domain maintainer for affected runtime path.
+- **Approver for exceptions:** tech lead or security delegate.
+
+### Escalation path
+
+1. CI finds vulnerability -> mark failing check and annotate advisory summary.
+2. Owner triages in <= 1 business day and classifies: runtime/dev, reachable/not reachable, fix available/no-fix.
+3. If fix available, create remediation PR immediately (or merge Dependabot PR).
+4. If no fix available, create temporary mitigation issue + documented exception with expiry date.
+5. If actively exploited/high business impact, escalate to incident channel and freeze non-security merges until mitigation in place.
+
+## Remediation timelines (SLA)
+
+- **Critical (runtime, reachable):** mitigate or patch within **24 hours**.
+- **Critical (dev-only):** remediate within **3 calendar days**.
+- **High (runtime):** remediate within **7 calendar days**.
+- **High (dev-only):** remediate within **14 calendar days**.
+- **Moderate/Low:** handle in weekly maintenance windows or next minor release.
+
+If SLA cannot be met, mandatory exception record must include:
+- CVE/GHSA identifiers
+- impact statement
+- compensating controls
+- expiration date (max 30 days)
+- explicit approver
+
+## Auditor pass/fail checklist for this blueprint
+
+Pass when implementation (future Engineer bead) includes:
+1. `.github/dependabot.yml` with npm + github-actions ecosystems, weekly schedule, grouping, and PR caps.
+2. `dependency-security-gate` workflow with stated triggers and scan commands.
+3. Severity gates match policy (runtime HIGH/CRITICAL blocking; dev CRITICAL blocking).
+4. Escalation and SLA policy is documented and referenced in repo security docs (`SECURITY.md` in later wave).
+
+Fail when any of the above is missing or severity thresholds are weaker than defined.
+
+## Dependency notes
+
+- Depends on stable required PR gate from **redemeine-1uh.1**.
+- Aligns with workflow hardening policy from **redemeine-1uh.4** (permissions + SHA pinning).
+- Inputs to wave-3 governance controls in **redemeine-1uh.5**.

--- a/docs/architecture/ci-hardening-wave1-github-actions-policy.md
+++ b/docs/architecture/ci-hardening-wave1-github-actions-policy.md
@@ -1,0 +1,172 @@
+# CI Hardening Wave 1 Blueprint: GitHub Actions Least Privilege & SHA Pinning
+
+- **Bead**: `redemeine-1uh.4`
+- **Owner Stage**: Architect
+- **Scope**: Policy + rollout design only (no workflow implementation in this bead)
+- **Non-goals**: Dependency automation (wave 2), branch protection/release integrity enforcement (wave 3)
+
+## 1. Problem Statement
+
+Current workflows include broad write permissions in at least one PR-triggered workflow and use mutable version tags for third-party actions (`@v4`, `@v2`, etc.). This creates two avoidable risks:
+
+1. **Over-privileged `GITHUB_TOKEN`** can be abused if any action step is compromised.
+2. **Mutable action refs** can change over time without explicit repository review.
+
+Wave 1 introduces a constrained trust + enforcement model to reduce blast radius while preserving delivery speed.
+
+## 2. Wave 1 Policy (Normative)
+
+The following requirements are mandatory for all workflows in `.github/workflows` after wave 1 rollout.
+
+### 2.1 Token Permissions (Least Privilege)
+
+1. Every workflow **MUST** define top-level `permissions`.
+2. Workflow-level `permissions` **MUST** be set to the minimum common baseline for all jobs, preferring:
+   - `contents: read` for most read-only CI jobs, or
+   - `{}` when checkout/repository read is not required.
+3. Job-level `permissions` **MUST** be used to elevate only specific jobs requiring write scopes.
+4. Write scopes (`*: write`) are **DENY by default** and require explicit rationale in workflow comments and PR description.
+5. Pull request validation workflows **MUST NOT** request repository write scopes unless they intentionally mutate PR branches and are allowlisted (see trust exceptions).
+
+### 2.2 Action Reference Immutability
+
+1. All `uses:` references to third-party actions **MUST** pin to a full 40-character commit SHA.
+2. Each SHA-pinned action **MUST** include a trailing comment indicating the upstream semver tag used for readability (example: `# v4.2.2`).
+3. Local actions (`uses: ./.github/actions/...`) are exempt from SHA pinning.
+4. Docker image actions **SHOULD** be digest-pinned (`@sha256:...`) where used (none currently in scope).
+
+### 2.3 Approved Trust Exceptions
+
+Wave 1 supports a narrowly-scoped exception model.
+
+Allowed without additional approval:
+
+- Official GitHub-authored actions under `actions/*` may remain tag-pinned (`@vN`) **only during transition**, but target state is still SHA pinning.
+- First-party reusable workflows within this repository.
+
+Requires explicit security exception entry:
+
+- Any non-SHA-pinned third-party action after migration date.
+- Any PR workflow requesting write permissions (`contents: write`, `pull-requests: write`, etc.).
+- Any use of `pull_request_target` with write scopes.
+
+Exception record fields (kept in policy file introduced in wave 1 implementation bead):
+
+- workflow path
+- job id
+- scope/ref exception requested
+- business reason
+- expiry date (required, max 30 days)
+- approver
+
+Expired exceptions automatically fail enforcement.
+
+## 3. Target Permission Matrix (Current Workflows)
+
+This matrix defines intended post-wave-1 permissions for existing workflows.
+
+| Workflow | Trigger | Current Risk | Target Workflow Permissions | Job-level Elevation | Notes |
+|---|---|---|---|---|---|
+| `testing-benchmark.yml` | `pull_request` | Mutable action refs | `contents: read` | none | Pure read-only benchmark job |
+| `publish.yml` | `release` | Mutable refs | `contents: read` | `id-token: write` for publish job | OIDC provenance requires id-token write |
+| `deploy-docs.yml` | `push main` | Mutable refs | `contents: read` | `pages: write`, `id-token: write` for deploy job | Keep write only for Pages deployment |
+| `documentation-audit.yml` | `pull_request` | Broad write on PR + mutable refs | baseline `contents: read` | temporary exception if auto-commit remains; otherwise none | Prefer redesign to artifact/check mode in wave 2+ |
+
+## 4. Maintenance & Update Model for SHA Pins
+
+### 4.1 Update Cadence
+
+- **Weekly** automated proposal PR (Dependabot/Renovate in wave 2) for action SHA bumps.
+- **Out-of-band** patching within 24h for critical GHSA/CVE affecting an action dependency.
+
+### 4.2 Update Process
+
+1. Bot or maintainer opens PR updating SHAs and tag comments.
+2. Validation job confirms all refs are immutable and no unauthorized permission expansion occurred.
+3. CODEOWNERS/security reviewer approves if write scope or exception touched.
+4. Merge once required checks pass.
+
+### 4.3 Rollback Strategy
+
+- Revert SHA bump commit(s) if regressions appear.
+- If urgent, temporarily allowlisted exception with expiry <= 7 days.
+
+## 5. Enforcement Checks (Auditor Pass/Fail Contract)
+
+Wave 1 defines policy checks with deterministic outcomes.
+
+### Check A: Action Pinning Compliance
+
+**Pass when all are true:**
+
+- Every external `uses:` in `.github/workflows/*.yml` is either:
+  - full commit SHA pinned (`@` + 40 hex), or
+  - explicitly listed in active exception allowlist.
+
+**Fail when any are true:**
+
+- Any external action uses mutable tag/branch ref not allowlisted.
+- Any exception is expired or missing required metadata.
+
+### Check B: Permission Baseline Compliance
+
+**Pass when all are true:**
+
+- Every workflow defines top-level `permissions`.
+- No job grants write permission unless required by matrix/exception.
+- PR-triggered workflows have no write scopes unless active exception exists.
+
+**Fail when any are true:**
+
+- Missing top-level `permissions`.
+- Unjustified write scope added in workflow or job.
+- PR workflow contains write scope without valid exception.
+
+### Check C: Privilege Regression Guard
+
+**Pass when all are true:**
+
+- PR does not increase permission scope compared to main branch baseline, unless PR includes approved exception update.
+
+**Fail when any are true:**
+
+- Scope expansion is detected without linked/approved exception artifact.
+
+## 6. Wave 1 Rollout Plan (Bounded)
+
+1. **Document policy + matrix** (this bead).
+2. **Implement enforcement in monitor mode** (non-blocking check for 1 week):
+   - emit violations in job summary.
+3. **Migrate workflows to policy target**:
+   - convert refs to SHAs,
+   - reduce top-level permissions,
+   - move write scopes to minimal job scope.
+4. **Enable blocking mode** for checks A+B; keep check C monitor-only for one additional week.
+5. **Promote check C to blocking** once baseline stabilized.
+
+## 7. Risks & Assumptions
+
+### Assumptions
+
+- Repository maintainers accept temporary exception handling for `documentation-audit.yml` PR writes.
+- Upcoming wave 2 introduces automation for SHA refresh to avoid manual drift.
+
+### Risks
+
+- SHA pinning without update automation can cause stale dependencies.
+- Tightening PR write permissions may require redesign of auto-commit behavior.
+
+### Mitigations
+
+- Time-box exceptions with expiry and explicit owner.
+- Treat permission escalation as security-significant change requiring review.
+
+## 8. Handoff to Engineer/Auditor
+
+Implementation bead(s) should include:
+
+1. Policy artifact file(s) for exceptions and baseline matrix.
+2. CI check script/workflow that enforces Checks A/B/C.
+3. Migration commits per workflow with rationale.
+
+Auditor verifies using section 5 pass/fail contract and records evidence per workflow file.

--- a/docs/architecture/ci-hardening-wave2-governance-blueprint.md
+++ b/docs/architecture/ci-hardening-wave2-governance-blueprint.md
@@ -1,0 +1,178 @@
+# CI Hardening Wave 2 Governance Blueprint (redemeine-1uh.3)
+
+## Scope and Intent
+
+This blueprint defines governance design for:
+
+1. `SECURITY.md` policy content and maintenance contract.
+2. `CODEOWNERS` ownership coverage for high-risk repository paths.
+3. Branch-protection/ruleset integration so code owner review is enforced where risk is highest.
+
+This is a planning artifact only. No enforcement implementation is included in this bead.
+
+## Target File Paths
+
+- `SECURITY.md` (repository root)
+- `.github/CODEOWNERS` (authoritative location for GitHub)
+
+### Path policy
+
+- Keep a single authoritative CODEOWNERS file under `.github/CODEOWNERS`.
+- If a root-level `CODEOWNERS` ever exists, it must be removed to avoid ambiguity.
+
+## SECURITY.md Blueprint
+
+## Required Sections
+
+1. **Security Policy Overview**
+   - Purpose and scope (what projects/packages are covered).
+2. **Supported Versions**
+   - Table listing maintained release lines and support status.
+3. **How to Report a Vulnerability**
+   - Private reporting channel (security email or GH private advisory path).
+   - Explicit instruction to avoid public issues for suspected vulnerabilities.
+4. **What to Include in Reports**
+   - Affected version/commit, reproduction steps, impact hypothesis, proof-of-concept guidance.
+5. **Response Expectations and SLA**
+   - Acknowledgement target (e.g., 2 business days).
+   - Triage target (e.g., 5 business days).
+   - Status update cadence (e.g., weekly until resolution).
+6. **Disclosure and Fix Process**
+   - Coordinated disclosure model, embargo handling, release + advisory publication flow.
+7. **Severity and Prioritization**
+   - CVSS-informed severity banding and patch priority expectations.
+8. **Safe Harbor / Good-Faith Research**
+   - Statement protecting good-faith disclosure within policy boundaries.
+9. **Security Updates and Credits**
+   - Where advisories/changelog notes appear and how researchers are credited.
+
+## SECURITY.md Content Requirements
+
+- Must reference maintained branch/version policy used by release process.
+- Must define who can receive reports when primary contact is unavailable.
+- Must define communication fallback if email is unavailable.
+- Must avoid promising timelines that cannot be staffed.
+
+## CODEOWNERS Blueprint
+
+## Ownership Model
+
+Use team-based owners (preferred) plus individual fallback owners per critical area.
+
+### Proposed owner groups (to provision/confirm)
+
+- `@redemeine/core-maintainers` (runtime/package maintainers)
+- `@redemeine/platform-security` (security + CI governance)
+- `@redemeine/docs-maintainers` (documentation maintainers)
+- Fallback individuals: at least two maintainers with admin/review access (to avoid single-point reviewer bottlenecks)
+
+## Required CODEOWNERS Entries (minimum)
+
+```text
+# Global fallback
+* @redemeine/core-maintainers
+
+# Security policy itself
+/SECURITY.md @redemeine/platform-security @redemeine/core-maintainers
+
+# CI/workflow governance (high risk)
+/.github/workflows/* @redemeine/platform-security @redemeine/core-maintainers
+/.github/CODEOWNERS @redemeine/platform-security @redemeine/core-maintainers
+
+# Release/publish pipeline controls (high risk)
+/bin/* @redemeine/platform-security @redemeine/core-maintainers
+/package.json @redemeine/core-maintainers @redemeine/platform-security
+/bun.lock @redemeine/core-maintainers @redemeine/platform-security
+/package-lock.json @redemeine/core-maintainers @redemeine/platform-security
+
+# Runtime and packages
+/src/** @redemeine/core-maintainers
+/packages/aggregate/** @redemeine/core-maintainers
+/packages/kernel/** @redemeine/core-maintainers
+/packages/mirage/** @redemeine/core-maintainers
+/packages/projection/** @redemeine/core-maintainers
+/packages/saga/** @redemeine/core-maintainers
+/packages/saga-runtime/** @redemeine/core-maintainers
+/packages/testing/** @redemeine/core-maintainers
+/packages/root-runner/** @redemeine/core-maintainers
+
+# Documentation
+/docs/** @redemeine/docs-maintainers @redemeine/core-maintainers
+/website/** @redemeine/docs-maintainers @redemeine/core-maintainers
+/README.md @redemeine/docs-maintainers @redemeine/core-maintainers
+/CONTRIBUTING.md @redemeine/docs-maintainers @redemeine/core-maintainers
+```
+
+> If team handles are not yet available, temporary individual owners may be used, but must be replaced by team handles in the next governance maintenance cycle.
+
+## Ownership Matrix by Directory/Risk
+
+| Path scope | Risk level | Primary owners | Secondary/fallback | Rationale |
+|---|---|---|---|---|
+| `.github/workflows/*` | Critical | platform-security | core-maintainers | Prevent CI privilege or supply-chain drift |
+| `bin/*`, `publish.yml`, manifests/locks | Critical | core-maintainers | platform-security | Release integrity and dependency trust |
+| `SECURITY.md`, `.github/CODEOWNERS` | Critical | platform-security | core-maintainers | Governance controls must be tightly reviewed |
+| `packages/**`, `src/**` | High | core-maintainers | platform-security (security-sensitive deltas) | Runtime integrity and API behavior |
+| `docs/**`, `website/**`, top-level docs | Medium | docs-maintainers | core-maintainers | Documentation quality with technical correctness backstop |
+
+## Review Load-Balancing Guidance
+
+- Maintain at least 2 active reviewers per owner group.
+- Rotate weekly primary reviewer for `platform-security` paths.
+- Use fallback owners only when SLA would otherwise be missed.
+- Reassess ownership quarterly (team membership and hot-path review volume).
+
+## Branch Protection / Ruleset Integration Blueprint
+
+## Required settings (main branch)
+
+1. **Require pull request before merging**: enabled.
+2. **Require approvals**:
+   - Critical paths (workflow/release/security governance): minimum 2 approvals.
+   - Other paths: minimum 1 approval.
+3. **Require review from Code Owners**: enabled.
+4. **Dismiss stale approvals on new commits**: enabled.
+5. **Require conversation resolution before merge**: enabled.
+6. **Require status checks to pass**: enabled, using stable check names defined in wave 1.
+7. **Restrict force pushes/deletions**: enabled (admins exempt only if operationally required).
+
+## Ruleset split recommendation
+
+- **Ruleset A (global baseline)**: applies to `main` for all files.
+- **Ruleset B (critical governance paths)**: applies to:
+  - `.github/workflows/**`
+  - `.github/CODEOWNERS`
+  - `SECURITY.md`
+  - `package.json`, `bun.lock`, `package-lock.json`
+  - `bin/**`
+
+Ruleset B enforces stricter approval count and mandatory code-owner review.
+
+## Dependency and rollout alignment
+
+- Depends on wave 1 CI hardening outputs (`redemeine-1uh.4`) for stable workflow/check naming.
+- Must be completed before branch-protection hard enforcement wave (`redemeine-1uh.5`).
+- Suggested rollout: monitor mode (1 sprint) -> enforce mode.
+
+## Acceptance Mapping (for redemeine-1uh.3)
+
+- **Target file paths defined**: `SECURITY.md`, `.github/CODEOWNERS`.
+- **Required sections/entries defined**: SECURITY section checklist + minimum CODEOWNERS entries.
+- **Ownership matrix by directory**: included with risk and fallback coverage.
+- **Branch-protection integration**: explicit required settings + critical-path ruleset model.
+
+## Assumptions and Risks
+
+### Assumptions
+
+- GitHub organization teams can be created/updated quickly.
+- Branch protection/ruleset controls are available on the repository plan.
+- At least two maintainers are available for fallback coverage.
+
+### Risks
+
+- Missing team provisioning can delay CODEOWNERS enforcement.
+- Overly broad ownership may increase review latency.
+- Tight rules without stable CI check names can block merges.
+
+Mitigation: run monitor-first rollout and finalize check names in wave 1 before enforcement.

--- a/docs/architecture/ci-hardening-wave3-branch-protection-release-integrity-blueprint.md
+++ b/docs/architecture/ci-hardening-wave3-branch-protection-release-integrity-blueprint.md
@@ -1,0 +1,194 @@
+---
+title: "Wave 3 Blueprint: Branch Protection + Release Integrity Controls"
+bead: "redemeine-1uh.5"
+status: "proposed"
+last_updated: "2026-04-08"
+owner_role: "Architect"
+---
+
+# Wave 3 Blueprint: Branch Protection + Release Integrity Controls (redemeine-1uh.5)
+
+## 1) Scope and intent
+
+This blueprint defines enforcement controls for:
+
+1. **Secure merges** into protected branches (`main` and `master` if both exist).
+2. **Release integrity** through provenance attestation, SBOM publication, and verification touchpoints.
+3. **Operational safety** via phased rollout and explicit rollback when enforcement blocks delivery.
+
+Design-only artifact. No workflow/ruleset implementation is performed in this bead.
+
+## 2) Preconditions / dependencies
+
+Wave 3 enforcement is gated on completed Wave 1 and Wave 2 design contracts:
+
+- `redemeine-1uh.1`: universal required PR gate (`ci-required-gate` stable check)
+- `redemeine-1uh.4`: workflow permissions minimization + SHA pinning policy
+- `redemeine-1uh.2`: dependency + vulnerability automation check design
+- `redemeine-1uh.3`: `SECURITY.md` + `CODEOWNERS` governance design
+
+## 3) Branch protection baseline (target settings)
+
+Apply repository rulesets/branch protection to **`main`** (and mirror to `master` if still used):
+
+### 3.1 Pull request and review controls
+
+- Require pull request before merging: **enabled**
+- Required approving reviews: **2**
+- Require review from Code Owners: **enabled**
+- Dismiss stale approvals on new commits: **enabled**
+- Require approval of most recent reviewable push: **enabled**
+- Allow self-approval: **disabled**
+- Last-pusher approval bypass: **disabled**
+
+### 3.2 Status check controls
+
+- Require status checks to pass before merge: **enabled**
+- Require branches to be up to date before merging: **enabled**
+- Required checks (stable names):
+  - `ci-required-gate` (from Wave 1)
+  - `actions-policy-gate` (Wave 1 policy enforcement)
+  - `dependency-security-gate` (Wave 2 dependency/vuln gate)
+- Check-source restriction: require checks from GitHub Actions in this repository (prevent spoofed contexts).
+
+### 3.3 Merge strategy and history controls
+
+- Require linear history: **enabled**
+- Force pushes: **disabled**
+- Branch deletion protection: **enabled**
+- Direct pushes to protected branches: **disabled** except designated release-admin bypass role (break-glass only, audited)
+- Merge queue: **recommended enabled** when throughput/flake profile is acceptable.
+
+### 3.4 Signed commit/tag expectations
+
+- Require signed commits on protected branches: **enabled** once contributor key coverage is validated.
+- Protected release tags (`v*`): creation limited to release workflow/bot identity and release-admins.
+
+## 4) Required reviews and CODEOWNERS integration
+
+High-risk path ownership (from `redemeine-1uh.3`) must be enforced by code-owner review:
+
+- `.github/workflows/**` -> Platform/Security owners
+- release scripts + packaging manifests -> Release + Security owners
+- dependency manifests/lockfiles -> Runtime + Security owners
+
+Approval policy for sensitive changes:
+
+- Any PR touching `.github/workflows/**` or release pipeline paths requires:
+  - at least **1 security/code-owner approval** and
+  - total **2 approvals** minimum.
+
+## 5) Release integrity controls (attestation + SBOM)
+
+## 5.1 Workflow touchpoints
+
+Release pipeline (`release.yml` or equivalent) must include these ordered touchpoints:
+
+1. **Build artifacts deterministically** (tag-triggered).
+2. **Generate SBOM** per releasable artifact (SPDX or CycloneDX).
+3. **Create provenance attestation** for each published artifact digest.
+4. **Sign published artifacts** (or signed attestations bound to digest).
+5. **Verify attestation + SBOM presence** before publish/promote step.
+6. **Publish release + attach evidence** (SBOM + attestation metadata/URIs).
+
+## 5.2 Minimum technical requirements
+
+- GitHub workflow permissions for release jobs:
+  - `contents: write` (release assets)
+  - `id-token: write` (OIDC provenance/attestation)
+  - everything else: least privilege / explicit
+- SBOM generation:
+  - Produce machine-readable SBOM files per artifact (`*.spdx.json` or `*.cdx.json`)
+  - Store as release assets and archive in CI artifacts
+- Provenance attestation:
+  - Use SLSA-compatible/GitHub artifact attestation mechanism bound to artifact digest
+  - Record attestation reference (URL/ID) in release notes body or manifest
+- Verification gate:
+  - Promotion/deploy jobs must fail closed if attestation verification fails or SBOM is missing.
+
+## 5.3 Evidence retention
+
+Retain release integrity evidence in two places:
+
+1. **GitHub Release assets**:
+   - built artifacts
+   - SBOM documents
+   - integrity manifest (artifact digest -> SBOM + attestation references)
+2. **Workflow run artifacts/logs**:
+   - attestation generation output
+   - verification output
+
+Retention policy:
+
+- Release assets: kept for lifetime of supported release
+- CI artifacts/logs: minimum **180 days** (or organizational minimum if higher)
+
+## 6) Phased rollout plan
+
+### Phase A - Monitor mode (1 sprint)
+
+- Configure all required checks to run and report.
+- Keep branch protection in "observe" for newly introduced checks where possible.
+- Track flakes, false positives, and runtime overhead.
+
+Exit criteria:
+
+- Required checks pass rate >= 95% on non-draft PRs.
+- No unresolved critical false-positive classes.
+
+### Phase B - Enforce merge protection
+
+- Enable required checks and mandatory review settings on `main`.
+- Enforce CODEOWNERS review requirements for protected paths.
+- Enable linear history + no direct pushes.
+
+Exit criteria:
+
+- Two weeks stable merge throughput without emergency bypass.
+
+### Phase C - Enforce release integrity gates
+
+- Block release publication if SBOM/attestation generation or verification fails.
+- Require integrity manifest for every release tag.
+
+Exit criteria:
+
+- Two consecutive successful releases with complete integrity evidence.
+
+## 7) Rollback / break-glass procedure
+
+Use only when enforcement causes delivery outage or critical incident response blockage.
+
+1. Incident commander declares break-glass and opens incident ticket.
+2. Temporarily relax only the minimal failing control, in this order of preference:
+   - Remove newly-added required check from protection (keep PR/review controls intact)
+   - If release-only failure, bypass release integrity gate for one hotfix release with explicit approvers
+   - Do **not** disable all branch protection unless repository availability is at risk
+3. Timebox relaxation to **<= 24h** and capture:
+   - who changed rule
+   - exact setting changed
+   - reason / impact
+   - planned re-enable time
+4. Create follow-up remediation bead(s) linked with `discovered-from:redemeine-1uh.5`.
+5. Re-enable controls and attach post-incident verification evidence.
+
+## 8) Auditor verification checklist (pass/fail)
+
+Audit passes when all conditions are true:
+
+1. Branch protection/ruleset on `main` includes PR requirement, 2 approvals, CODEOWNERS review, stale dismissal, linear history, and no force pushes.
+2. Required checks list exactly includes stable check contexts:
+   - `ci-required-gate`
+   - `actions-policy-gate`
+   - `dependency-security-gate`
+3. Release pipeline has explicit SBOM generation and provenance attestation steps with `id-token: write` only where needed.
+4. Release promotion/publish is fail-closed on missing/invalid attestation or missing SBOM.
+5. Rollback playbook is documented and references incident logging + timeboxed re-enable.
+
+## 9) Risks and assumptions
+
+- Assumes stable check names from prior waves are implemented exactly as specified.
+- Enforcing signed commits may require contributor onboarding period (keys/sigstore identities).
+- Merge queue adoption may be deferred if CI flake rate remains above acceptable threshold.
+
+

--- a/docs/architecture/ci-required-pr-gate-blueprint.md
+++ b/docs/architecture/ci-required-pr-gate-blueprint.md
@@ -1,0 +1,146 @@
+# Universal Required PR Gate Blueprint (Wave 1)
+
+- **Bead ID:** `redemeine-1uh.1`
+- **Scope owner:** Architect (planning/design only)
+- **Status:** Blueprint for Engineer/Auditor implementation in subsequent execution step
+
+## Goal
+
+Define a single, deterministic, always-present pull-request gate that can be marked **required** in branch protection without introducing merge deadlocks from skipped/path-filtered checks.
+
+## Current-state findings (input to design)
+
+- Existing workflows are fragmented and purpose-specific:
+  - `.github/workflows/documentation-audit.yml` (PR, path-filtered, write permissions, auto-commits)
+  - `.github/workflows/testing-benchmark.yml` (PR, path-filtered, non-blocking)
+  - `.github/workflows/deploy-docs.yml` (push to `main`)
+  - `.github/workflows/publish.yml` (release)
+- No single universal PR gate with stable required-check semantics currently exists.
+- Existing `paths:` PR workflows can be skipped, which is unsafe to mark as required.
+
+## Target workflow files
+
+### 1) Add (new required gate)
+
+- **`.github/workflows/ci-required-pr-gate.yml`**
+
+Purpose: host the universal required PR workflow for branch protection.
+
+### 2) Keep informational workflows non-required
+
+- `.github/workflows/testing-benchmark.yml` remains informational/non-required.
+- `.github/workflows/documentation-audit.yml` remains non-required until permissions/minimization hardening in `redemeine-1uh.4` and policy decision in `redemeine-1uh.2/.5`.
+
+> Branch protection must require only the stable check from `ci-required-pr-gate.yml` in this wave.
+
+## Required check naming strategy (stable)
+
+Use a single aggregator job with immutable naming:
+
+- **Workflow name:** `CI Required PR Gate`
+- **Required job id:** `required-gate`
+- **Required job display name:** `ci-required-gate`
+
+Branch protection should require:
+
+- `ci-required-gate`
+
+Rules:
+
+1. Do not encode runtime dimensions in required check name (no Node/Bun version suffixes, no matrix values).
+2. If internal job topology changes later, preserve `required-gate` job id and `ci-required-gate` display name.
+3. Any experimental/perf/docs checks must use separate names and remain optional.
+
+## Trigger rules
+
+`ci-required-pr-gate.yml` triggers:
+
+```yaml
+on:
+  pull_request:
+    branches: [main, master]
+    types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
+```
+
+Design constraints:
+
+- **No `paths` or `paths-ignore` filters** on the required workflow.
+- Draft PR behavior is implementation choice; recommended to still run for deterministic visibility.
+- Include `merge_group` for merge queue compatibility (if/when enabled).
+
+## Job topology and policy
+
+Recommended jobs inside `ci-required-pr-gate.yml`:
+
+1. `verify` (internal quality execution)
+   - install (`bun install --frozen-lockfile`)
+   - lint (`bun run lint`)
+   - typecheck (`bun run typecheck`)
+   - test (`bun run test`)
+   - build (`bun run build`)
+2. `required-gate` (aggregator; **required check**)
+   - `needs: [verify]`
+   - fails if any needed gate fails/cancels
+   - succeeds only when all mandatory steps pass
+
+Permissions baseline (wave 1):
+
+```yaml
+permissions:
+  contents: read
+```
+
+No write permissions for the required gate workflow.
+
+## No-deadlock skipped-check policy
+
+Policy objective: required check must always resolve to success/failure (never permanently missing/skipped).
+
+Rules:
+
+1. Required workflow cannot use PR path filters.
+2. Required check must be produced by a dedicated aggregator job that always schedules.
+3. If conditional execution is ever introduced internally, fallback paths must still conclude `required-gate` explicitly.
+4. Path-filtered workflows are never configured as required checks.
+5. If workflow is temporarily disabled/renamed, branch protection must be updated in same change window to avoid hard merge lock.
+
+## Auditor pass/fail definition (for implementation bead review)
+
+### Pass when all are true
+
+1. `.github/workflows/ci-required-pr-gate.yml` exists and is valid YAML.
+2. It triggers on PRs to `main/master` without `paths` filters.
+3. It includes mandatory commands for install/lint/typecheck/test/build (directly or via equivalent wrapper script).
+4. It contains a stable required aggregator job with:
+   - id `required-gate`
+   - name `ci-required-gate`
+   - deterministic success/failure based on prerequisite jobs.
+5. Existing informational workflows remain non-required in documented policy.
+6. Branch-protection recommendation references `ci-required-gate` as sole required status for this wave.
+
+### Fail if any are true
+
+1. Required workflow uses path filters causing possible skipped required checks.
+2. Required check name is unstable (matrix-dependent/dynamic).
+3. Required workflow grants write permissions without explicit justification.
+4. Mandatory quality stage (install/lint/typecheck/test/build) is omitted without approved replacement.
+5. Branch protection is documented to require a path-filtered or optional workflow.
+
+## Implementation handoff notes for Engineer
+
+- Introduce the new workflow without deleting existing workflows in this wave.
+- Keep required check naming exactly as specified.
+- Ensure CI failure signal is simple: red `ci-required-gate` blocks merge.
+- Defer further hardening (action SHA pinning, docs automation permission redesign, vuln/dependency policy) to sibling beads:
+  - `redemeine-1uh.4`
+  - `redemeine-1uh.2`
+  - `redemeine-1uh.5`
+
+## Out-of-scope for this bead
+
+- Full CI hardening migration or workflow rewrites
+- Dependabot/Renovate and vulnerability threshold policy
+- CODEOWNERS/SECURITY.md governance rollout
+- Release attestation/SBOM enforcement details
+

--- a/docs/architecture/ci-security-hardening-blueprint-redemeine-1uh.md
+++ b/docs/architecture/ci-security-hardening-blueprint-redemeine-1uh.md
@@ -1,0 +1,123 @@
+# CI/Security Hardening Blueprint (Parent) - redemeine-1uh
+
+## Scope and intent
+
+This document is the consolidated Architect blueprint for **redemeine-1uh** (planning only, no workflow/policy implementation).
+
+It aligns the already-planned/verified wave artifacts (**redemeine-1uh.1**, **redemeine-1uh.4**) with planned follow-up waves (**redemeine-1uh.2**, **redemeine-1uh.3**, **redemeine-1uh.5**) into a single repo-level execution contract.
+
+## Inputs and baseline
+
+Current repository workflows observed:
+
+- `.github/workflows/documentation-audit.yml`
+- `.github/workflows/testing-benchmark.yml`
+- `.github/workflows/deploy-docs.yml`
+- `.github/workflows/publish.yml`
+
+Current characteristics relevant to hardening:
+
+- PR checks are fragmented and path-filtered in places (risk: required-check deadlocks if skipped).
+- Third-party actions are version-tag pinned (`@v*`) rather than immutable SHA pinned.
+- Workflow permissions vary, with at least one workflow requesting write on PRs.
+- Release publish already uses npm provenance (`--provenance`) and `id-token: write`.
+
+## Consolidated wave plan (dependency-aware)
+
+| Wave | Bead | Objective | Dependency contract |
+|---|---|---|---|
+| Wave 1A | redemeine-1uh.1 | Universal required PR gate with stable required check name | Foundation for branch protection and later security gates |
+| Wave 1B | redemeine-1uh.4 | Least-privilege `permissions` + action SHA pinning policy/enforcement | Foundation for all downstream CI/security work |
+| Wave 2A | redemeine-1uh.2 | Dependency automation + vulnerability scanning strategy | Blocked by 1A and 1B |
+| Wave 2B | redemeine-1uh.3 | `SECURITY.md` + `CODEOWNERS` governance model | Blocked by 1B |
+| Wave 3 | redemeine-1uh.5 | Branch protection enforcement + release integrity (attestation/SBOM controls) | Blocked by 1A, 1B, 2A, 2B |
+
+## Workflow/files blueprint (add/update matrix)
+
+### A) Files to add
+
+1. **`.github/workflows/ci-required-pr-gate.yml`** (Wave 1A / redemeine-1uh.1)
+   - Trigger: `pull_request` (main/master) + `merge_group`.
+   - Policy: no path filters on required gate.
+   - Stable required check: `ci-required-gate` (single aggregator result).
+
+2. **`.github/dependabot.yml`** (Wave 2A / redemeine-1uh.2)
+   - npm/bun ecosystem update cadence and grouping strategy.
+   - GitHub Actions update coverage.
+
+3. **`.github/workflows/dependency-vulnerability-scan.yml`** (Wave 2A / redemeine-1uh.2)
+   - Scheduled + PR/manual scan flow.
+   - Severity threshold and failure policy defined by wave-2 design.
+
+4. **`SECURITY.md`** (Wave 2B / redemeine-1uh.3)
+   - Reporting channel, SLA expectations, supported versions, disclosure process.
+
+5. **`.github/CODEOWNERS`** (Wave 2B / redemeine-1uh.3)
+   - Explicit owners for `.github/workflows/**`, release files, package manifests, runtime core.
+
+6. **`.github/workflows/release-integrity.yml`** *(optional separate workflow; may be merged into publish workflow during implementation)* (Wave 3 / redemeine-1uh.5)
+   - Attestation/SBOM generation, verification, and evidence retention touchpoints.
+
+### B) Files to update
+
+1. **`.github/workflows/documentation-audit.yml`**
+   - Minimize default permissions and job-level grants.
+   - Pin third-party actions to full SHA.
+   - Re-evaluate write-on-PR behavior and constrain to least privilege.
+
+2. **`.github/workflows/testing-benchmark.yml`**
+   - Pin actions to SHA.
+   - Keep non-blocking benchmark semantics (informational).
+
+3. **`.github/workflows/deploy-docs.yml`**
+   - Pin actions to SHA.
+   - Keep only required permissions (`pages: write`, `id-token: write`, minimal contents scope).
+
+4. **`.github/workflows/publish.yml`**
+   - Pin actions to SHA.
+   - Preserve release provenance path; integrate with wave-3 integrity evidence strategy.
+
+## Branch protection recommendations (target state for Wave 3)
+
+Apply to `main` (and `master` if still active):
+
+1. Require pull request before merge.
+2. Require approvals (minimum 1; increase to 2 for protected paths if org policy allows).
+3. Require CODEOWNERS review.
+4. Require status checks to pass before merge, with stable required checks:
+   - `ci-required-gate` (mandatory)
+   - Add wave-2 security scan check(s) once signal/noise baseline is stable.
+5. Require branches to be up to date before merging (or merge queue + `merge_group` required gate).
+6. Restrict force pushes and branch deletion.
+7. Optional (recommended): require signed commits/tags for release-critical branches.
+
+## Validation criteria (auditable)
+
+### Parent acceptance mapping
+
+Parent bead acceptance: **"Concrete blueprint with workflow files to add/update, branch protection recommendations, and validation criteria."**
+
+- **AC-1 (Workflow inventory):** This blueprint names concrete files to add/update under `.github/workflows` plus governance files (`SECURITY.md`, `CODEOWNERS`, `dependabot.yml`).
+- **AC-2 (Branch protection):** This blueprint defines explicit required-rule recommendations and required-check naming contract (`ci-required-gate`).
+- **AC-3 (Validation):** This blueprint defines wave-gated auditable validation points (below).
+- **AC-4 (Alignment):** This blueprint explicitly maps to redemeine-1uh.1/.4 and planned .2/.3/.5 dependency order.
+
+### Wave-gated validation points
+
+1. **Wave 1A validated** when a PR to main/master always emits `ci-required-gate` regardless of changed paths and does not deadlock required checks.
+2. **Wave 1B validated** when all targeted workflows use least-privilege permissions and third-party actions are SHA pinned (with documented exceptions).
+3. **Wave 2A validated** when dependency update automation and vulnerability scan checks run on defined cadence with documented severity/SLA handling.
+4. **Wave 2B validated** when `SECURITY.md` and `CODEOWNERS` exist with required sections/path ownership and are integrated into review policy.
+5. **Wave 3 validated** when branch protection settings are enforced and release integrity evidence (attestation/SBOM/provenance path) is retained per policy.
+
+## Risks and rollout guardrails
+
+- **Deadlock risk:** Avoid required checks tied to path-filtered workflows.
+- **Noise risk:** Start vulnerability gates in monitor mode if needed; promote to blocking after baseline.
+- **Delivery friction risk:** Phase branch protection tightening after stable check naming and ownership coverage.
+- **Maintenance risk:** SHA pinning requires explicit update process (handled by wave 2 automation strategy).
+
+## Handoff contract
+
+- This parent blueprint is architecture-ready and dependency-aligned for Engineer/Auditor execution across child beads.
+- Implementation remains in child beads only; this parent bead remains a consolidated design reference.

--- a/docs/architecture/hwj-abandoned-implementation-notes.md
+++ b/docs/architecture/hwj-abandoned-implementation-notes.md
@@ -1,0 +1,69 @@
+# hwj Epic: Abandoned Implementation Work
+
+## Context
+
+PR #27 (`feature/redemeine-hwj`) was a cross-cutting epic covering production hardening, observability, and infrastructure design. After PR #41 (`feature/mirage-api-cleanup`) merged — which refactored the mirage root namespace, projection module structure, and aggregate builder generics — several implementation commits from #27 became incompatible with main.
+
+A selective cherry-pick was performed on 2026-04-29 to preserve all safe work (architecture docs + `@redemeine/otel` package). This document records what was left behind and what needs reimplementation.
+
+## What Was Preserved (cherry-picked into `feature/hwj-architecture-docs`)
+
+- 17 architecture documents (CI hardening waves 1-3, telemetry SPI, transactional outbox RFC, CDC relay semantics, projection-over-MQ, aggregate intent contracts, inspection hooks contract, etc.)
+- `@redemeine/otel` package — no-op-safe telemetry facade with context propagation, adapter registry, semantic conventions, and tests
+- Observability audit verification evidence
+
+## What Was Abandoned (needs reimplementation)
+
+### 1. Transactional Outbox Persistence Seam (`packages/mirage/src/Depot.ts`)
+- **Original commit**: `d0bc8f1`
+- **What it did**: Added outbox capability negotiation in Depot so append+enqueue can be atomically persisted via `saveEventsWithOutbox`, with `compatibility_inline` mode for legacy stores.
+- **Why it conflicts**: PR #41 restructured Depot's internal API surface, inheritance model, and token passing. The outbox seam needs to be re-wired against the new `BuiltAggregate` generics and `.mirror()` builder pattern.
+- **Design spec preserved**: `docs/architecture/transactional-outbox-rfc.md`
+
+### 2. Outbox Dispatcher Worker (`packages/mirage/src/outboxDispatcher.ts`)
+- **Original commit**: `5fc84be`
+- **What it did**: Added a worker lifecycle for dispatching queued outbox entries to downstream consumers (CDC relay pattern).
+- **Why it conflicts**: Depends on the outbox persistence seam above, plus references createMirage internals that were restructured.
+- **Design spec preserved**: `docs/architecture/transactional-outbox-rfc.md`, `docs/architecture/cdc-relay-mq-inbox-durability-semantics.md`
+
+### 3. Canonical Inspection Hook Envelope Emission (`packages/kernel/src/inspection.ts` + wiring)
+- **Original commit**: `85e0367`
+- **What it did**: Added `kernel/src/inspection.ts` with canonical inspection hook types, and wired emission into mirage (createMirage.ts), projection (ProjectionDaemon.ts), and saga-runtime (sagaExecutionBridge.ts).
+- **Why it conflicts**: 
+  - `ProjectionDaemon.ts` and its test were **deleted** on main (projection was migrated into `createProjection.ts` with a new architecture)
+  - `createMirage.ts` was heavily refactored with new generics and token inheritance
+  - `sagaExecutionBridge.ts` had minor changes but the import structure shifted
+- **Design spec preserved**: `docs/architecture/inspection-hooks-contract-v1.md`
+
+### 4. OTel Integration Across Runtime Boundaries (`packages/otel/test/otel-bridge.integration.test.ts` + wiring)
+- **Original commit**: `5610ae8`
+- **What it did**: Wired `@redemeine/otel` fallback-safe context propagation into mirage, saga-runtime, and projection inspection points. Added end-to-end trace continuity tests for command→event→outbox→side-effect→projection correlation.
+- **Why it conflicts**: Depends on inspection hooks (#3 above) and references pre-refactor mirage/projection internals.
+- **Design spec preserved**: `docs/architecture/otel-implementation-design.md`, `docs/architecture/telemetry-spi-design.md`
+
+### 5. Audit Evidence Tests (outbox reliability, lease recovery)
+- **Original commits**: `c834bad`, `bb42ead`
+- **What they did**: Integration tests proving outbox reliability (guaranteed delivery) and lease recovery (stale reclaim fencing) for `redemeine-sy8`.
+- **Why they conflict**: Test fixtures reference the old `referenceAdapters.ts` shape which was changed.
+- **Audit spec preserved**: `docs/architecture/redemeine-sy8-auditor-reliability-verification-evidence.md` (was in the original PR but not cherry-picked since it references non-existent test paths)
+
+## Reimplementation Guidance
+
+When reimplementing these features against the post-PR-#41 codebase:
+
+1. **Start with inspection hooks** — The kernel inspection contract (`inspection-hooks-contract-v1.md`) is still valid. Wire emission into:
+   - `createMirage.ts` (new token-inherited builder)
+   - `createProjection.ts` (replaces deleted `ProjectionDaemon.ts`)
+   - `sagaExecutionBridge.ts` (minor adaptation)
+
+2. **Then outbox** — The transactional outbox RFC is still valid. Adapt the Depot seam to use the new `BuiltAggregate` type surface and `.mirror()` pattern.
+
+3. **Then OTel wiring** — The `@redemeine/otel` package is already in place. Just add the integration bridge tests and wire context propagation through the new inspection hook emission points.
+
+4. **Finally audit tests** — Re-create reliability evidence against the new adapter shapes.
+
+## Source Reference
+
+- Original PR: #27 (`feature/redemeine-hwj`)
+- Conflicting PR: #41 (`feature/mirage-api-cleanup`) — merged 2026-04-29
+- Cherry-pick PR: (this branch, `feature/hwj-architecture-docs`)

--- a/docs/architecture/inspection-hooks-contract-v1.md
+++ b/docs/architecture/inspection-hooks-contract-v1.md
@@ -1,0 +1,342 @@
+# Canonical Inspection Hooks Contract and Event Taxonomy (v1)
+
+- **Bead:** `redemeine-33p`
+- **Status:** Draft for Engineer/Auditor handoff
+- **Scope:** Runtime inspection signals across Mirage/Depot, outbox lifecycle, saga runtime, and projection processing.
+
+## 1) Goals
+
+Define one canonical inspection contract that:
+
+1. Standardizes hook names across runtime boundaries.
+2. Uses a stable payload envelope with explicit versioning.
+3. Maps existing plugin hooks and telemetry surfaces without breaking current behavior.
+4. Supports low-overhead defaults and progressive adoption.
+
+## 2) Runtime boundaries in scope
+
+1. **Command ingress** (Mirage dispatch loop)
+2. **Event hydration** (replay into aggregate state)
+3. **Event append** (pre-persist and persisted)
+4. **Outbox enqueue/dequeue** (post-commit execution pipeline)
+5. **Side-effect execution** (attempt/success/failure)
+6. **Retry/dead-letter** (policy and terminal handling)
+7. **Projection batch processing** (batch lifecycle and per-event application)
+
+## 3) Canonical envelope schema
+
+All inspection signals MUST conform to this envelope:
+
+```ts
+export type InspectionSchemaVersion = '1.0';
+
+export type InspectionLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface InspectionEnvelopeV1<TPayload = Record<string, unknown>> {
+  // Contract version for envelope fields (breaking changes require major bump)
+  schemaVersion: InspectionSchemaVersion; // '1.0'
+
+  // Taxonomy version for hook/event naming set
+  taxonomyVersion: '2026-04.v1';
+
+  // Canonical inspection event name (see section 4)
+  name: CanonicalInspectionEventName;
+
+  // Event identity
+  id: string;
+  occurredAt: string; // ISO-8601 UTC
+  level: InspectionLevel;
+
+  // Runtime placement
+  boundary: 'aggregate' | 'depot' | 'outbox' | 'saga_runtime' | 'projection';
+  stage:
+    | 'command_ingress'
+    | 'event_hydration'
+    | 'event_append'
+    | 'outbox_enqueue'
+    | 'outbox_dequeue'
+    | 'side_effect_execution'
+    | 'retry'
+    | 'dead_letter'
+    | 'projection_batch';
+
+  // Correlation / causality
+  correlationId?: string;
+  causationId?: string;
+  traceId?: string;
+  spanId?: string;
+
+  // Domain identity
+  aggregateId?: string;
+  aggregateType?: string;
+  commandType?: string;
+  eventType?: string;
+  sagaId?: string;
+  sagaType?: string;
+  intentId?: string;
+  executionId?: string;
+  projectionName?: string;
+
+  // Compatibility + source hints
+  source: {
+    runtimePackage: string; // e.g. '@redemeine/mirage'
+    emitter: string;        // e.g. 'Depot.save'
+    legacyHook?: string;    // e.g. 'onBeforeAppend'
+    legacyTelemetryKind?: string;
+    legacyMetric?: string;
+    legacyEvent?: string;
+  };
+
+  payload: TPayload;
+}
+```
+
+### Required vs optional rules
+
+- Required: `schemaVersion`, `taxonomyVersion`, `name`, `id`, `occurredAt`, `level`, `boundary`, `stage`, `source`, `payload`.
+- Optional but recommended: `correlationId`, `causationId`, `traceId`, `spanId`.
+- Identity fields are conditionally required by stage (see section 5).
+
+## 4) Canonical event taxonomy (v1)
+
+### 4.1 Command ingress
+
+- `inspection.command.ingress.received`
+- `inspection.command.ingress.validated`
+- `inspection.command.ingress.rejected`
+
+### 4.2 Event hydration
+
+- `inspection.event.hydration.read`
+- `inspection.event.hydration.transformed`
+- `inspection.event.hydration.applied`
+- `inspection.event.hydration.failed`
+
+### 4.3 Event append
+
+- `inspection.event.append.intercepted`
+- `inspection.event.append.persisted`
+- `inspection.event.append.failed`
+
+### 4.4 Outbox
+
+- `inspection.outbox.enqueued`
+- `inspection.outbox.dequeue.claimed`
+- `inspection.outbox.dequeue.released`
+
+### 4.5 Side effects
+
+- `inspection.side_effect.execution.started`
+- `inspection.side_effect.execution.succeeded`
+- `inspection.side_effect.execution.failed`
+
+### 4.6 Retry / dead-letter
+
+- `inspection.retry.scheduled`
+- `inspection.retry.exhausted`
+- `inspection.dead_letter.recorded`
+
+### 4.7 Projection batch
+
+- `inspection.projection.batch.started`
+- `inspection.projection.batch.event_applied`
+- `inspection.projection.batch.completed`
+- `inspection.projection.batch.failed`
+
+## 5) Stage payload contracts
+
+### 5.1 Command ingress payload
+
+```ts
+interface CommandIngressPayload {
+  commandPayload?: unknown;
+  commandMeta?: Record<string, unknown>;
+  validation?: { status: 'passed' | 'failed'; reason?: string };
+}
+```
+
+Required identities: `aggregateId`, `commandType`.
+
+### 5.2 Event hydration payload
+
+```ts
+interface EventHydrationPayload {
+  eventPayload?: unknown;
+  eventMeta?: Record<string, unknown>;
+  replayIndex?: number;
+  replayVersion?: number;
+  transformApplied?: boolean;
+  error?: { message: string; code?: string };
+}
+```
+
+Required identities: `aggregateId`, `eventType`.
+
+### 5.3 Event append payload
+
+```ts
+interface EventAppendPayload {
+  eventPayload?: unknown;
+  eventMeta?: Record<string, unknown>;
+  expectedVersion?: number;
+  persistedVersion?: number;
+  appendedCount?: number;
+  error?: { message: string; code?: string };
+}
+```
+
+Required identities: `aggregateId`; `eventType` required for single-event emissions, optional for multi-event summary emission.
+
+### 5.4 Outbox payload
+
+```ts
+interface OutboxPayload {
+  outboxId: string;
+  topic?: string;
+  partitionKey?: string;
+  attempt?: number;
+  leaseOwner?: string;
+  visibleAt?: string;
+}
+```
+
+Required identities: `aggregateId` OR `sagaId`, plus `intentId` when tied to intent execution.
+
+### 5.5 Side-effect execution payload
+
+```ts
+interface SideEffectExecutionPayload {
+  sideEffectType: 'plugin-one-way' | 'plugin-request' | 'run-activity' | 'dispatch';
+  pluginKey?: string;
+  actionName?: string;
+  status?: 'started' | 'succeeded' | 'failed';
+  durationMs?: number;
+  error?: { message: string; code?: string; retriable?: boolean };
+}
+```
+
+Required identities: `sagaId`, `intentId`, `executionId`.
+
+### 5.6 Retry/dead-letter payload
+
+```ts
+interface RetryDeadLetterPayload {
+  attempt: number;
+  maxAttempts?: number;
+  nextRunAt?: string;
+  policy?: { mode?: string; backoffMs?: number };
+  reason?: string;
+}
+```
+
+Required identities: `sagaId` or `aggregateId`, `intentId`.
+
+### 5.7 Projection batch payload
+
+```ts
+interface ProjectionBatchPayload {
+  batchId: string;
+  size: number;
+  fromOffset?: string;
+  toOffset?: string;
+  applied?: number;
+  skipped?: number;
+  durationMs?: number;
+  error?: { message: string; code?: string };
+}
+```
+
+Required identities: `projectionName`; `eventType` required for `event_applied`.
+
+## 6) Versioning strategy
+
+1. **Envelope version (`schemaVersion`)**
+   - `MAJOR` for breaking field/semantic changes.
+   - `MINOR/PATCH` for additive non-breaking updates.
+
+2. **Taxonomy version (`taxonomyVersion`)**
+   - Locked per wave (`2026-04.v1`).
+   - New names added additively within same version only if no semantic conflict.
+   - Renames/removals require next taxonomy major wave (e.g., `2026-08.v2`).
+
+3. **Payload evolution rules**
+   - Additive optional fields are backward compatible.
+   - Required-field additions require major bump.
+   - Field deprecations require dual-emit window of at least one minor release wave.
+
+4. **Compatibility emission mode**
+   - Runtime MAY emit legacy + canonical side-by-side in transitional mode.
+   - Canonical-only mode is allowed once dependent packages and dashboards migrate.
+
+## 7) Compatibility mapping to current surfaces
+
+### 7.1 Plugin hook mapping (`@redemeine/kernel`, `@redemeine/mirage`)
+
+| Current hook | Current context | Canonical event(s) | Notes |
+|---|---|---|---|
+| `onBeforeCommand` | `CommandInterceptorContext` | `inspection.command.ingress.received` (+ `...validated/rejected`) | Preserve `pluginKey`, `aggregateId`, `commandType`, `payload`, `meta`. |
+| `onHydrateEvent` | `EventInterceptorContext` | `inspection.event.hydration.transformed` (plus `...read`/`...applied`) | Payload mutation represented as `transformApplied=true`. |
+| `onBeforeAppend` | `EventInterceptorContext` | `inspection.event.append.intercepted` | Preserve per-event interception semantics. |
+| `onAfterCommit` | `AfterCommitContext` | `inspection.event.append.persisted` and/or `inspection.outbox.enqueued` | Inline post-commit is legacy bridge until outbox worker becomes primary. |
+
+### 7.2 Runtime telemetry kind mapping (`packages/saga-runtime/src/runtimeObservabilityContracts.ts`)
+
+| Current `RuntimeTelemetryKind` | Canonical mapping |
+|---|---|
+| `source_event.observed` | `inspection.event.hydration.read` |
+| `intent.lifecycle` | `inspection.side_effect.execution.started` / `inspection.retry.scheduled` / `inspection.dead_letter.recorded` |
+| `intent.execution` | `inspection.side_effect.execution.succeeded` / `inspection.side_effect.execution.failed` |
+| `scheduler.trigger` | `inspection.outbox.dequeue.claimed` or `inspection.retry.scheduled` (context-dependent) |
+| `scheduler.misfire` | `inspection.retry.scheduled` |
+| `dispatch.attempt` | `inspection.command.ingress.received` |
+| `dispatch.response` | `inspection.command.ingress.validated` or `inspection.command.ingress.rejected` |
+| `saga.lifecycle`, `saga.transition`, `activity.lifecycle`, `runtime.invariant` | Remain runtime-domain telemetry; can be bridged into inspection namespace only for boundary events with explicit `stage`. |
+
+### 7.3 Reference telemetry plugin mapping (`SagaRuntimeTelemetryPluginV1`)
+
+| Current metric/event | Canonical event |
+|---|---|
+| `saga.intent.received` | `inspection.command.ingress.received` (for intent dispatch ingress) |
+| `saga.intent.executed` | `inspection.side_effect.execution.succeeded/failed` |
+| `saga.intent.execution_succeeded` | `inspection.side_effect.execution.succeeded` |
+| `saga.intent.execution_failed` | `inspection.side_effect.execution.failed` |
+| `saga.intent.scheduled` | `inspection.retry.scheduled` |
+| `saga.intent.cancelled_schedule` | `inspection.retry.exhausted` (if terminal) or contextual scheduler cancellation event |
+| `saga.schedule.created` | `inspection.retry.scheduled` |
+| `saga.schedule.cancelled` | `inspection.retry.exhausted` (cancellation terminal path) |
+
+## 8) Migration and rollout plan
+
+1. **Phase A (bridge)**
+   - Add canonical emitter adapter at each boundary.
+   - Dual-emit legacy hook/telemetry + canonical envelope.
+
+2. **Phase B (default canonical)**
+   - Runtime internals and dashboards consume canonical names.
+   - Legacy names marked deprecated.
+
+3. **Phase C (legacy off by config)**
+   - Keep compatibility toggle for one release wave.
+   - Remove legacy emission in next major.
+
+## 9) Engineer implementation guidance (dependency-aware)
+
+1. Introduce shared contract types in telemetry SPI package (depends on `redemeine-bxt` / `redemeine-h8i`).
+2. Add Mirage/Depot adapters first (`onBeforeCommand`, `onHydrateEvent`, `onBeforeAppend`, `onAfterCommit`).
+3. Add saga-runtime telemetry bridge next.
+4. Add outbox/projection boundary emissions as outbox architecture (`redemeine-4gu`) lands.
+5. Validate compatibility matrix with contract tests in `redemeine-xvr`.
+
+## 10) Acceptance criteria mapping (`redemeine-33p`)
+
+- **Hook names defined:** Section 4 taxonomy.
+- **Payload schemas defined:** Sections 3 and 5.
+- **Versioning strategy defined:** Section 6.
+- **Compatibility mapping provided:** Section 7 tables for plugin hooks and runtime telemetry.
+
+## 11) Risks and assumptions
+
+- **Assumption:** canonical inspection is not a replacement for domain telemetry; it is boundary-focused.
+- **Risk:** overloading one event name with multiple semantics; mitigated via strict `stage` + payload typing.
+- **Risk:** performance overhead from dual-emit; mitigated by lazy payload fields and batch-capable sinks.
+

--- a/docs/architecture/otel-implementation-design.md
+++ b/docs/architecture/otel-implementation-design.md
@@ -1,0 +1,270 @@
+# @redemeine/otel Implementation Design Spec
+
+- **Bead:** `redemeine-h8i`
+- **Status:** Architect design artifact (no implementation)
+- **Last updated:** 2026-04-08
+- **Depends on:** `redemeine-bxt` (`@redemeine/telemetry` SPI design)
+
+## 1) Purpose and Scope
+
+This document defines the concrete implementation design for `@redemeine/otel`, an OpenTelemetry adapter package that implements the backend-agnostic `@redemeine/telemetry` SPI.
+
+### In scope
+
+1. Mapping from `@redemeine/telemetry` SPI contracts to OpenTelemetry APIs.
+2. Optional dependency model so runtime packages remain OTel-agnostic.
+3. SPI conformance test design (adapter behavior tests against SPI expectations).
+4. Package boundaries and rollout notes for Engineer handoff.
+
+### Out of scope
+
+- Runtime code implementation.
+- Exporter wiring specifics for production vendors (Jaeger, OTLP collectors, etc.).
+- Any direct OTel imports inside core runtime packages (`kernel`, `aggregate`, `mirage`, `projection`, `saga`, `saga-runtime`).
+
+---
+
+## 2) Architectural Positioning
+
+`@redemeine/otel` is one pluggable implementation adapter. Runtime packages use only `@redemeine/telemetry` interfaces.
+
+```text
+runtime packages -> @redemeine/telemetry (SPI) -> @redemeine/otel (adapter) -> OpenTelemetry API/SDK
+```
+
+### Boundary rules
+
+- `@redemeine/telemetry`: contracts, lifecycle, no-op defaults.
+- `@redemeine/otel`: translates SPI calls/events to OTel primitives.
+- Runtime packages never import `@opentelemetry/*` directly.
+- Alternative adapters (future): e.g. `@redemeine/honeycomb`, `@redemeine/datadog`, custom sink adapter.
+
+---
+
+## 3) SPI → OTel Mapping
+
+> Note: Names below use representative SPI naming from `redemeine-bxt` intent (provider, span, metric, propagation, logger correlation). Engineer should bind exact symbol names from final `@redemeine/telemetry` package exports.
+
+### 3.1 Provider lifecycle
+
+| SPI responsibility | OTel target | Mapping notes |
+|---|---|---|
+| `createTelemetryProvider(config)` | `TracerProvider` + `MeterProvider` + Context API | Build a composite adapter instance that owns OTel handles. |
+| `provider.start()` | provider registration and setup | If SDK mode enabled, register global providers; otherwise remain local for test mode. |
+| `provider.shutdown()` | `shutdown()`/`forceFlush()` | Flush and teardown in deterministic order (traces first, then metrics). |
+| `provider.isEnabled()` | config gate | Reflect adapter activation state independent of runtime packages. |
+
+### 3.2 Tracing
+
+| SPI responsibility | OTel target | Mapping notes |
+|---|---|---|
+| `tracer.startSpan(name, options)` | `trace.getTracer(...).startSpan(...)` | Map attributes, kind, links, start time. |
+| `tracer.withSpan(span, fn)` | `context.with(trace.setSpan(ctx, span), fn)` | Preserve async context propagation. |
+| `span.setAttribute(k,v)` | `Span#setAttribute` | Normalize SPI value union to OTel-accepted scalar/array values. |
+| `span.addEvent(name, attrs)` | `Span#addEvent` | Pass timestamps when provided; default now. |
+| `span.recordException(err)` | `Span#recordException` | Include normalized error type/message/stack attributes. |
+| `span.setStatus(code, message?)` | `Span#setStatus` | Map SPI status enum to `SpanStatusCode`. |
+| `span.end(endTime?)` | `Span#end` | Ensure idempotent end in adapter wrapper. |
+
+### 3.3 Metrics
+
+| SPI responsibility | OTel target | Mapping notes |
+|---|---|---|
+| `meter.counter(name).add(value, attrs)` | `Meter#createCounter().add` | Lazy instrument cache by (name, unit, description). |
+| `meter.histogram(name).record(value, attrs)` | `Meter#createHistogram().record` | Support number histograms only in v1 scope. |
+| `meter.upDownCounter(name).add(...)` | `Meter#createUpDownCounter().add` | Optional: include if SPI includes this instrument. |
+| `meter.observableGauge(name, callback)` | `Meter#createObservableGauge` | Bridge SPI observe callback to OTel callback semantics. |
+
+### 3.4 Context propagation
+
+| SPI responsibility | OTel target | Mapping notes |
+|---|---|---|
+| `propagation.inject(carrier, setter)` | `propagation.inject` | Use OTel global propagator configured in adapter options. |
+| `propagation.extract(carrier, getter)` | `propagation.extract` | Return SPI context wrapper that can re-enter `withContext`. |
+| `context.current()` | `context.active()` | SPI context object wraps raw OTel context. |
+| `context.with(ctx, fn)` | `context.with(ctx, fn)` | Core mechanism for request/saga correlation continuity. |
+
+### 3.5 Log correlation (non-logging backend)
+
+OTel does not provide a canonical logs API in every deployment path used by Redemeine. In v1:
+
+- `@redemeine/otel` must provide **log correlation helpers**, not a full logging implementation.
+- SPI methods that request correlation fields should derive from active span context:
+  - `trace_id`
+  - `span_id`
+  - `trace_flags`
+- If no active span/context, return empty correlation object (no throw).
+
+---
+
+## 4) Semantic Conventions Mapping for Redemeine Runtime Signals
+
+`packages/saga-runtime/src/runtimeObservabilityContracts.ts` defines runtime telemetry kinds that should map consistently into span/event names and metric dimensions.
+
+### 4.1 Event name strategy
+
+- Keep low-cardinality operation names (e.g., `redemeine.saga.dispatch`).
+- Put dynamic details in attributes (IDs, status, kind) rather than span names.
+
+### 4.2 Proposed attribute namespace
+
+Use stable namespace prefix:
+
+- `redemeine.saga.id`
+- `redemeine.saga.type`
+- `redemeine.intent.id`
+- `redemeine.intent.execution_id`
+- `redemeine.activity.id`
+- `redemeine.trigger.key`
+- `redemeine.correlation.id`
+- `redemeine.causation.id`
+- `redemeine.tenant.id`
+- `redemeine.telemetry.kind`
+- `redemeine.telemetry.level`
+
+### 4.3 Runtime telemetry kind translation
+
+| Runtime kind | Trace shape | Metric shape |
+|---|---|---|
+| `saga.lifecycle` | span event on saga operation span | counter `redemeine_saga_lifecycle_total` |
+| `saga.transition` | span event `saga.transition` | counter `redemeine_saga_transition_total` |
+| `source_event.observed` | span event `source_event.observed` | counter `redemeine_source_event_observed_total` |
+| `intent.lifecycle` | child span or event by stage | counter `redemeine_intent_lifecycle_total` |
+| `intent.execution` | child span around execution | histogram `redemeine_intent_execution_duration_ms` |
+| `activity.lifecycle` | span event | counter |
+| `scheduler.trigger` | span event | counter |
+| `scheduler.misfire` | span event + warning status | counter |
+| `dispatch.attempt` | span event | counter |
+| `dispatch.response` | span event | counter + status dimension |
+| `runtime.invariant` | error event / exception record | counter `redemeine_runtime_invariant_total` |
+
+---
+
+## 5) Optional Dependency Model
+
+Goal: runtime package consumers can use Redemeine without installing OTel packages unless they choose `@redemeine/otel`.
+
+### 5.1 Dependency policy
+
+For `@redemeine/otel`:
+
+- `dependencies`:
+  - `@redemeine/telemetry`
+- `peerDependencies` (preferred):
+  - `@opentelemetry/api`
+  - optional SDK peers used by adapter features (e.g., `@opentelemetry/sdk-trace-base`, `@opentelemetry/sdk-metrics`)
+- `peerDependenciesMeta` mark SDK peers optional where possible.
+
+Rationale:
+
+- Keeps core runtime install light.
+- Lets app host control OTel package versions.
+- Prevents duplicate global API instances from nested dependency trees.
+
+### 5.2 Activation model
+
+- Default runtime path uses `@redemeine/telemetry` no-op provider.
+- Apps explicitly install and register `@redemeine/otel` provider.
+- If required OTel peer not present, adapter should fail fast with actionable startup error message from provider creation (not silent partial mode).
+
+### 5.3 Packaging/exports
+
+`@redemeine/otel` should expose:
+
+1. `createOtelTelemetryAdapter(options)` factory.
+2. `createOtelPropagationBridge(...)` only if split utility is needed.
+3. `semanticConventions` constants for Redemeine-specific attribute keys.
+
+No global side effects on module import; registration should happen only in explicit factory/init calls.
+
+---
+
+## 6) Error Handling and Fallback Behavior
+
+- Adapter must never throw from no-op-safe read helpers (e.g., correlation lookup).
+- Operational startup errors (missing peer deps, invalid config) should throw clearly.
+- Runtime telemetry publishing failures should be isolated:
+  - do not crash domain execution path for non-fatal telemetry failures,
+  - optionally route internal adapter errors to a provided diagnostics callback.
+
+---
+
+## 7) SPI Conformance Test Design (for Engineer)
+
+Conformance tests validate adapter behavior against `@redemeine/telemetry` SPI contract, independent of vendor backend.
+
+### 7.1 Test package and placement
+
+- Package: `packages/otel` (future implementation slice).
+- Tests:
+  - `packages/otel/test/spi-conformance.tracing.test.ts`
+  - `packages/otel/test/spi-conformance.metrics.test.ts`
+  - `packages/otel/test/spi-conformance.propagation.test.ts`
+  - `packages/otel/test/spi-conformance.lifecycle.test.ts`
+
+### 7.2 Conformance matrix
+
+| Contract area | Required assertions |
+|---|---|
+| Provider lifecycle | Start/shutdown are idempotent and flush hooks invoked once per lifecycle transition. |
+| Tracing creation | `startSpan` returns valid wrapper; attributes/events/status map correctly. |
+| Context continuity | `withSpan`/`withContext` preserve active span across async boundaries used by runtime. |
+| Exception mapping | `recordException` emits expected exception fields. |
+| Metrics instruments | Counter/histogram operations function and attribute sets preserved. |
+| Propagation inject/extract | Round-trip carrier preserves trace context IDs. |
+| Correlation lookup | Returns trace/span IDs when active span exists; empty object otherwise. |
+| Failure isolation | Telemetry sink failure path does not break caller control flow (where contract defines non-fatal behavior). |
+
+### 7.3 Test harness strategy
+
+- Prefer in-memory/fake exporters/processors for deterministic assertions.
+- Avoid dependence on external collectors in CI.
+- Use adapter black-box tests through SPI interfaces only (do not assert private OTel internals).
+
+---
+
+## 8) Implementation Decomposition (Engineer-ready)
+
+1. **Scaffold package** (`redemeine-26i`): package manifest, exports, baseline adapter factory.
+2. **Tracing bridge**: SPI tracer wrapper + context bridge.
+3. **Metrics bridge**: instrument registry and attribute normalization.
+4. **Propagation bridge**: carrier extract/inject wrappers.
+5. **Semantic mapping module**: constants and runtime kind translation helpers.
+6. **Conformance tests**: full matrix in Section 7.
+
+Dependencies/order:
+
+- Requires finalized `@redemeine/telemetry` SPI symbols (from `redemeine-bxt` output).
+- Conformance tests block production adoption of `@redemeine/otel` in runtime bootstrap examples.
+
+---
+
+## 9) Risks and Assumptions
+
+### Assumptions
+
+- `@redemeine/telemetry` provides stable abstractions for traces, metrics, context, and correlation helpers.
+- Runtime packages will emit telemetry through SPI only.
+
+### Risks
+
+1. **SPI mismatch risk:** final SPI naming may differ from this design wording.
+   - Mitigation: treat this spec as mapping intent; bind exact names during implementation.
+2. **OTel version skew:** peer version incompatibility across app hosts.
+   - Mitigation: define supported peer range and validate at startup.
+3. **High-cardinality attributes:** unbounded IDs in metric labels.
+   - Mitigation: keep identifiers in traces/events; limit metric labels to bounded dimensions.
+
+---
+
+## 10) Acceptance Criteria Coverage (redemeine-h8i)
+
+Bead criterion: _“Design spec defines mapping from @redemeine/telemetry SPI to OpenTelemetry APIs, optional dependency model, and conformance tests against SPI.”_
+
+Coverage:
+
+1. **SPI → OTel mapping:** Section 3.
+2. **Optional dependency model:** Section 5.
+3. **SPI conformance tests:** Section 7.
+
+This satisfies the design-only deliverable for `redemeine-h8i` and enables Engineer implementation on dependent bead(s).

--- a/docs/architecture/production-hardening-roadmap-parallel-dag-redemeine-8ew.md
+++ b/docs/architecture/production-hardening-roadmap-parallel-dag-redemeine-8ew.md
@@ -1,0 +1,154 @@
+# Production Hardening Roadmap + Parallel Delivery DAG (redemeine-8ew)
+
+## Scope
+
+This roadmap operationalizes Epic **redemeine-hwj** into execution-ready waves with explicit dependency order, parallel tracks, and role handoff gates for:
+- Transactional outbox reliability
+- Observability + inspectability
+- CI/security enforcement
+- Release readiness and communication
+
+## Planning assumptions
+
+1. Architecture contracts are baseline-complete (redemeine-4gu, redemeine-33p, redemeine-bxt, redemeine-h8i, redemeine-fa0, redemeine-48z, redemeine-yvf, redemeine-9ff, redemeine-1uh).
+2. Implementation slices for outbox and telemetry have landed in feature branches, but release confidence depends on Auditor evidence beads.
+3. Release gate remains blocked until reliability + observability verification and wave-3 release-integrity controls are all satisfied.
+
+## Wave plan (P0 / P1 / P2)
+
+### P0 (Stabilize and de-risk production path)
+
+**Objective:** Prove core reliability/observability invariants before broader rollout.
+
+- **redemeine-sy8** (Auditor): reliability verification suite for outbox
+  - Validate atomicity, retries, dead-letter, lease recovery, idempotency
+- **redemeine-vx5** (Auditor): observability verification suite
+  - Validate canonical hook schema coverage and trace continuity
+- **redemeine-1uh.5** (CI/Security): branch protection + release integrity controls
+  - Enforce required checks/reviews and integrity evidence
+
+**Exit gate (P0-GATE):**
+- sy8 = verified
+- vx5 = verified
+- 1uh.5 = verified
+- all required CI checks stable and branch protection enforceable without deadlock
+
+### P1 (Scale confidence + operability hardening)
+
+**Objective:** Raise confidence from correctness to operational resilience.
+
+- Execute replay/lag/drift drills from MQ + projection architecture contracts
+- Add failure-injection cadence in CI/nightly for outbox and projection paths
+- Finalize operator runbook links and release evidence packaging for Diplomacy
+
+**Exit gate (P1-GATE):**
+- replay/recovery drill evidence attached
+- SLO/alert thresholds validated in staging-like conditions
+- on-call runbook complete and referenced in release template
+
+### P2 (Institutionalize + optimize)
+
+**Objective:** Make hardening durable and low-regression over time.
+
+- Promote performance/telemetry budgets from advisory to enforced guardrails
+- Add periodic dependency/security attestation audits
+- Close loop from production incidents -> new discovered-from beads
+
+**Exit gate (P2-GATE):**
+- enforcement checks active
+- periodic audit owners assigned
+- feedback loop documented and in use
+
+## Parallel delivery tracks
+
+### Track A - Reliability path (Outbox)
+- Inputs: redemeine-4gu, redemeine-42m, redemeine-ogq, redemeine-48z, redemeine-yvf
+- Gate bead: **redemeine-sy8**
+- Critical risk focus: atomicity regressions, lease recovery edge cases, duplicate dispatch
+
+### Track B - Observability/Inspectability path
+- Inputs: redemeine-33p, redemeine-xvr, redemeine-bxt, redemeine-h8i, redemeine-26i, redemeine-rt5, redemeine-9ff
+- Gate bead: **redemeine-vx5**
+- Critical risk focus: missing hook emission points, broken trace correlation, overhead drift
+
+### Track C - CI/Security/Release integrity path
+- Inputs: redemeine-1uh, redemeine-1uh.1, redemeine-1uh.2, redemeine-1uh.3, redemeine-1uh.4
+- Gate bead: **redemeine-1uh.5**
+- Critical risk focus: weak policy enforcement, untrusted artifact chain, merge/deploy deadlock
+
+### Track D - Release communication path
+- Input gate bead: **redemeine-haf**
+- Depends on: sy8 + vx5 + 1uh.5
+- Critical risk focus: releasing before verification evidence is complete
+
+## Dependency DAG (implementation order)
+
+```text
+[Foundational architecture COMPLETE]
+  4gu 33p bxt h8i fa0 48z yvf 9ff 1uh
+
+Track A (Reliability):
+  4gu + 33p + fa0 -> 42m -> ogq -> sy8
+  48z + yvf ----------------------^ (supporting verification context)
+
+Track B (Observability):
+  bxt + h8i -> 26i -> xvr -> rt5 -> vx5
+  33p + 9ff ----------------------^ (schema/taxonomy + projection model)
+
+Track C (CI/Security):
+  1uh.1 + 1uh.4 -> 1uh.2
+  1uh.4 ---------> 1uh.3
+  1uh.1 + 1uh.2 + 1uh.3 + 1uh.4 -> 1uh.5
+
+Track D (Release handoff):
+  sy8 + vx5 + 1uh.5 -> haf -> epic release close sequence
+```
+
+## Risk register
+
+| ID | Risk | Probability | Impact | Detection signal | Mitigation | Owner stage |
+|---|---|---:|---:|---|---|---|
+| R1 | Outbox atomicity breaks under adapter edge cases | M | H | flaky rollback/failure-injection tests | enforce adapter conformance + sy8 failure matrix tests | Engineer + Auditor |
+| R2 | Lease recovery causes duplicate side-effects | M | H | duplicate delivery IDs in test/prod telemetry | strengthen idempotency keys + lease expiry recovery assertions | Engineer + Auditor |
+| R3 | Canonical hook coverage incomplete | M | M/H | missing taxonomy events in vx5 evidence | strict hook coverage checklist against redemeine-33p | Engineer + Auditor |
+| R4 | Trace context discontinuity across command->projection path | M | H | orphan spans / broken parent-child chains | dedicated continuity E2E in rt5/vx5 | Engineer + Auditor |
+| R5 | Security controls create merge deadlock | L/M | H | required check stuck/skipped states | single stable required gate + no path-filter required checks | Architect + Engineer |
+| R6 | Release integrity evidence incomplete (SBOM/attestation/provenance) | M | H | missing artifact evidence at release cut | enforce 1uh.5 checklist before release candidate | Auditor + Diplomat |
+| R7 | Coordination drift between tracks delays release | M | M | bead states inconsistent with gate assumptions | explicit gate checklist + bead-status audit cadence | Builder + Architect |
+
+## Handoff gates by role
+
+### Engineer -> Auditor gate
+- Bead status: `implemented`
+- Required artifact bundle:
+  - test evidence (integration/E2E, failure injection where applicable)
+  - docs delta (runbook/contracts updated if behavior changed)
+  - known limitations list
+
+### Auditor -> Diplomat gate
+- Bead status: `verified` (or `changes_requested` with blocking defects)
+- Required artifact bundle:
+  - reproducible command log
+  - acceptance mapping to bead criteria
+  - explicit go/no-go recommendation
+
+### Diplomat release gate
+- Bead status: `in_review` during PR/release workflow, then close on merge/deploy
+- Required readiness:
+  - sy8 + vx5 + 1uh.5 all verified
+  - rollout messaging + rollback notes linked to bead IDs
+  - release notes include hardening evidence references
+
+## Recommended execution sequence (fastest safe path)
+
+1. Run **P0 in parallel** across Tracks A/B/C with daily gate check.
+2. Treat **sy8, vx5, 1uh.5** as co-equal blockers; no partial release gate.
+3. Once P0-GATE clears, run P1 operational drills and finalize haf.
+4. Promote to P2 enforcement only after one successful release cycle.
+
+## Bead traceability summary
+
+- This roadmap bead: **redemeine-8ew**
+- Epic: **redemeine-hwj**
+- P0 release blockers: **redemeine-sy8**, **redemeine-vx5**, **redemeine-1uh.5**
+- Release communication gate: **redemeine-haf**

--- a/docs/architecture/projection-service-over-mq-commit-feed.md
+++ b/docs/architecture/projection-service-over-mq-commit-feed.md
@@ -1,0 +1,244 @@
+---
+title: Projection Service over MQ Commit Feed
+bead: redemeine-9ff
+status: proposed
+last_updated: 2026-04-08
+---
+
+# Projection Service over MQ Commit Feed
+
+## 1) Goal and scope
+
+Define a projection runtime that consumes commit envelopes from MQ (not direct event-store subscriptions) while preserving deterministic replay, partition-safe scaling, and failure isolation.
+
+This spec covers:
+- Processing model and worker topology
+- Checkpoint transaction semantics
+- Idempotency and partitioning strategy
+- Replay/reset workflows
+- Drift detection and correction
+- DLQ behavior and recovery
+- Lag monitoring and alerting
+
+## 2) Canonical processing model
+
+1. **CDC relay publishes commit envelopes** to a topic (at-least-once).
+2. **Projection consumer group** subscribes and receives partition-ordered envelopes.
+3. Worker executes **persist-before-ack** pipeline:
+   - Deserialize + validate envelope
+   - Apply idempotency gate
+   - Execute projection mutation in local projection store
+   - Persist checkpoint in the same local transaction
+   - Commit transaction
+   - Ack MQ message
+4. If transaction fails, message is **not acked** and is retried by MQ.
+
+### Envelope requirements
+
+Each message must include at minimum:
+- `stream_id`
+- `commit_id` (globally unique)
+- `stream_version`
+- `commit_timestamp`
+- `event_count`
+- `events[]`
+- `trace_id` / correlation metadata
+
+`commit_id` is the primary dedupe key.
+
+## 3) Partitioning and scaling
+
+### Partition key
+
+Default key: `stream_id`.
+
+Rationale:
+- Preserves ordering for all commits of a stream.
+- Prevents cross-worker races on same aggregate history.
+
+### Consumer group behavior
+
+- Multiple projection workers join same consumer group.
+- MQ guarantees one active consumer per partition.
+- Rebalances are expected; worker must flush in-flight transaction before partition revoke.
+
+### Horizontal scaling
+
+- Throughput scales by increasing partitions and worker replicas.
+- Per-partition strict order is preserved; global order is not required.
+
+## 4) Checkpoint transaction semantics
+
+Checkpoint must be written atomically with projection mutation.
+
+### Required invariant
+
+For a given projection + partition:
+- Either both are committed:
+  - projection row/document updates
+  - checkpoint `(partition, offset, commit_id, processed_at)`
+- Or neither is committed.
+
+### Data model
+
+`projection_checkpoints`
+- `projection_name` (PK part)
+- `partition_id` (PK part)
+- `offset` (monotonic)
+- `last_commit_id`
+- `last_stream_version` (optional)
+- `updated_at`
+
+`projection_dedupe`
+- `projection_name` (PK part)
+- `commit_id` (PK part)
+- `partition_id`
+- `offset`
+- `processed_at`
+- retention policy (TTL/windowed cleanup)
+
+### Commit algorithm
+
+Within one DB transaction:
+1. Verify offset progression (no regressions unless replay mode enabled).
+2. Upsert dedupe key (`commit_id`), no-op if exists.
+3. If newly inserted, apply projection mutation.
+4. Upsert checkpoint to current offset.
+5. Commit DB transaction.
+6. Ack MQ offset after DB commit only.
+
+## 5) Idempotency guarantees
+
+Transport is at-least-once; projection correctness must be effectively-once.
+
+### Rules
+
+- `commit_id` dedupe is authoritative.
+- Projection handlers must be deterministic and side-effect-free (or side-effects routed through outbox).
+- Duplicate delivery must produce no net state change.
+
+### Handler contract
+
+`apply(commitEnvelope, state) -> newState` must satisfy:
+- Pure function semantics for same input + prior state
+- No dependency on wall clock without explicit event timestamp usage
+- No non-deterministic random branching
+
+## 6) Replay and reset semantics
+
+## 6.1 Replay (non-destructive)
+
+Use replay mode to rebuild or backfill a projection into a separate target table/namespace.
+
+- Start from offset 0 (or requested start offset/time).
+- Disable real-time lag alerts for replay job label.
+- Produce progress metrics (`replay_processed_total`, ETA).
+- Cutover by versioned alias/table swap after verification.
+
+## 6.2 Reset (destructive)
+
+Reset clears projection state and checkpoints for selected projection scope.
+
+Required safeguards:
+- Operator confirmation token
+- Scoped reset boundary (`projection_name`, optional partition subset)
+- Audit log entry with actor/reason/change-ticket
+
+Post-reset behavior:
+- Consumer starts from configured bootstrap offset (`earliest` by default).
+- Dedupe table cleared only for reset scope.
+
+## 7) Drift detection and correction
+
+Drift = projection state not matching expected state from event history.
+
+### Detection methods
+
+1. **Continuous checksum sampling**
+   - Periodically recompute deterministic hash for sampled entities from source events.
+   - Compare against stored projection hash/version.
+2. **Invariant probes**
+   - Domain-level assertions (e.g., counters non-negative, referential links present).
+3. **Replay-compare jobs**
+   - Rebuild in shadow table and compare row counts + keyed hashes.
+
+### Correction policy
+
+- Minor/local drift: targeted entity replay by stream.
+- Widespread drift: full projection reset + replay.
+- Emit `projection_drift_detected` event/metric and open incident if threshold exceeded.
+
+## 8) Failure isolation and DLQ policy
+
+Classify errors to avoid blocking healthy partitions.
+
+### Error classes
+
+1. **Transient** (timeouts, network, lock contention)
+   - Retry with exponential backoff + jitter.
+2. **Poison payload / schema violation**
+   - Non-retriable after bounded attempts.
+3. **Code bug / invariant violation**
+   - Retriable briefly, then DLQ and page owner.
+
+### DLQ behavior
+
+- After `max_attempts`, publish original envelope + error metadata to DLQ topic:
+  - `projection_name`, `partition`, `offset`, `commit_id`, `error_class`, `stack_hash`, `attempts`, `failed_at`
+- Ack source message only after DLQ publish succeeds (to prevent poison loop).
+- Provide redrive tool for DLQ -> main topic after fix.
+
+## 9) Lag monitoring and observability requirements
+
+### Core metrics
+
+- `projection_consumer_lag_messages{projection,partition}`
+- `projection_consumer_lag_seconds{projection,partition}`
+- `projection_throughput_commits_per_sec{projection}`
+- `projection_apply_latency_ms{projection}` (p50/p95/p99)
+- `projection_checkpoint_age_seconds{projection,partition}`
+- `projection_dedupe_hits_total{projection}`
+- `projection_failures_total{projection,error_class}`
+- `projection_dlq_total{projection,error_class}`
+
+### Alerts
+
+- **Critical**: lag seconds above SLO for N minutes on any hot partition.
+- **Warning**: checkpoint age increasing while input traffic exists.
+- **Critical**: DLQ rate above threshold or any sustained poison stream.
+- **Warning**: repeated rebalance churn indicating unstable consumers.
+
+### Tracing/logging
+
+- Propagate `trace_id` from envelope through handler pipeline.
+- Structured logs include `projection_name`, `partition`, `offset`, `commit_id`, `attempt`.
+- Emit span around `apply+checkpoint` transaction.
+
+## 10) Operational runbooks (minimum)
+
+1. **Lag spike runbook**: identify partition skew, consumer health, store bottlenecks.
+2. **DLQ runbook**: classify failure, patch handler/schema, redrive safely.
+3. **Drift runbook**: verify scope, choose targeted replay vs full reset, validate post-fix.
+4. **Replay cutover runbook**: shadow rebuild, consistency checks, alias swap, rollback plan.
+
+## 11) Acceptance mapping (redemeine-9ff)
+
+- Processing model: defined in sections 2-4.
+- Checkpoint transaction semantics: section 4 atomic invariant and algorithm.
+- Idempotency/partitioning/replay/reset/drift: sections 3, 5, 6, 7.
+- DLQ behavior: section 8.
+- Observability + lag monitoring: section 9.
+
+## 12) Open risks and assumptions
+
+### Assumptions
+- MQ supports partitioned ordered consumption with consumer groups.
+- Projection store supports ACID transaction over mutation + checkpoint writes.
+- CDC relay guarantees unique `commit_id` per commit envelope.
+
+### Risks
+- Hot-stream partition skew may dominate latency.
+- Long-running handlers can cause rebalance thrash and lag cliffs.
+- Incomplete schema evolution policy may inflate poison/DLQ rates.
+
+Mitigations: partition planning, handler latency budgets, schema compatibility gates, replay rehearsal in staging.

--- a/docs/architecture/redemeine-vx5-auditor-observability-verification.md
+++ b/docs/architecture/redemeine-vx5-auditor-observability-verification.md
@@ -1,0 +1,120 @@
+# redemeine-vx5 Auditor Observability Verification Evidence
+
+Date: 2026-04-09  
+Worktree: `C:\opt\projects\redemeine\worktrees\trees\bead-redemeine-vx5`  
+Branch: `task/redemeine-vx5`
+
+## Scope
+Validate observability verification for canonical hooks and runtime observability contracts, with evidence for:
+- Hook taxonomy coverage
+- Schema stability
+- Correlation propagation
+- Minimal-mode overhead/sampling expectations
+
+## Environment and Bead Context
+### Command
+`bd context --json`
+
+### Result
+- `is_worktree: true`
+- `is_redirected: true`
+- Shared beads DB confirmed.
+
+### Command
+`bd show redemeine-vx5 --json`
+
+### Result
+- Bead acceptance requires evidence for hook taxonomy coverage, schema conformance, trace continuity, and minimal mode overhead expectations.
+
+## Verification Commands and Results
+
+### 1) Canonical hook taxonomy coverage
+#### Command
+`bunx jest packages/mirage/test/createMirage.test.ts --runInBand`
+
+#### Result
+- PASS (18/18)
+- Includes lifecycle plugin hook execution tests for:
+  - `onBeforeCommand`
+  - `onHydrateEvent`
+  - builder/runtime plugin composition behavior
+
+#### Command
+`bunx jest packages/mirage/test/Depot.test.ts --runInBand`
+
+#### Result
+- PASS (14/14)
+- Includes append/post-commit plugin lifecycle and failure policy tests for:
+  - `onBeforeAppend`
+  - `onAfterCommit`
+  - structured plugin hook failure behavior
+
+Conclusion: Canonical hook taxonomy is covered by runtime tests and currently passing.
+
+---
+
+### 2) Schema stability (runtime observability contracts)
+#### Command
+`bunx jest packages/saga-runtime/test/runtime-observability-contracts.test.ts --runInBand`
+
+#### Result
+- PASS (4/4)
+- Validates telemetry/audit/read-model contract payload shape and method signatures.
+
+#### Command
+`bunx jest packages/saga-runtime/test/runtime-audit-projections.test.ts --runInBand`
+
+#### Result
+- PASS (4/4)
+- Validates deterministic ordering and pagination behavior for runtime audit/read projections.
+
+Conclusion: Observability schema/contract stability assertions are present and passing.
+
+---
+
+### 3) Correlation propagation evidence
+#### Command
+`bunx jest packages/saga-runtime/test/reference-adapters.integration.test.ts --runInBand`
+
+#### Result
+- PASS (10/10)
+- Includes concurrent response correlation assertions ensuring per-correlation mapping of `responseRef` and execution outcomes.
+
+Conclusion: Correlation propagation in reference runtime adapters is validated and passing.
+
+---
+
+### 4) End-to-end continuity/regression signal
+#### Command
+`bunx jest packages/saga-runtime/test/order-workflow-v1.e2e.test.ts --runInBand`
+
+#### Result
+- FAIL (3/3 failed)
+- All scenarios fail at expected intent type comparison:
+  - Expected: `plugin-request`
+  - Received: `plugin-intent`
+
+Conclusion: E2E runtime behavior has a taxonomy mismatch regression in intent type naming.
+
+---
+
+### 5) OTel integration + minimal-mode/sampling/overhead expectations
+#### Commands
+- Search for OTel package/integration markers in workspace package manifests and source:
+  - `grep @redemeine/otel|OpenTelemetry|otel`
+  - glob searches under `packages/**` for `*otel*`
+
+#### Result
+- No `@redemeine/otel` package or direct OpenTelemetry integration files found in this worktree.
+- No explicit minimal-mode sampling/overhead benchmark/threshold assertions tied to OTel integration found.
+
+Conclusion: Evidence for OTel integration and minimal-mode overhead/sampling expectations is **not currently demonstrable** in this branch.
+
+## Overall Auditor Verdict
+- Hook taxonomy coverage: PASS
+- Schema conformance/stability: PASS
+- Correlation propagation: PASS
+- E2E continuity/regression: FAIL (intent taxonomy mismatch in runtime E2E)
+- OTel integration + minimal-mode overhead/sampling evidence: FAIL (not present/discoverable in current branch)
+
+Release readiness for this bead scope: **Not ready** until failing E2E mismatch and explicit OTel/minimal-mode evidence gap are addressed.

--- a/docs/architecture/tapeworm-durable-commit-feed-ulid-cursor-contract.md
+++ b/docs/architecture/tapeworm-durable-commit-feed-ulid-cursor-contract.md
@@ -1,0 +1,255 @@
+# Tapeworm Durable Commit Feed + ULID Cursor Contract (redemeine-48z)
+
+## Status
+- Owner: Architect
+- Bead: redemeine-48z
+- Scope: Durable commit-feed contract for Tapeworm adapters (MongoDB, IndexedDB, others)
+- Depends on: redemeine-4gu (transactional outbox architecture)
+
+## 1) Goals and Non-goals
+
+### Goals
+1. Define a **portable commit envelope** emitted by all Tapeworm adapters.
+2. Define a **ULID cursor contract** for ordered catch-up and resume.
+3. Specify **ordering guarantees** and adapter conformance boundaries.
+4. Specify **backfill/rehydration API semantics** for consumers that fall behind oplog/change-stream windows.
+5. Define **index/checkpoint/failure-recovery** rules to guarantee at-least-once delivery with deterministic replay.
+
+### Non-goals
+1. No transport binding decision (Kafka/SQS/etc. is out of scope here).
+2. No implementation details for specific storage engines beyond conformance requirements.
+3. No change to domain event schema itself beyond feed envelope wrapping.
+
+---
+
+## 2) Commit Envelope Schema (Canonical)
+
+Every committed unit (aggregate append + optional outbox intents) MUST be exportable as one immutable envelope.
+
+```ts
+type TapewormCommitEnvelopeV1 = {
+  schemaVersion: 1;
+
+  // globally unique, lexicographically sortable cursor key
+  commitId: string; // ULID
+
+  // commit metadata
+  committedAt: string; // RFC3339 UTC timestamp
+  stream: {
+    aggregateType: string;
+    aggregateId: string;
+    expectedVersion?: number;
+    nextVersion: number;
+  };
+
+  // deterministic ordering tie-breakers when storage clock granularity is coarse
+  ordering: {
+    partitionKey: string;      // typically aggregateType|aggregateId
+    partitionOffset: number;   // monotonic within partition
+    globalSequence?: string;   // optional adapter-native sequence if available
+  };
+
+  causation?: {
+    commandId?: string;
+    correlationId?: string;
+    actorId?: string;
+    tenantId?: string;
+  };
+
+  events: Array<{
+    eventId: string;
+    eventType: string;
+    eventVersion: number;
+    payload: unknown;
+    metadata?: Record<string, unknown>;
+  }>;
+
+  outbox?: Array<{
+    intentId: string;
+    intentType: 'command' | 'integration' | 'timer' | 'compensation';
+    topic?: string;
+    payload: unknown;
+    headers?: Record<string, string>;
+    notBefore?: string; // RFC3339
+  }>;
+
+  integrity: {
+    checksum?: string;      // optional content hash for corruption detection
+    adapterName: string;
+    adapterVersion: string;
+  };
+};
+```
+
+### Envelope invariants
+- `commitId` MUST be unique in adapter scope and stable forever.
+- `events[]` order MUST match append order in the transactional boundary.
+- If outbox exists, outbox intents MUST represent the same atomic commit boundary as events.
+- Envelope is append-only and immutable after commit success.
+
+---
+
+## 3) ULID Cursor Model
+
+### Cursor type
+```ts
+type TapewormCursor = {
+  v: 1;
+  afterCommitId?: string; // ULID, exclusive lower bound
+  limit?: number;         // requested batch size
+  partition?: string;     // optional future extension for sharded scans
+};
+```
+
+### Cursor semantics
+1. `afterCommitId` is **exclusive**: next page begins strictly after this commit.
+2. Empty cursor means from oldest retained commit in feed.
+3. Returned page includes `nextCursor` with the last envelope `commitId`.
+4. Cursor is opaque to external consumers once serialized; producers may add fields with version bump.
+
+### Why ULID
+- Lexicographic ordering makes checkpoint persistence simple.
+- Monotonic ULID generation minimizes collision risk within same millisecond.
+- Works across adapters lacking native global sequence primitives.
+
+---
+
+## 4) Ordering Guarantees
+
+### Required guarantees (all adapters)
+1. **Per-commit atomicity**: envelope is either fully visible or not visible.
+2. **Total feed order by (`commitId`, adapter tie-breaker)** for replay APIs.
+3. **Per-partition monotonic order** by `partitionOffset` for same aggregate partition.
+4. **No mutation/rewrite** of committed envelopes.
+
+### Allowed behavior
+- Feed is **at-least-once consumable**; duplicates are possible under retry/resume.
+- Cross-partition real-time causality is not guaranteed beyond feed order.
+
+### Consumer requirement
+- Consumers MUST dedupe by `commitId` (and optionally `eventId`/`intentId` downstream).
+
+---
+
+## 5) Backfill / Rehydration API Semantics
+
+### Contract
+```ts
+interface DurableCommitFeed {
+  readPage(input: {
+    cursor?: TapewormCursor;
+    limit?: number;
+    fromCommittedAt?: string; // optional bounded-time recovery
+  }): Promise<{
+    envelopes: TapewormCommitEnvelopeV1[];
+    nextCursor?: TapewormCursor;
+    highWatermark?: { commitId: string; committedAt: string };
+  }>;
+
+  getByCommitId(commitId: string): Promise<TapewormCommitEnvelopeV1 | null>;
+
+  getWindow(input: {
+    fromCommitId?: string;
+    toCommitId?: string;
+    limit?: number;
+  }): Promise<TapewormCommitEnvelopeV1[]>;
+}
+```
+
+### Semantics
+- `readPage` MUST return envelopes in ascending feed order.
+- `highWatermark` indicates snapshot upper bound observed during request.
+- If `fromCommittedAt` precedes retention floor, adapter returns an explicit retention error with oldest available watermark.
+- `getByCommitId` enables point recovery after partial batch processing crash.
+
+---
+
+## 6) Adapter Conformance Requirements
+
+Each adapter MUST provide:
+1. **Atomic write boundary** for events + outbox intents in one commit package.
+2. **Deterministic ULID assignment** at commit creation time.
+3. **Durable feed storage** retaining envelopes at least for configured replay horizon.
+4. **Idempotent read behavior** (same cursor boundary always yields stable ordering for retained data).
+5. **Conformance tests** validating ordering, dedupe keys, and crash recovery.
+
+### MongoDB adapter
+- Use transaction/session for atomic append+outbox.
+- Required indexes:
+  - unique `{ commitId: 1 }`
+  - `{ committedAt: 1, commitId: 1 }`
+  - `{ stream.aggregateType: 1, stream.aggregateId: 1, ordering.partitionOffset: 1 }`
+
+### IndexedDB adapter
+- Use one transaction spanning event/outbox object stores and commit feed store.
+- Required indexes:
+  - primary key `commitId`
+  - secondary `committedAt`
+  - compound `(partitionKey, partitionOffset)`
+
+---
+
+## 7) Index and Checkpoint Strategy
+
+### Producer-side indexes
+- Primary lookup: `commitId`.
+- Sequential scan: `(committedAt, commitId)` for stable pagination.
+- Partition debugging/rebuild: `(partitionKey, partitionOffset)`.
+
+### Consumer checkpoints
+Checkpoint record:
+```ts
+type FeedCheckpoint = {
+  consumerId: string;
+  lastProcessedCommitId: string;
+  lastProcessedAt: string;
+  updatedAt: string;
+  leaseToken?: string;
+};
+```
+
+Rules:
+1. Persist checkpoint **after** successful processing side-effects for the commit.
+2. Resume with `afterCommitId=lastProcessedCommitId`.
+3. On duplicate redelivery, skip when `commitId <= lastProcessedCommitId` (or dedupe table hit).
+
+---
+
+## 8) Failure / Recovery Flows
+
+### A) Consumer crash after processing, before checkpoint
+- On restart, same commit may replay.
+- Required mitigation: idempotent side-effect handlers + dedupe by commitId/intentId.
+
+### B) Cursor references pruned data
+- Adapter returns `RetentionWindowExceeded` with `oldestAvailableCommitId`.
+- Consumer performs bounded backfill from retention floor and emits observability alert.
+
+### C) Partial adapter outage during read
+- Reader retries with same cursor (safe due to immutable ordering).
+- Exponential backoff with jitter required at integration layer.
+
+### D) Cross-node clock skew
+- ULID monotonic factory per node + tie-break with adapter-native sequence where present.
+- Conformance tests must prove stable order under skew simulation.
+
+---
+
+## 9) Acceptance Mapping (redemeine-48z)
+
+- API contract: Defined in sections 2, 3, 5.
+- Index strategy: Section 7 (+ adapter specifics in section 6).
+- Checkpoint semantics: Section 7.
+- Failure/recovery for catch-up + resume: Section 8.
+- Adapter conformance across MongoDB/IndexedDB/etc.: Section 6.
+
+## 10) Engineer Handoff Notes
+
+1. Implement `TapewormCommitEnvelopeV1` and `TapewormCursor` as shared contracts package-level.
+2. Add adapter conformance test suite with fixtures for ordering, retention errors, resume, and dedupe replay.
+3. Wire runtime checkpoint abstraction to persist `lastProcessedCommitId` atomically with consumer progress where possible.
+4. Emit metrics:
+   - feed_read_lag_ms
+   - backfill_window_exceeded_total
+   - replay_duplicate_total
+   - checkpoint_write_latency_ms

--- a/docs/architecture/telemetry-spi-design.md
+++ b/docs/architecture/telemetry-spi-design.md
@@ -1,0 +1,265 @@
+﻿# @redemeine/telemetry SPI Design (Backend-Agnostic)
+
+**Bead:** `redemeine-bxt`  
+**Status:** Architect deliverable (design-only)  
+**Last updated:** 2026-04-08
+
+---
+
+## 1) Scope and intent
+
+Define a stable, backend-agnostic telemetry SPI package (`@redemeine/telemetry`) that runtime packages can depend on without importing OpenTelemetry (or any other backend) directly.
+
+This design covers:
+- tracing interfaces and span lifecycle contracts,
+- metrics interfaces,
+- log-correlation context contracts,
+- provider registration / runtime lifecycle,
+- hook sink contracts for runtime inspection events,
+- no-op defaults and failure-isolation semantics,
+- package boundaries and dependency rules,
+- migration path from direct OTel assumptions.
+
+## 2) Goals / non-goals
+
+### Goals
+1. Runtime packages (`mirage`, `projection`, `saga-runtime`, etc.) depend only on SPI contracts.
+2. Backends (e.g. `@redemeine/otel`) are pluggable adapters.
+3. Telemetry calls are safe by default (no provider required).
+4. Hook sinks can be attached once and reused across runtimes.
+5. Migration can be incremental without behavioral breakage.
+
+### Non-goals
+- Implementing concrete OpenTelemetry integration (belongs to `redemeine-h8i`).
+- Final semantic convention naming for all domain events (handled in inspection/outbox beads).
+- Rewriting runtime internals in this bead.
+
+---
+
+## 3) Package boundaries
+
+### New package
+- `packages/telemetry` (`@redemeine/telemetry`)
+
+### Dependency policy
+- `@redemeine/telemetry` MAY depend on `@redemeine/kernel` for shared primitive contracts.
+- Runtime packages MAY depend on `@redemeine/telemetry`.
+- Runtime packages MUST NOT depend on `@redemeine/otel` directly.
+- `@redemeine/otel` MUST depend on `@redemeine/telemetry` (SPI -> implementation direction).
+- `@redemeine/telemetry` MUST NOT depend on backend SDKs (OTel, Datadog, etc.).
+
+### Boundary matrix extension
+| from \\ to | `@redemeine/kernel` | `@redemeine/telemetry` | `@redemeine/otel` |
+|---|---:|---:|---:|
+| `@redemeine/telemetry` | allowed | same-package | forbidden |
+| runtime packages (`mirage`, `projection`, `saga-runtime`) | allowed | allowed | forbidden |
+| `@redemeine/otel` | allowed | allowed | same-package |
+
+---
+
+## 4) SPI contracts (proposed)
+
+> Naming is intentionally interface-first to keep implementation freedom.
+
+```ts
+// packages/telemetry/src/contracts.ts
+
+export type TelemetryAttributes = Record<string, string | number | boolean | null | undefined>;
+
+export interface TelemetryContextCarrier {
+  traceId?: string;
+  spanId?: string;
+  correlationId?: string;
+  causationId?: string;
+  baggage?: Record<string, string>;
+}
+
+export interface TelemetrySpan {
+  setAttribute(key: string, value: TelemetryAttributes[string]): void;
+  addEvent(name: string, attributes?: TelemetryAttributes): void;
+  recordError(error: unknown, attributes?: TelemetryAttributes): void;
+  setStatus(status: 'ok' | 'error', message?: string): void;
+  end(endTime?: number): void;
+}
+
+export interface TelemetryTracer {
+  startSpan(name: string, options?: {
+    kind?: 'internal' | 'server' | 'client' | 'producer' | 'consumer';
+    attributes?: TelemetryAttributes;
+    parent?: TelemetryContextCarrier;
+    startTime?: number;
+  }): TelemetrySpan;
+
+  withSpan<T>(name: string, fn: (span: TelemetrySpan) => T | Promise<T>, options?: {
+    kind?: 'internal' | 'server' | 'client' | 'producer' | 'consumer';
+    attributes?: TelemetryAttributes;
+    parent?: TelemetryContextCarrier;
+  }): T | Promise<T>;
+}
+
+export interface TelemetryMeter {
+  counter(name: string, options?: { description?: string; unit?: string }): {
+    add(value: number, attributes?: TelemetryAttributes): void;
+  };
+  histogram(name: string, options?: { description?: string; unit?: string }): {
+    record(value: number, attributes?: TelemetryAttributes): void;
+  };
+  gauge(name: string, options?: { description?: string; unit?: string }): {
+    set(value: number, attributes?: TelemetryAttributes): void;
+  };
+}
+
+export interface TelemetryLogger {
+  bind(context: TelemetryContextCarrier): TelemetryLogger;
+  info(message: string, fields?: TelemetryAttributes): void;
+  warn(message: string, fields?: TelemetryAttributes): void;
+  error(message: string, fields?: TelemetryAttributes): void;
+  debug?(message: string, fields?: TelemetryAttributes): void;
+}
+
+export interface TelemetryHookSink {
+  emit(eventName: string, payload: {
+    ts: number;
+    source: string; // mirage | projection | saga-runtime | ...
+    attributes?: TelemetryAttributes;
+    context?: TelemetryContextCarrier;
+  }): void | Promise<void>;
+}
+
+export interface TelemetryProvider {
+  readonly name: string;
+  tracer(scope: string): TelemetryTracer;
+  meter(scope: string): TelemetryMeter;
+  logger(scope: string): TelemetryLogger;
+
+  inject?(context: TelemetryContextCarrier, carrier: Record<string, string>): void;
+  extract?(carrier: Record<string, string>): TelemetryContextCarrier;
+
+  hookSink?(): TelemetryHookSink;
+  flush?(): Promise<void>;
+  shutdown?(): Promise<void>;
+}
+```
+
+Design notes:
+- `TelemetryProvider` is the only backend-facing contract runtime code sees.
+- Runtime packages request scoped tracer/meter/logger by logical package scope string.
+- Hook sink is optional to keep minimal providers lightweight.
+
+---
+
+## 5) Provider registration and lifecycle
+
+### Registry API
+
+```ts
+export interface TelemetryRegistry {
+  register(provider: TelemetryProvider): void;
+  get(): TelemetryProvider;
+  resetForTests?(): void;
+}
+```
+
+### Lifecycle rules
+1. **Default state:** registry returns a built-in no-op provider.
+2. **Registration:** first explicit `register` replaces no-op provider.
+3. **Idempotency:** repeated register of same logical provider is allowed; last-write-wins.
+4. **Failure isolation:** telemetry failures MUST NOT break domain command processing by default.
+5. **Shutdown:** host application may call `flush` then `shutdown` during process drain.
+
+### Startup/teardown guidance
+- Application bootstrap selects implementation package and calls `register(...)` once.
+- Tests can keep no-op or inject fake provider.
+- Runtime packages never construct provider directly.
+
+---
+
+## 6) Hook sink contracts
+
+Hook sink is the transport-neutral emission point for inspection signals that are not strictly span/metric operations.
+
+Contract rules:
+1. `emit(eventName, payload)` must be stable and versionable.
+2. Payload must include `ts` and `source` to support replay/auditing.
+3. Event names should follow namespaced convention (`runtime.<domain>.<action>`).
+4. Hook sink failures are swallowed + surfaced as logger warnings unless explicitly configured fail-closed by host.
+5. Hook sinks must support no-op behavior with near-zero overhead.
+
+Recommended initial event families:
+- `runtime.command.received`
+- `runtime.event.appended`
+- `runtime.outbox.enqueued`
+- `runtime.intent.dispatched`
+- `runtime.intent.failed`
+- `runtime.projection.batch.processed`
+
+(Exact taxonomy will align with inspection-hook bead deliverables.)
+
+---
+
+## 7) No-op defaults
+
+`@redemeine/telemetry` ships a no-op provider implementing all interfaces.
+
+No-op requirements:
+- Every method is safe to call with no side effects.
+- `withSpan` executes callback directly and still catches/records nothing.
+- Counter/histogram/gauge operations are no-op.
+- Logger methods are no-op unless debug test mode explicitly enabled.
+- `hookSink().emit(...)` resolves immediately.
+
+Rationale:
+- No runtime package needs conditional telemetry guards.
+- Feature works in minimal/edge environments without SDK footprint.
+
+---
+
+## 8) Migration path (from direct OTel assumptions)
+
+### Phase 0: SPI introduction
+- Add `@redemeine/telemetry` interfaces + no-op provider + registry.
+- No runtime behavior change.
+
+### Phase 1: runtime dependency swap
+- Replace direct OTel references in runtime packages with SPI calls.
+- Keep emitted names/attributes aligned with existing behavior.
+
+### Phase 2: concrete adapter package
+- Implement `@redemeine/otel` against SPI.
+- Add conformance tests proving adapter satisfies SPI contract.
+
+### Phase 3: host wiring + docs
+- Bootstrap docs show `registerTelemetryProvider(createOtelProvider(...))`.
+- Optional alternative provider examples (console/fake/custom).
+
+### Compatibility guarantee
+- If host app does nothing, system uses no-op provider and remains functional.
+
+---
+
+## 9) Risks and mitigations
+
+1. **Risk:** SPI too thin, forcing runtime leaks.  
+   **Mitigation:** add extension points via optional methods (`inject/extract/hookSink`) before backend-specific escape hatches.
+
+2. **Risk:** Hook sink schema drift across packages.  
+   **Mitigation:** central event-name registry and shared payload contracts in telemetry package.
+
+3. **Risk:** Provider lifecycle mismanaged in tests.  
+   **Mitigation:** explicit `resetForTests` support in test utilities.
+
+---
+
+## 10) Acceptance mapping (`redemeine-bxt`)
+
+Bead acceptance text:  
+> "Design spec defines SPI interfaces, provider lifecycle, package boundaries, and migration path from direct OTel assumptions."
+
+| Acceptance requirement | Where covered in this document |
+|---|---|
+| SPI interfaces | Section 4 (`TelemetryProvider`, tracer/meter/logger/span/context/hook sink) |
+| Provider lifecycle | Section 5 (registry, registration rules, startup/teardown) |
+| Package boundaries | Section 3 (new package, dependency policy, matrix extension) |
+| Migration path from direct OTel assumptions | Section 8 (phased migration and compatibility guarantee) |
+
+Result: **All acceptance criteria are explicitly mapped and satisfied at design level.**

--- a/docs/architecture/transactional-outbox-rfc.md
+++ b/docs/architecture/transactional-outbox-rfc.md
@@ -1,0 +1,307 @@
+﻿---
+title: 'Transactional Outbox RFC (Tapeworm Commit Boundary + Dispatch Models)'
+last_updated: 2026-04-08
+status: proposed
+bead: redemeine-4gu
+ai_priority: high
+---
+
+# Transactional Outbox RFC (redemeine-4gu)
+
+## 1) Problem statement
+
+`@redemeine/mirage` currently persists events via `EventStore.saveEvents(...)` and then executes plugin `onAfterCommit` inline in the request lifecycle (`packages/mirage/src/Depot.ts`). This has two reliability gaps:
+
+1. Side-effects are coupled to command latency/failure path.
+2. Post-commit failures are not first-class persisted work items with replay/retry/dead-letter semantics.
+
+Goal: move to an outbox-first model where append + enqueue is one atomic Tapeworm commit, and dispatch is asynchronous and recoverable.
+
+---
+
+## 2) Decision summary
+
+### 2.1 Chosen atomicity boundary
+
+Adopt a **Tapeworm packaged commit boundary** as the only valid atomic write boundary for append + outbox enqueue.
+
+- The runtime asks a Tapeworm-capable adapter to persist:
+  - aggregate stream events,
+  - outbox rows/intents,
+  - and commit envelope metadata,
+  in a **single durable commit unit**.
+- If adapter cannot provide this guarantee, it is non-conformant for outbox-primary mode.
+
+### 2.2 Chosen dispatch model
+
+Adopt **Model A (Transactional outbox rows + worker)** as the canonical cross-adapter strategy.
+
+Model B (Mongo change streams) is allowed as an optimization adapter-layer trigger for Mongo deployments but not the portability baseline.
+
+---
+
+## 3) Model A vs B comparison
+
+| Dimension | A: Outbox rows + worker | B: Mongo change streams |
+| --- | --- | --- |
+| Portability (Mongo/IndexedDB/other Tapeworm adapters) | **High** (adapter-agnostic) | **Low** (Mongo-specific) |
+| Append+enqueue atomicity | **Strong** (same commit unit) | Medium (depends on document model and stream lag/window) |
+| Replay/backfill control | **Strong** (cursor over outbox table) | Weaker (window handling and resume token expiry concerns) |
+| Retry/dead-letter policy ownership | **Runtime-owned, explicit** | Split between stream infra + runtime |
+| Operational complexity | Moderate, predictable | Higher (stream operations, resume tokens, failover tuning) |
+| Multi-adapter fit | **Excellent** | Poor |
+
+### Recommendation
+
+- **Primary**: Model A for all adapters.
+- **Optional**: Model B may be used only as a wake-up signal for a worker that still processes durable outbox state.
+
+---
+
+## 4) Tapeworm commit boundary contract
+
+## 4.1 Commit port (runtime-facing)
+
+```ts
+export interface TapewormCommitPort {
+  supportsAtomicOutbox(): boolean;
+
+  /**
+   * Must atomically persist stream append + outbox enqueue + commit envelope.
+   * Either all are durable, or none are.
+   */
+  commitWithOutbox(input: {
+    aggregateId: string;
+    expectedVersion?: number;
+    events: readonly Event[];
+    outbox: readonly OutboxMessageToEnqueue[];
+    commit: TapewormCommitEnvelope;
+  }): Promise<{
+    commitId: string; // ULID or monotonic sortable id
+    streamVersion: number;
+    enqueuedCount: number;
+  }>;
+
+  /** Fallback legacy path when outbox disabled by config */
+  saveEvents?(aggregateId: string, events: readonly Event[], expectedVersion?: number): Promise<void>;
+}
+```
+
+## 4.2 Adapter conformance requirements
+
+A Tapeworm adapter is outbox-conformant iff:
+
+1. **Atomicity**: no visible state exists where events are appended but corresponding outbox messages are missing (or inverse) for one commit.
+2. **Durability**: successful return means both stream and outbox records survive crash/restart.
+3. **Ordering**: commitId ordering is monotonic per adapter storage order and stable for cursoring.
+4. **Idempotent commit identity**: duplicate commit attempts with same dedupe key do not create duplicate outbox messages.
+5. **Visibility rule**: worker can observe only committed rows.
+
+---
+
+## 5) Outbox message schema and invariants
+
+```ts
+type OutboxStatus =
+  | 'pending'
+  | 'leased'
+  | 'dispatched'
+  | 'retry_scheduled'
+  | 'dead_lettered';
+
+interface OutboxMessage {
+  messageId: string;          // stable id (ULID)
+  commitId: string;           // Tapeworm commit envelope id
+  aggregateId: string;
+  aggregateVersion: number;
+  pluginKey: string;
+  intentType: string;
+  payload: Record<string, unknown>;
+  idempotencyKey: string;     // stable key for external side-effect dedupe
+  attemptCount: number;
+  nextAttemptAt: string;      // ISO timestamp
+  leasedUntil?: string;
+  leaseOwner?: string;
+  status: OutboxStatus;
+  createdAt: string;
+  updatedAt: string;
+  lastError?: {
+    code: string;
+    message: string;
+    retriable: boolean;
+  };
+}
+```
+
+### Invariants
+
+1. `messageId` unique globally.
+2. `idempotencyKey` deterministic from `(pluginKey, aggregateId, commitId, intentType, logicalIntentRef)`.
+3. Status transitions are monotonic and valid per state machine (below).
+4. `attemptCount` increments only on actual dispatch attempt.
+5. `dead_lettered` is terminal.
+
+---
+
+## 6) Dispatch worker lifecycle and state machine
+
+## 6.1 Worker responsibilities
+
+1. Poll or wake on new pending work.
+2. Lease a bounded batch (`pending/retry_scheduled` and due).
+3. Execute plugin/intent side-effect with idempotency metadata.
+4. Ack success (`dispatched`) or classify failure:
+   - retriable -> backoff + `retry_scheduled`
+   - non-retriable / max-attempts reached -> `dead_lettered`
+5. Emit inspection hooks + telemetry at each transition.
+
+## 6.2 State machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> pending
+    pending --> leased: lease acquired
+    retry_scheduled --> leased: due + lease acquired
+    leased --> dispatched: side-effect success
+    leased --> retry_scheduled: retriable failure
+    leased --> dead_lettered: non-retriable or max attempts
+    leased --> pending: lease timeout/reclaim
+    dispatched --> [*]
+    dead_lettered --> [*]
+```
+
+### Transition guards
+
+- `leased -> retry_scheduled` requires computed `nextAttemptAt` using retry policy.
+- `leased -> dead_lettered` if `attemptCount >= maxAttempts` OR failure is non-retriable.
+- lease reclaim allowed when `leasedUntil < now`.
+
+---
+
+## 7) Interface seams (implementation-ready)
+
+```ts
+export interface OutboxPersistencePort {
+  enqueueInCommit(input: EnqueueInCommitInput): Promise<EnqueueInCommitResult>;
+  leaseDue(batchSize: number, nowIso: string, leaseMs: number, workerId: string): Promise<readonly OutboxMessage[]>;
+  markDispatched(messageId: string, nowIso: string): Promise<void>;
+  markRetryScheduled(messageId: string, update: {
+    nowIso: string;
+    nextAttemptAt: string;
+    error: OutboxMessage['lastError'];
+  }): Promise<void>;
+  markDeadLettered(messageId: string, update: {
+    nowIso: string;
+    error: OutboxMessage['lastError'];
+  }): Promise<void>;
+  reclaimExpiredLeases(nowIso: string): Promise<number>;
+}
+
+export interface OutboxDispatcher {
+  dispatch(message: OutboxMessage): Promise<
+    | { kind: 'success' }
+    | { kind: 'retry'; error: { code: string; message: string } }
+    | { kind: 'dead-letter'; error: { code: string; message: string } }
+  >;
+}
+```
+
+---
+
+## 8) Migration strategy from inline `onAfterCommit`
+
+## 8.1 Modes
+
+- `legacy_inline` (current): `saveEvents` then inline `onAfterCommit`.
+- `outbox_primary` (target): `commitWithOutbox`; no inline side-effects.
+- `dual_write_shadow` (temporary): outbox row creation + inline execution for parity validation (no worker dispatch to external systems in shadow unless explicitly enabled).
+
+## 8.2 Rollout phases
+
+1. **Phase 0 – Contract landing**
+   - Introduce Tapeworm commit/outbox interfaces and feature flags.
+2. **Phase 1 – Atomic persistence**
+   - Implement `commitWithOutbox` path in mirage depot.
+3. **Phase 2 – Worker + retries**
+   - Deliver dispatcher loop, lease/retry/dead-letter behavior.
+4. **Phase 3 – Cutover**
+   - Enable `outbox_primary` by default for conformant adapters.
+5. **Phase 4 – Removal**
+   - Deprecate inline `onAfterCommit` path from production mode.
+
+---
+
+## 9) Failure matrix (minimum)
+
+| Failure point | Expected result |
+| --- | --- |
+| Append fails before commit | no stream append, no outbox rows |
+| Outbox enqueue fails inside commit | no stream append, no outbox rows |
+| Crash after commit before dispatch | rows remain pending and are retried by worker |
+| Worker crash during lease | lease expires and message is reclaimed |
+| Side-effect timeout/retriable error | retry_scheduled with backoff |
+| Non-retriable side-effect error | dead_lettered with classified error |
+
+---
+
+## 10) Target files (planned implementation map)
+
+### New/updated runtime contracts
+- `packages/mirage/src/Depot.ts` (replace inline post-commit path behind mode switch)
+- `packages/mirage/src/outbox.ts` (new: message types, persistence/dispatch interfaces)
+- `packages/mirage/src/tapewormCommitPort.ts` (new: atomic commit contract)
+- `packages/mirage/src/index.ts` (export new contracts)
+
+### Adapter integrations (likely follow-up beads)
+- Tapeworm Mongo adapter: atomic commit + outbox write in one transaction unit
+- Tapeworm IndexedDB adapter: atomic commit + outbox write in one database transaction
+
+### Saga-runtime touchpoints (optional bridge)
+- `packages/saga-runtime/src/referenceAdapters.ts` (reuse retry/dead-letter semantics where compatible)
+- `packages/saga-runtime/src/runtimeObservabilityContracts.ts` (align outbox lifecycle observability event names)
+
+---
+
+## 11) Target tests
+
+### Mirage unit/integration
+- `packages/mirage/test/Depot.test.ts`
+  - append+enqueue atomic rollback tests
+  - no inline side-effect execution in `outbox_primary`
+  - compatibility coverage for `legacy_inline`
+- `packages/mirage/test/Depot.outbox.integration.test.ts` (new)
+  - lease/retry/dead-letter lifecycle
+  - idempotency key stability
+
+### Contract tests
+- `packages/mirage/test/TapewormCommitPort.contract.test.ts` (new)
+  - adapter conformance invariants
+
+### Optional saga-runtime alignment
+- `packages/saga-runtime/test/runtime-observability-contracts.test.ts`
+  - include outbox dispatch lifecycle event shape checks
+
+---
+
+## 12) Risks and assumptions
+
+Assumptions:
+- Tapeworm adapters can expose a shared commit envelope identity (`commitId`) consumable by outbox processing.
+- Plugin side-effects can accept idempotency metadata without breaking existing plugin contracts.
+
+Risks:
+- Adapter capability mismatch across environments (must be explicit via capability negotiation).
+- Legacy plugins expecting inline execution timing may require migration guidance.
+
+Mitigation:
+- feature-flagged rollout + dual-write shadow validation + contract test suite for adapters.
+
+---
+
+## 13) Acceptance mapping (redemeine-4gu)
+
+This RFC includes:
+- Tapeworm commit boundary definition and adapter conformance requirements.
+- Dispatch model A/B comparison with recommendation matrix.
+- Explicit interfaces, state machine, invariants, failure matrix, and phased rollout.
+- Concrete target files and tests for Engineer handoff.

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@redemeine/otel",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/index.ts",
+  "module": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "require": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "bun test ./test",
+    "lint": "bunx tsc -p tsconfig.json --noEmit"
+  }
+}

--- a/packages/otel/src/adapterRegistry.ts
+++ b/packages/otel/src/adapterRegistry.ts
@@ -1,0 +1,23 @@
+import type { TelemetryAdapter } from './types';
+
+const registeredAdapters = new Map<string, TelemetryAdapter>();
+
+export function registerAdapter(adapter: TelemetryAdapter): void {
+  registeredAdapters.set(adapter.id, adapter);
+}
+
+export function unregisterAdapter(id: string): boolean {
+  return registeredAdapters.delete(id);
+}
+
+export function clearAdapters(): void {
+  registeredAdapters.clear();
+}
+
+export function getAdapter(id: string): TelemetryAdapter | undefined {
+  return registeredAdapters.get(id);
+}
+
+export function listAdapters(): ReadonlyArray<TelemetryAdapter> {
+  return Array.from(registeredAdapters.values());
+}

--- a/packages/otel/src/contextPropagation.ts
+++ b/packages/otel/src/contextPropagation.ts
@@ -1,0 +1,29 @@
+import { listAdapters } from './adapterRegistry';
+import type { MutableTelemetryCarrier, TelemetryCarrier, TelemetryContext } from './types';
+
+export const NOOP_TELEMETRY_CONTEXT: TelemetryContext = Object.freeze({
+  values: Object.freeze({})
+});
+
+export function extractContext(carrier: TelemetryCarrier): TelemetryContext {
+  const adapters = listAdapters();
+
+  for (const adapter of adapters) {
+    const extracted = adapter.extract?.(carrier) ?? null;
+    if (extracted != null) {
+      return extracted;
+    }
+  }
+
+  return NOOP_TELEMETRY_CONTEXT;
+}
+
+export function injectContext(context: TelemetryContext, carrier: MutableTelemetryCarrier): MutableTelemetryCarrier {
+  const adapters = listAdapters();
+
+  for (const adapter of adapters) {
+    adapter.inject?.(context, carrier);
+  }
+
+  return carrier;
+}

--- a/packages/otel/src/facade.ts
+++ b/packages/otel/src/facade.ts
@@ -1,0 +1,41 @@
+import { getAdapter } from './adapterRegistry';
+import { NOOP_TELEMETRY_CONTEXT, extractContext, injectContext } from './contextPropagation';
+import type {
+  MutableTelemetryCarrier,
+  TelemetryAdapter,
+  TelemetryCarrier,
+  TelemetryContext
+} from './types';
+
+const DEFAULT_ADAPTER_ID = 'default';
+
+export interface TelemetryFacade {
+  readonly adapter: TelemetryAdapter | null;
+  readonly isNoop: boolean;
+  extract(carrier: TelemetryCarrier): TelemetryContext;
+  inject(context: TelemetryContext, carrier: MutableTelemetryCarrier): MutableTelemetryCarrier;
+}
+
+export function createTelemetryFacade(adapterId: string = DEFAULT_ADAPTER_ID): TelemetryFacade {
+  const adapter = getAdapter(adapterId) ?? null;
+
+  return {
+    adapter,
+    isNoop: adapter == null,
+    extract: (carrier) => {
+      if (adapter?.extract != null) {
+        return adapter.extract(carrier) ?? NOOP_TELEMETRY_CONTEXT;
+      }
+
+      return extractContext(carrier);
+    },
+    inject: (context, carrier) => {
+      if (adapter?.inject != null) {
+        adapter.inject(context, carrier);
+        return carrier;
+      }
+
+      return injectContext(context, carrier);
+    }
+  };
+}

--- a/packages/otel/src/index.ts
+++ b/packages/otel/src/index.ts
@@ -1,0 +1,5 @@
+export * from './types';
+export * from './adapterRegistry';
+export * from './contextPropagation';
+export * from './facade';
+export * from './semconv';

--- a/packages/otel/src/semconv.ts
+++ b/packages/otel/src/semconv.ts
@@ -1,0 +1,19 @@
+export const RUNTIME_TELEMETRY_KIND_PREFIX = 'redemeine.runtime';
+
+export const RUNTIME_TELEMETRY_SEMANTIC_CONVENTIONS = {
+  serviceName: 'service.name',
+  sagaId: 'redemeine.saga.id',
+  sagaType: 'redemeine.saga.type',
+  intentId: 'redemeine.intent.id',
+  executionId: 'redemeine.execution.id',
+  activityId: 'redemeine.activity.id',
+  triggerKey: 'redemeine.trigger.key',
+  correlationId: 'redemeine.correlation.id',
+  causationId: 'redemeine.causation.id',
+  tenantId: 'redemeine.tenant.id',
+  sequence: 'redemeine.sequence',
+  telemetryKind: 'redemeine.telemetry.kind',
+  telemetryLevel: 'redemeine.telemetry.level'
+} as const;
+
+export type RuntimeTelemetrySemanticConventionKey = keyof typeof RUNTIME_TELEMETRY_SEMANTIC_CONVENTIONS;

--- a/packages/otel/src/types.ts
+++ b/packages/otel/src/types.ts
@@ -1,0 +1,25 @@
+export type TelemetryPrimitive = string | number | boolean;
+
+export type TelemetryAttributeValue =
+  | TelemetryPrimitive
+  | null
+  | undefined
+  | ReadonlyArray<TelemetryPrimitive>;
+
+export type TelemetryAttributes = Record<string, TelemetryAttributeValue>;
+
+export interface TelemetryCarrier {
+  readonly [key: string]: string | undefined;
+}
+
+export type MutableTelemetryCarrier = Record<string, string>;
+
+export interface TelemetryContext {
+  readonly values?: Readonly<Record<string, unknown>>;
+}
+
+export interface TelemetryAdapter {
+  readonly id: string;
+  extract?(carrier: TelemetryCarrier): TelemetryContext | null;
+  inject?(context: TelemetryContext, carrier: MutableTelemetryCarrier): void;
+}

--- a/packages/otel/test/contextPropagation.test.ts
+++ b/packages/otel/test/contextPropagation.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import {
+  NOOP_TELEMETRY_CONTEXT,
+  clearAdapters,
+  extractContext,
+  injectContext,
+  registerAdapter,
+  unregisterAdapter
+} from '../src';
+
+describe('context propagation helpers', () => {
+  beforeEach(() => {
+    clearAdapters();
+  });
+
+  it('returns NOOP context when no adapter extracts', () => {
+    const context = extractContext({ traceparent: '00-abc-def-01' });
+
+    expect(context).toBe(NOOP_TELEMETRY_CONTEXT);
+    expect(context.values).toEqual({});
+  });
+
+  it('extracts from first adapter returning context', () => {
+    registerAdapter({ id: 'first', extract: () => null });
+    registerAdapter({ id: 'second', extract: () => ({ values: { spanId: 'span-123' } }) });
+
+    const context = extractContext({});
+
+    expect(context.values?.spanId).toBe('span-123');
+  });
+
+  it('injects context through all registered adapters', () => {
+    registerAdapter({
+      id: 'a',
+      inject: (_context, carrier) => {
+        carrier.a = '1';
+      }
+    });
+    registerAdapter({
+      id: 'b',
+      inject: (_context, carrier) => {
+        carrier.b = '2';
+      }
+    });
+
+    const carrier = injectContext({ values: { traceId: 'trace-1' } }, {});
+
+    expect(carrier).toEqual({ a: '1', b: '2' });
+  });
+
+  it('supports unregistering adapters', () => {
+    registerAdapter({ id: 'temp', inject: (_context, carrier) => (carrier.temp = 'on') });
+    unregisterAdapter('temp');
+
+    const carrier = injectContext({ values: {} }, {});
+
+    expect(carrier).toEqual({});
+  });
+});

--- a/packages/otel/test/facade.test.ts
+++ b/packages/otel/test/facade.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import {
+  clearAdapters,
+  createTelemetryFacade,
+  registerAdapter,
+  type TelemetryContext
+} from '../src';
+
+describe('telemetry facade', () => {
+  beforeEach(() => {
+    clearAdapters();
+  });
+
+  it('is no-op safe when no adapter is registered', () => {
+    const facade = createTelemetryFacade();
+    const extracted = facade.extract({ traceparent: 'ignored' });
+    const carrier = facade.inject(extracted, {});
+
+    expect(facade.isNoop).toBe(true);
+    expect(extracted.values).toEqual({});
+    expect(carrier).toEqual({});
+  });
+
+  it('uses explicitly selected adapter when registered', () => {
+    registerAdapter({
+      id: 'default',
+      extract: (carrier) => ({ values: { traceparent: carrier.traceparent } }),
+      inject: (context, carrier) => {
+        const traceparent = context.values?.traceparent;
+        if (typeof traceparent === 'string') {
+          carrier.traceparent = traceparent;
+        }
+      }
+    });
+
+    const facade = createTelemetryFacade('default');
+    const extracted = facade.extract({ traceparent: '00-abc-xyz-01' });
+    const injected = facade.inject(extracted, {});
+
+    expect(facade.isNoop).toBe(false);
+    expect(extracted.values?.traceparent).toBe('00-abc-xyz-01');
+    expect(injected.traceparent).toBe('00-abc-xyz-01');
+  });
+
+  it('falls back to registry-wide extraction/injection when selected adapter missing hooks', () => {
+    registerAdapter({ id: 'default' });
+    registerAdapter({
+      id: 'secondary',
+      extract: () => ({ values: { source: 'secondary' } }),
+      inject: (_context, carrier) => {
+        carrier.source = 'secondary';
+      }
+    });
+
+    const facade = createTelemetryFacade('default');
+    const context = facade.extract({});
+    const carrier = facade.inject(context as TelemetryContext, {});
+
+    expect(context.values?.source).toBe('secondary');
+    expect(carrier.source).toBe('secondary');
+  });
+});

--- a/packages/otel/tsconfig.json
+++ b/packages/otel/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "moduleResolution": "node"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
﻿## Summary

Cherry-picks the safe, non-conflicting work from PR #27 (feature/redemeine-hwj epic) after the PR #41 mirage/projection refactor made the implementation commits incompatible with main.

## What's Included

### Architecture Documents (17)
- CI hardening waves 1-3 (GitHub Actions policy, governance, branch protection, release integrity)
- CI security hardening parent blueprint + dependency vulnerability automation
- PR gate blueprint
- Telemetry SPI design + OTel implementation design
- Canonical inspection hooks contract v1
- Transactional outbox RFC for Tapeworm boundary
- Aggregate vs saga intent contract v1
- AggregateIntent plugin capability boundaries
- Tapeworm durable commit-feed ULID cursor contract
- CDC relay MQ inbox durability semantics
- Projection service over MQ commit feed
- Production hardening roadmap delivery DAG
- Observability verification evidence (redemeine-vx5)

### New Package: @redemeine/otel
- No-op-safe telemetry facade core
- Adapter registry, context propagation, semantic conventions
- Tests for facade and context propagation

### Abandoned Work Documentation
- hwj-abandoned-implementation-notes.md records what was left behind and provides reimplementation guidance against the post-PR-41 API surface.

## What Was NOT Included (conflicts with PR #41 refactor)

- Transactional outbox persistence seam in Depot.ts
- Outbox dispatcher worker lifecycle
- Canonical inspection hook emission wiring
- OTel cross-runtime integration bridge tests
- Audit reliability evidence tests

See docs/architecture/hwj-abandoned-implementation-notes.md for full details.

## Impact on Existing Code

None. All changes are additive (new docs, new package). No existing files modified except bun.lock.

## Related

- Supersedes implementation portions of PR #27 (draft remains open for reference)
- Depends on PR #41 being merged (done)
