### PR TITLE
chore(saga): prepare prerelease package metadata

### DIFF
--- a/.changeset/quiet-wolves-smile.md
+++ b/.changeset/quiet-wolves-smile.md
@@ -1,5 +1,6 @@
 ---
+"@redemeine/aggregate": patch
 "@redemeine/saga": patch
 ---
 
-Prepare @redemeine/saga for prerelease publishing by generating declaration files and publishing package metadata.
+Prepare @redemeine/aggregate and @redemeine/saga for prerelease publishing by using npm-compatible prerelease dependency metadata and generating saga declaration files.

--- a/.changeset/quiet-wolves-smile.md
+++ b/.changeset/quiet-wolves-smile.md
@@ -1,0 +1,5 @@
+---
+"@redemeine/saga": patch
+---
+
+Prepare @redemeine/saga for prerelease publishing by generating declaration files and publishing package metadata.

--- a/packages/aggregate/package.json
+++ b/packages/aggregate/package.json
@@ -38,7 +38,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@redemeine/kernel": "workspace:*"
+    "@redemeine/kernel": "0.2.0-pre.0"
   },
   "devDependencies": {
     "tsup": "^8.4.0",

--- a/packages/saga/package.json
+++ b/packages/saga/package.json
@@ -22,6 +22,7 @@
     "orchestration"
   ],
   "type": "module",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -41,7 +42,9 @@
     "test": "bun test ./test",
     "lint": "tsc --noEmit"
   },
-  "private": true,
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@redemeine/aggregate": "workspace:*",
     "immer": "^10.1.1"

--- a/packages/saga/package.json
+++ b/packages/saga/package.json
@@ -46,7 +46,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@redemeine/aggregate": "workspace:*",
+    "@redemeine/aggregate": "0.2.0-pre.0",
     "immer": "^10.1.1"
   },
   "devDependencies": {

--- a/packages/saga/tsconfig.json
+++ b/packages/saga/tsconfig.json
@@ -5,7 +5,8 @@
     "exactOptionalPropertyTypes": false,
     "noUncheckedIndexedAccess": false,
     "paths": {
-      "@redemeine/aggregate": ["../aggregate/src/index.ts"]
+      "@redemeine/aggregate": ["../aggregate/src/index.ts"],
+      "@redemeine/kernel": ["../kernel/src/index.ts"]
     }
   },
   "include": ["src"]

--- a/packages/saga/tsup.config.ts
+++ b/packages/saga/tsup.config.ts
@@ -4,5 +4,5 @@ import { baseConfig } from '../../tsup.config.base'
 export default defineConfig({
   ...baseConfig,
   entry: ['src/index.ts', 'src/aggregateBridge.ts'],
-  dts: false,
+  dts: true,
 })

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -3,10 +3,13 @@
   "compilerOptions": {
     "noEmit": true,
     "paths": {
+      "@redemeine/aggregate": ["../aggregate/src/index.ts"],
+      "@redemeine/kernel": ["../kernel/src/index.ts"],
       "@redemeine/mirage": ["../mirage/src/index.ts"],
       "@redemeine/projection": ["../projection/src/index.ts"],
       "@redemeine/projection-runtime-core": ["../projection-runtime-core/src/index.ts"],
-      "@redemeine/projection-runtime-store-inmemory": ["../projection-runtime-store-inmemory/src/index.ts"]
+      "@redemeine/projection-runtime-store-inmemory": ["../projection-runtime-store-inmemory/src/index.ts"],
+      "@redemeine/saga": ["../saga/src/index.ts"]
     }
   },
   "include": ["src"]


### PR DESCRIPTION
## Summary

Prepares @redemeine/saga for prerelease packaging under Bead redemeine-4ny.

### Changes
- Enable DTS generation for @redemeine/saga: dist/index.d.ts and dist/aggregateBridge.d.ts.
- Make saga package metadata publishable: remove private true, add top-level types, add publishConfig access public.
- Replace publish-facing workspace dependencies in the saga dependency chain:
  - @redemeine/saga depends on @redemeine/aggregate 0.2.0-pre.0
  - @redemeine/aggregate depends on @redemeine/kernel 0.2.0-pre.0
- Add missing TS workspace paths needed by saga/testing validation.
- Add changeset for @redemeine/saga and @redemeine/aggregate patch prereleases.

### Validation
- bun run --cwd packages/saga typecheck: pass
- bun run --cwd packages/saga build: pass
- bun run --cwd packages/saga test: pass, 69 pass / 0 fail
- bun run --cwd packages/saga-runtime typecheck: pass
- bun run --cwd packages/saga-runtime build: pass
- bun run --cwd packages/saga-runtime test: pass, 51 pass / 0 fail
- bun run --cwd packages/testing typecheck: pass
- bun run --cwd packages/testing build: pass
- bun run --cwd packages/testing test: pass, 17 pass / 0 fail
- npm pack --json ./packages/aggregate --pack-destination /tmp/opencode: pass
- npm pack --json ./packages/saga --pack-destination /tmp/opencode: pass
- Packed manifests contain no workspace dependencies: pass
- Local kernel to aggregate to saga tarball chain install/import succeeds: pass

### Release sequencing note
Local tarball-chain validation requires kernel to be built before packing. Release order should be:
1. kernel already published/fixed at 0.2.0-pre.0
2. aggregate fixed prerelease
3. saga prerelease

### Non-goals
- No npm publish performed.
- No createSaga.ts refactor in this lane; the large file remains a known follow-up quality item.
- No public API surface reduction.

Bead: redemeine-4ny