### PR TITLE
fix(saga-runtime): use static saga ESM imports

### DIFF
--- a/packages/saga-runtime/src/index.ts
+++ b/packages/saga-runtime/src/index.ts
@@ -1,9 +1,4 @@
-declare const require: (id: string) => any;
-
-const sagaPackage = require('@redemeine/saga');
-
-export const createSagaDispatchContext = sagaPackage.createSagaDispatchContext as any;
-export const runSagaHandler = sagaPackage.runSagaHandler as any;
+export { createSagaDispatchContext, runSagaHandler } from '@redemeine/saga';
 export * from './createSagaAggregate';
 export * from './sagaExecutionBridge';
 export * from './inboundRouter';

--- a/packages/saga-runtime/src/sagaExecutionBridge.ts
+++ b/packages/saga-runtime/src/sagaExecutionBridge.ts
@@ -1,18 +1,12 @@
-declare const require: (id: string) => any;
-
-const sagaPackage = require('@redemeine/saga');
-const runSagaHandler = sagaPackage.runSagaHandler as (
-  state: unknown,
-  event: unknown,
-  handler: (...args: unknown[]) => unknown,
-  metadata: SagaIntentMetadata,
-  responseHandlers?: SagaResponseHandlerTokenBindings,
-  plugins?: readonly unknown[]
-) => Promise<{ state: unknown; intents: SagaIntent[] }>;
+import {
+  runSagaHandler as runImportedSagaHandler,
+  type SagaIntent,
+  type SagaIntentMetadata,
+  type SagaResponseHandlerTokenBindings as ImportedSagaResponseHandlerTokenBindings
+} from '@redemeine/saga';
 import {
   createReferenceAdaptersV1,
   runReferenceAdapterFlowV1,
-  type SagaIntent as RuntimeSagaIntent,
   type SagaRuntimeReferenceAdapters,
   type SagaRuntimeReferenceFlowResult,
   type SagaSchedulerTriggerPolicyContract
@@ -25,15 +19,23 @@ import {
 } from './SagaAggregate';
 import { toCamelCase } from '@redemeine/aggregate';
 
-interface SagaIntentMetadata {
-  readonly sagaId: string;
-  readonly correlationId: string;
-  readonly causationId: string;
-}
-
-type SagaIntent = RuntimeSagaIntent;
-
 export type SagaResponseHandlerTokenBindings = Record<string, { phase: 'response' | 'error' | 'retry' }>;
+
+const runSagaBridgeHandler = (
+  state: unknown,
+  event: unknown,
+  handler: unknown,
+  metadata: SagaIntentMetadata,
+  responseHandlers?: ImportedSagaResponseHandlerTokenBindings,
+  plugins?: readonly unknown[]
+): Promise<{ state: unknown; intents: SagaIntent[] }> => runImportedSagaHandler(
+  state,
+  event as never,
+  handler as never,
+  metadata,
+  responseHandlers,
+  plugins as never
+) as Promise<{ state: unknown; intents: SagaIntent[] }>;
 
 export interface SagaDefinitionLike<TState> {
   readonly sagaType: string;
@@ -314,10 +316,10 @@ export function createSagaExecutionBridge<TState>(
       let state = getSagaState(input.sagaId) ?? options.definition.initialState();
 
       for (const match of matches) {
-        const output = await runSagaHandler(
+        const output = await runSagaBridgeHandler(
           state,
-          input.event as any,
-          match.handler as any,
+          input.event,
+          match.handler,
           metadata,
           tokenBindings,
           options.runtimePlugins ?? []

--- a/packages/saga-runtime/test/dist-import-smoke.test.ts
+++ b/packages/saga-runtime/test/dist-import-smoke.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'bun:test';
+
+test('built saga package is ESM importable', async () => {
+  const saga = await import('../../saga/dist/index.js');
+
+  expect(typeof saga.runSagaHandler).toBe('function');
+});
+
+test('built saga-runtime package is ESM importable', async () => {
+  const sagaRuntime = await import('../dist/index.js');
+
+  expect(typeof sagaRuntime.createSagaAggregate).toBe('function');
+  expect(typeof sagaRuntime.createSagaDispatchContext).toBe('function');
+  expect(typeof sagaRuntime.runSagaHandler).toBe('function');
+});

--- a/packages/saga/src/index.ts
+++ b/packages/saga/src/index.ts
@@ -1,6 +1,7 @@
 export {
   createSaga,
   createSagaCommandsFor,
+  createSagaDispatchContext,
   defineCustomAction,
   defineOneWay,
   defineRequestResponse,
@@ -186,4 +187,3 @@ export {
   type RetryableErrorClassificationOptions,
   type RetrySchedulingNow
 } from './RetryPolicy';
-


### PR DESCRIPTION
## Summary

Fixes Bead redemeine-9vny by replacing saga-runtime dynamic require shims with static ESM imports and adding built-dist import smoke coverage.

This is a stacked PR on top of feature/saga-release-prep / PR #88.

### Changes
- Replace dynamic require of @redemeine/saga in @redemeine/saga-runtime with static typed ESM imports.
- Preserve saga-runtime public exports: createSagaDispatchContext and runSagaHandler remain available from @redemeine/saga-runtime.
- Add built dist smoke tests for @redemeine/saga and @redemeine/saga-runtime imports.
- Add additive @redemeine/saga export for createSagaDispatchContext so runtime can statically re-export it.

### Validation
- bun run --cwd packages/kernel build: pass
- bun run --cwd packages/aggregate build: pass
- bun run --cwd packages/saga build: pass
- bun run --cwd packages/saga-runtime typecheck: pass
- bun run --cwd packages/saga-runtime build: pass
- bun run --cwd packages/saga-runtime test: pass, 53 pass / 0 fail
- node ESM import of packages/saga-runtime/dist/index.js: pass
- bun run --cwd packages/testing typecheck: pass

### Compatibility
- No public exports removed or renamed.
- Dynamic require of @redemeine/saga is gone from saga-runtime source and dist.
- No new any shims introduced; static typed imports improve DX and ESM compatibility.

Bead: redemeine-9vny