### PR TITLE
feat(aggregate): unmatched event handler + command payload validation (#63, #75)

### DIFF
--- a/packages/aggregate/src/applyEvent.ts
+++ b/packages/aggregate/src/applyEvent.ts
@@ -1,6 +1,7 @@
 import { produce, type Draft } from 'immer';
 import type { Event } from '@redemeine/kernel';
 import type { AnyFunction } from './redemeineComponent';
+import type { UnmatchedEventHandler } from './createAggregate';
 import { toCamelCase, singular, parseTargetedEventPath, formatFlatEventType } from './naming';
 
 /**
@@ -77,7 +78,8 @@ export function applyEventToDraft<S>(
     allEventOverrides: Record<string, string>,
     projectorByEventType: Record<string, AnyFunction> = {},
     scopedProjectorByEventType: Record<string, AnyFunction> = {},
-    scopedEventProjectors: Record<string, AnyFunction> = {}
+    scopedEventProjectors: Record<string, AnyFunction> = {},
+    unmatchedEventHandler?: UnmatchedEventHandler
 ): void {
     // SAFETY: `any` required — targetDraft narrows to sub-entities during path traversal, losing the Draft<S> type
     let targetDraft: any = draft;
@@ -136,8 +138,12 @@ export function applyEventToDraft<S>(
         if (projector) {
             projector(targetDraft, event);
         }
-    } else if (process.env.NODE_ENV !== 'production') {
-        console.warn(`[redemeine] Event "${event.type}" has no projector on aggregate "${aggregateName}" — event was silently dropped`);
+    } else {
+        if (unmatchedEventHandler) {
+            unmatchedEventHandler(event.type, aggregateName);
+        } else {
+            console.warn(`[redemeine] Event "${event.type}" has no projector on aggregate "${aggregateName}" — event was silently dropped`);
+        }
     }
 }
 
@@ -149,9 +155,10 @@ export function applyEvent<S>(
     allEventOverrides: Record<string, string>,
     projectorByEventType: Record<string, AnyFunction> = {},
     scopedProjectorByEventType: Record<string, AnyFunction> = {},
-    scopedEventProjectors: Record<string, AnyFunction> = {}
+    scopedEventProjectors: Record<string, AnyFunction> = {},
+    unmatchedEventHandler?: UnmatchedEventHandler
 ): S {
     return produce(state, (draft: Draft<S>) => {
-        applyEventToDraft(aggregateName, draft, event, allEvents, allEventOverrides, projectorByEventType, scopedProjectorByEventType, scopedEventProjectors);
+        applyEventToDraft(aggregateName, draft, event, allEvents, allEventOverrides, projectorByEventType, scopedProjectorByEventType, scopedEventProjectors, unmatchedEventHandler);
     }) as S;
 }

--- a/packages/aggregate/src/buildAggregate.ts
+++ b/packages/aggregate/src/buildAggregate.ts
@@ -1,7 +1,8 @@
-import type { Event, NamingStrategy, AggregateHooks, RedemeinePlugin } from '@redemeine/kernel';
+import type { Event, NamingStrategy, AggregateHooks, RedemeinePlugin, Contract } from '@redemeine/kernel';
 import type { MountedEntityPackage, MountedStructureMetadata } from './types/entityMount';
 import type { AggregateMixinLike, AggregateSelectorsMap } from './types/aggregate';
 import type { GenericCommandFactory } from './redemeineComponent';
+import type { UnmatchedEventHandler } from './createAggregate';
 import { resolveCommandHandler } from './redemeineComponent';
 import { createCommandProcessor } from './createCommandProcessor';
 import { createEmitProxy } from './proxies/createEmitProxy';
@@ -29,6 +30,8 @@ export type BuildAggregateInput<S, TMeta> = {
     namingStrategy: NamingStrategy;
     hooks: AggregateHooks<S>;
     plugins: RedemeinePlugin<any>[];
+    unmatchedEventHandler?: UnmatchedEventHandler;
+    contract?: Contract;
 };
 
 /**
@@ -36,7 +39,7 @@ export type BuildAggregateInput<S, TMeta> = {
  * and assembles the final aggregate object.
  */
 export function buildAggregate<S, TMeta extends Record<string, unknown>>(input: BuildAggregateInput<S, TMeta>) {
-    const { aggregateName, initialState, snapshot, commandsFactory, mixins, entityPackages, namingStrategy, hooks, plugins } = input;
+    const { aggregateName, initialState, snapshot, commandsFactory, mixins, entityPackages, namingStrategy, hooks, plugins, unmatchedEventHandler, contract } = input;
 
     // 1. Resolve events from mixins
     const resolved = resolveEvents<S, TMeta>(snapshot, mixins, aggregateName, namingStrategy);
@@ -94,10 +97,10 @@ export function buildAggregate<S, TMeta extends Record<string, unknown>>(input: 
     return {
         aggregateType: aggregateName,
         initialState,
-        process: createCommandProcessor<S>(aggregateName, allCommandsMap as any, allCommandOverrides, commandHandlerByType),
-        apply: (state: S, event: Event): S => applyEvent(aggregateName, state, event, allEvents, allEventOverrides, projectorByEventTypeObj, scopedProjectorByEventType, scopedEventProjectors),
+        process: createCommandProcessor<S>(aggregateName, allCommandsMap as any, allCommandOverrides, commandHandlerByType, contract),
+        apply: (state: S, event: Event): S => applyEvent(aggregateName, state, event, allEvents, allEventOverrides, projectorByEventTypeObj, scopedProjectorByEventType, scopedEventProjectors, unmatchedEventHandler),
         applyToDraft: (draft: S, event: Event): void => {
-            applyEventToDraft(aggregateName, draft as Draft<S>, event, allEvents, allEventOverrides, projectorByEventTypeObj, scopedProjectorByEventType, scopedEventProjectors);
+            applyEventToDraft(aggregateName, draft as Draft<S>, event, allEvents, allEventOverrides, projectorByEventTypeObj, scopedProjectorByEventType, scopedEventProjectors, unmatchedEventHandler);
         },
         commandCreators: createCommandCreatorsProxy(aggregateName, allCommandsMap as any, allCommandOverrides, namingStrategy),
         eventCreators: emit,

--- a/packages/aggregate/src/createAggregate.ts
+++ b/packages/aggregate/src/createAggregate.ts
@@ -1,4 +1,4 @@
-import type { NamingStrategy, AggregateHooks, PluginExtensions, RedemeinePlugin } from '@redemeine/kernel';
+import type { NamingStrategy, AggregateHooks, PluginExtensions, RedemeinePlugin, Contract } from '@redemeine/kernel';
 import type { EntityPackage } from './createEntity';
 import type { RedemeineEventDefinition, GenericCommandFactory } from './redemeineComponent';
 import { createComponentBehaviorState, bindFluentMethods } from './redemeineComponent';
@@ -35,6 +35,8 @@ export type { AggregateBuilder } from './types/aggregate';
  *     }
  *   }))
  */
+export type UnmatchedEventHandler = (eventType: string, aggregateName: string) => void;
+
 export function createAggregate<S, Name extends string, TMeta extends Record<string, unknown> = Record<string, unknown>, TPlugins extends PluginExtensions = {}>(
     aggregateName: Name,
     initialState: S
@@ -48,6 +50,8 @@ export function createAggregate<S, Name extends string, TMeta extends Record<str
     let _hooks: AggregateHooks<S> = {};
     // SAFETY: `any` required — RedemeinePlugin generic param must satisfy PluginExtensions constraint
     let _plugins: RedemeinePlugin<any>[] = [];
+    let _unmatchedEventHandler: UnmatchedEventHandler | undefined;
+    let _contract: Contract | undefined;
 
     const builder = bindFluentMethods({}, {
         selectors: (selectorsOrFactory: AggregateSelectorsMap<S> | ((utils: AggregateSelectorUtils) => AggregateSelectorsMap<S>)) => {
@@ -154,6 +158,16 @@ export function createAggregate<S, Name extends string, TMeta extends Record<str
             return builder;
         },
 
+        onUnmatchedEvent: (handler: UnmatchedEventHandler) => {
+            _unmatchedEventHandler = handler;
+            return builder;
+        },
+
+        contract: (contract: Contract) => {
+            _contract = contract;
+            return builder;
+        },
+
         get _state() {
             const snapshot = component.getSnapshot();
             return {
@@ -180,7 +194,9 @@ export function createAggregate<S, Name extends string, TMeta extends Record<str
                 entityPackages: _entityPackages,
                 namingStrategy: _namingStrategy,
                 hooks: _hooks,
-                plugins: _plugins
+                plugins: _plugins,
+                ...(_unmatchedEventHandler ? { unmatchedEventHandler: _unmatchedEventHandler } : {}),
+                ...(_contract ? { contract: _contract } : {})
             });
         }
     });

--- a/packages/aggregate/src/createCommandProcessor.ts
+++ b/packages/aggregate/src/createCommandProcessor.ts
@@ -1,4 +1,4 @@
-import { type Event, type Command, type CommandResult, type EventCommandLink, type EnvelopeHeaders, type PluginExtensions, type PluginIntents, type ReadonlyDeep, createReadonlyDeepProxy, createIdentity } from '@redemeine/kernel';
+import { type Event, type Command, type CommandResult, type EventCommandLink, type EnvelopeHeaders, type PluginExtensions, type PluginIntents, type ReadonlyDeep, createReadonlyDeepProxy, createIdentity, type Contract, ContractError } from '@redemeine/kernel';
 import type { GenericCommandMap } from './redemeineComponent';
 import { resolveCommandHandler } from './redemeineComponent';
 import { formatCommandType } from './naming';
@@ -85,7 +85,8 @@ export function createCommandProcessor<S>(
     aggregateName: string,
     allCommandsMap: GenericCommandMap,
     allCommandOverrides: Record<string, string>,
-    commandHandlerByType?: Record<string, CommandHandler<S>>
+    commandHandlerByType?: Record<string, CommandHandler<S>>,
+    contract?: Contract
 ) {
     const handlerByType: Record<string, CommandHandler<S>> = commandHandlerByType || Object.keys(allCommandsMap).reduce((acc, key) => {
         const commandType = allCommandOverrides[key] || formatCommandType(aggregateName, key);
@@ -99,6 +100,18 @@ export function createCommandProcessor<S>(
         const payload = commandWithId.payload;
         const handler = handlerByType[commandType];
         if (!handler) throw new Error('Unknown command: ' + commandType);
+
+        if (contract) {
+            const schema = contract.getCommand(commandType);
+            if (schema) {
+                const result = schema.safeParse(payload);
+                if (!result.success) {
+                    throw new ContractError(
+                        `Command "${commandType}" payload failed validation: ${result.error.message}`
+                    );
+                }
+            }
+        }
         
         const readonlyState = createReadonlyDeepProxy(state);
         const result = handler(readonlyState as ReadonlyDeep<S>, payload);

--- a/packages/aggregate/src/types/aggregate.ts
+++ b/packages/aggregate/src/types/aggregate.ts
@@ -1,4 +1,4 @@
-import type { Event, Command, EventType, CommandType, NamingStrategy, AggregateHooks, PluginContext, PluginExtensions, CommandContext, CommandIntents, MergePluginExtensions, RedemeinePlugin, ReadonlyDeep } from '@redemeine/kernel';
+import type { Event, Command, EventType, CommandType, NamingStrategy, AggregateHooks, PluginContext, PluginExtensions, CommandContext, CommandIntents, MergePluginExtensions, RedemeinePlugin, ReadonlyDeep, Contract } from '@redemeine/kernel';
 import type { EntityPackage } from '../createEntity';
 import type { GenericCommandFactory, AnyFunction } from '../redemeineComponent';
 import type { Merge } from './Merge';
@@ -170,6 +170,10 @@ export interface AggregateBuilder<S, Name extends string, M = {}, E = {}, EOverr
         AggregateBuilder<S, Name, M, E, EOverrides, Sel, Registry, TMeta, TPlugins>;
 
     hooks: (hooks: AggregateHooks<S>) => AggregateBuilder<S, Name, M, E, EOverrides, Sel, Registry, TMeta, TPlugins>;
+
+    onUnmatchedEvent: (handler: (eventType: string, aggregateName: string) => void) => AggregateBuilder<S, Name, M, E, EOverrides, Sel, Registry, TMeta, TPlugins>;
+
+    contract: (contract: Contract) => AggregateBuilder<S, Name, M, E, EOverrides, Sel, Registry, TMeta, TPlugins>;
 
     build: () => {
         aggregateType: Name;

--- a/packages/aggregate/test/commandPayloadValidation.test.ts
+++ b/packages/aggregate/test/commandPayloadValidation.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test, afterEach } from '@jest/globals';
+import { createCommandProcessor } from '../src/createCommandProcessor';
+import { Contract, ContractError, resetIdentityFactory } from '@redemeine/kernel';
+import { z } from 'zod';
+
+describe('command payload validation with Contract', () => {
+    afterEach(() => {
+        resetIdentityFactory();
+    });
+
+    test('throws ContractError when payload fails schema validation', () => {
+        const contract = new Contract();
+        contract.addCommand('myAggregate.do_something.command', z.object({
+            name: z.string(),
+            age: z.number()
+        }));
+
+        const mockMap = {
+            doSomething: (state: any, payload: any) => {
+                return { type: 'something.done.event', payload };
+            }
+        };
+
+        const processor = createCommandProcessor<{ val: number }>(
+            'myAggregate',
+            mockMap,
+            {},
+            undefined,
+            contract
+        );
+
+        expect(() => {
+            processor({ val: 10 }, { type: 'myAggregate.do_something.command', payload: { name: 123, age: 'wrong' } });
+        }).toThrow(ContractError);
+    });
+
+    test('passes through when payload matches schema', () => {
+        const contract = new Contract();
+        contract.addCommand('myAggregate.do_something.command', z.object({
+            name: z.string(),
+            age: z.number()
+        }));
+
+        const mockMap = {
+            doSomething: (state: any, payload: any) => {
+                return { type: 'something.done.event', payload };
+            }
+        };
+
+        const processor = createCommandProcessor<{ val: number }>(
+            'myAggregate',
+            mockMap,
+            {},
+            undefined,
+            contract
+        );
+
+        const result = processor({ val: 10 }, {
+            type: 'myAggregate.do_something.command',
+            payload: { name: 'Alice', age: 30 }
+        });
+
+        expect(result[0].type).toBe('something.done.event');
+        expect(result[0].payload).toEqual({ name: 'Alice', age: 30 });
+    });
+
+    test('skips validation when no schema exists for command type', () => {
+        const contract = new Contract();
+        // No schema added for this command
+
+        const mockMap = {
+            doSomething: (state: any, payload: any) => {
+                return { type: 'something.done.event', payload };
+            }
+        };
+
+        const processor = createCommandProcessor<{ val: number }>(
+            'myAggregate',
+            mockMap,
+            {},
+            undefined,
+            contract
+        );
+
+        const result = processor({ val: 10 }, {
+            type: 'myAggregate.do_something.command',
+            payload: { anything: 'goes' }
+        });
+
+        expect(result[0].type).toBe('something.done.event');
+    });
+
+    test('skips validation when no contract provided', () => {
+        const mockMap = {
+            doSomething: (state: any, payload: any) => {
+                return { type: 'something.done.event', payload };
+            }
+        };
+
+        const processor = createCommandProcessor<{ val: number }>(
+            'myAggregate',
+            mockMap,
+            {}
+        );
+
+        const result = processor({ val: 10 }, {
+            type: 'myAggregate.do_something.command',
+            payload: { anything: 'goes' }
+        });
+
+        expect(result[0].type).toBe('something.done.event');
+    });
+
+    test('error message includes command type and validation details', () => {
+        const contract = new Contract();
+        contract.addCommand('myAggregate.do_something.command', z.object({
+            name: z.string()
+        }));
+
+        const mockMap = {
+            doSomething: (state: any, payload: any) => {
+                return { type: 'something.done.event', payload };
+            }
+        };
+
+        const processor = createCommandProcessor<{ val: number }>(
+            'myAggregate',
+            mockMap,
+            {},
+            undefined,
+            contract
+        );
+
+        expect(() => {
+            processor({ val: 10 }, {
+                type: 'myAggregate.do_something.command',
+                payload: { name: 42 }
+            });
+        }).toThrow(/Command "myAggregate\.do_something\.command" payload failed validation/);
+    });
+});

--- a/packages/aggregate/test/unmatchedEvent.test.ts
+++ b/packages/aggregate/test/unmatchedEvent.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test, jest } from '@jest/globals';
+import { createAggregate } from '@redemeine/aggregate';
+import { Event } from '@redemeine/kernel';
+
+interface TestState {
+    count: number;
+}
+
+const initialState: TestState = { count: 0 };
+
+describe('onUnmatchedEvent', () => {
+    test('calls custom handler when event has no projector', () => {
+        const handler = jest.fn();
+
+        const aggregate = createAggregate('Counter', initialState)
+            .events({
+                incremented: (state, event: Event<{ amount: number }>) => {
+                    state.count += event.payload.amount;
+                }
+            })
+            .onUnmatchedEvent(handler)
+            .build();
+
+        const unknownEvent: Event = { type: 'counter.unknown.event', payload: {} };
+        aggregate.apply(initialState, unknownEvent);
+
+        expect(handler).toHaveBeenCalledWith('counter.unknown.event', 'Counter');
+    });
+
+    test('uses default console.warn when no handler provided', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const aggregate = createAggregate('Counter', initialState)
+            .events({
+                incremented: (state, event: Event<{ amount: number }>) => {
+                    state.count += event.payload.amount;
+                }
+            })
+            .build();
+
+        const unknownEvent: Event = { type: 'counter.unknown.event', payload: {} };
+        aggregate.apply(initialState, unknownEvent);
+
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining('counter.unknown.event')
+        );
+        warnSpy.mockRestore();
+    });
+
+    test('does not call handler when event matches a projector', () => {
+        const handler = jest.fn();
+
+        const aggregate = createAggregate('Counter', initialState)
+            .events({
+                incremented: (state, event: Event<{ amount: number }>) => {
+                    state.count += event.payload.amount;
+                }
+            })
+            .onUnmatchedEvent(handler)
+            .build();
+
+        const validEvent: Event = { type: 'Counter.incremented.event', payload: { amount: 5 } };
+        const newState = aggregate.apply(initialState, validEvent);
+
+        expect(handler).not.toHaveBeenCalled();
+        expect(newState.count).toBe(5);
+    });
+});


### PR DESCRIPTION
## Summary

Resolves #63, #75. Two behavioral improvements to the aggregate package.

### 1. Configurable unmatched event handler (#63)

```typescript
createAggregate('Order')
  .onUnmatchedEvent((eventType, aggregateName) => {
    metrics.increment('unmatched_event', { eventType, aggregateName });
  })
  .build();
```

- **Default**: `console.warn` in all environments (previously silent in prod)
- **Custom**: user-provided callback replaces the default
- **Non-breaking**: existing code gets a new warning where previously events vanished

### 2. Command payload validation (#75)

When a Contract with schemas is provided, command payloads are validated before handler execution:

```typescript
createAggregate('Order')
  .contract(orderContract)  // Contract with command schemas
  .build();

// Now throws ContractError if payload doesn't match schema
```

- **Silent breaking change**: malformed payloads that previously passed silently now throw
- **Opt-in**: only validates if a Contract is provided (schemaless commands pass through)
- **Error format**: `ContractError: Command "type" payload validation failed: details`

### New Tests
- 3 tests for unmatched event handler behavior
- 5 tests for command payload validation

### Verification
- ✅ `bun run typecheck` — 22/22 pass
- ✅ `bun test packages/aggregate` — 35 pass, 3 pre-existing failures (mirage dep)
- ✅ 8 new tests covering both features

### PR Checklist
- [x] Correctness validated
- [x] Tests added proportional to risk
- [x] Files under 400 lines
- [x] Functions under 50 lines
- [x] No unintended scope expansion