### PR TITLE
refactor(saga): split handler execution internals

### DIFF
--- a/.changeset/red-sagas-split.md
+++ b/.changeset/red-sagas-split.md
@@ -1,0 +1,5 @@
+---
+"@redemeine/saga": patch
+---
+
+Refactor saga handler execution internals into focused modules without changing public API or runtime behavior.

--- a/packages/saga/src/createSaga.ts
+++ b/packages/saga/src/createSaga.ts
@@ -1,9 +1,43 @@
-import { createDraft, finishDraft, type Draft } from 'immer';
+import type { Draft } from 'immer';
 import {
   normalizeSagaIdentity,
   type SagaIdentityInput
 } from './identity';
 import type { SagaRetryPolicy } from './RetryPolicy';
+export {
+  runSagaErrorHandler,
+  runSagaHandler,
+  runSagaResponseHandler
+} from './handlerExecution';
+export type {
+  SagaErrorTokenKey,
+  SagaResponseHandlerPhase,
+  SagaResponseHandlerTokenAccess,
+  SagaResponseHandlerTokenBinding,
+  SagaResponseHandlerTokenBindings,
+  SagaResponseHandlerTokenNamespace,
+  SagaResponseTokenKey,
+  SagaRetryTokenKey,
+  TErrorToken,
+  TRetryToken,
+  TResponseToken
+} from './responseTokens';
+import type {
+  SagaBindingsFromErrorHandlers,
+  SagaBindingsFromResponseHandlers,
+  SagaBindingsFromRetryHandlers,
+  SagaErrorTokenKey,
+  SagaResponseHandlerPhase,
+  SagaResponseHandlerTokenAccess,
+  SagaResponseHandlerTokenBinding,
+  SagaResponseHandlerTokenBindings,
+  SagaResponseHandlerTokenNamespace,
+  SagaResponseTokenKey,
+  SagaRetryTokenKey,
+  TErrorToken,
+  TRetryToken,
+  TResponseToken
+} from './responseTokens';
 
 /** Factory used to initialize saga state for a new saga definition. */
 export type SagaInitialStateFactory<TState> = () => TState;
@@ -143,83 +177,6 @@ export type SagaPluginFireAndForgetActionNames<TPlugin extends SagaPluginManifes
 
 export type SagaPluginRequestResponseActionNames<TPlugin extends SagaPluginManifest> =
   SagaPluginActionNamesByInteraction<TPlugin, 'request_response'>;
-
-export type SagaResponseHandlerPhase = 'response' | 'error' | 'retry';
-
-declare const sagaResponseHandlerTokenBrand: unique symbol;
-
-type SagaPhaseToken<TToken extends string, TPhase extends SagaResponseHandlerPhase> = TToken & {
-  readonly [sagaResponseHandlerTokenBrand]: TPhase;
-};
-
-export type TResponseToken<TToken extends string = string> = SagaPhaseToken<TToken, 'response'>;
-
-export type TErrorToken<TToken extends string = string> = SagaPhaseToken<TToken, 'error'>;
-
-export type TRetryToken<TToken extends string = string> = SagaPhaseToken<TToken, 'retry'>;
-
-export interface SagaResponseHandlerTokenBinding<
-  TPhase extends SagaResponseHandlerPhase = SagaResponseHandlerPhase
-> {
-  readonly phase: TPhase;
-}
-
-export type SagaResponseHandlerTokenBindings = Record<string, SagaResponseHandlerTokenBinding>;
-
-export type SagaResponseTokenKey<TBindings extends SagaResponseHandlerTokenBindings> =
-  SagaResponseHandlerKeysByPhase<TBindings, 'response'>;
-
-export type SagaErrorTokenKey<TBindings extends SagaResponseHandlerTokenBindings> =
-  SagaResponseHandlerKeysByPhase<TBindings, 'error'>;
-
-export type SagaRetryTokenKey<TBindings extends SagaResponseHandlerTokenBindings> =
-  SagaResponseHandlerKeysByPhase<TBindings, 'retry'>;
-
-type SagaResponseHandlerTokenForPhase<
-  TToken extends string,
-  TPhase extends SagaResponseHandlerPhase
-> = TPhase extends 'response'
-  ? TResponseToken<TToken>
-  : TPhase extends 'error'
-    ? TErrorToken<TToken>
-    : TRetryToken<TToken>;
-
-type SagaResponseHandlerKeysByPhase<
-  TBindings extends SagaResponseHandlerTokenBindings,
-  TPhase extends SagaResponseHandlerPhase
-> = {
-  [THandlerKey in keyof TBindings & string]: TBindings[THandlerKey]['phase'] extends TPhase
-    ? THandlerKey
-    : never;
-}[keyof TBindings & string];
-
-export type SagaResponseHandlerTokenNamespace<
-  TBindings extends SagaResponseHandlerTokenBindings,
-  TPhase extends SagaResponseHandlerPhase
-> = {
-  readonly [THandlerKey in SagaResponseHandlerKeysByPhase<TBindings, TPhase>]: SagaResponseHandlerTokenForPhase<
-    THandlerKey,
-    TPhase
-  >;
-};
-
-export type SagaResponseHandlerTokenAccess<TBindings extends SagaResponseHandlerTokenBindings> = {
-  readonly onResponse: SagaResponseHandlerTokenNamespace<TBindings, 'response'>;
-  readonly onError: SagaResponseHandlerTokenNamespace<TBindings, 'error'>;
-  readonly onRetry: SagaResponseHandlerTokenNamespace<TBindings, 'retry'>;
-};
-
-type SagaBindingsFromResponseHandlers<THandlers extends Record<string, unknown>> = {
-  [TKey in keyof THandlers & string]: SagaResponseHandlerTokenBinding<'response'>;
-};
-
-type SagaBindingsFromErrorHandlers<THandlers extends Record<string, unknown>> = {
-  [TKey in keyof THandlers & string]: SagaResponseHandlerTokenBinding<'error'>;
-};
-
-type SagaBindingsFromRetryHandlers<THandlers extends Record<string, unknown>> = {
-  [TKey in keyof THandlers & string]: SagaResponseHandlerTokenBinding<'retry'>;
-};
 
 type SagaAnyResponseHandlerMap<TState, TPlugins extends SagaPluginManifestList> = Record<
   string,
@@ -1737,218 +1694,6 @@ function createSagaPluginRegistry<TPlugins extends SagaPluginManifestList>(
     action_names: Object.keys(plugin.actions),
     ...(plugin.version === undefined ? {} : { version: plugin.version })
   })) as SagaPluginRegistryFromManifests<TPlugins>;
-}
-
-function resolveIntentMetadata(
-  request: SagaExternalHandlerRequestContext,
-  override?: Partial<SagaIntentMetadata>
-): SagaIntentMetadata {
-  return {
-    sagaId: override?.sagaId ?? request.sagaId ?? 'unknown-saga-id',
-    correlationId: override?.correlationId ?? request.correlationId ?? 'unknown-correlation-id',
-    causationId: override?.causationId ?? request.causationId ?? 'unknown-causation-id'
-  };
-}
-
-function createTokenBindingsFromHandlerMaps<
-  TResponseHandlers extends Record<string, unknown>,
-  TErrorHandlers extends Record<string, unknown>,
-  TRetryHandlers extends Record<string, unknown>
->(
-  responseHandlers: TResponseHandlers,
-  errorHandlers: TErrorHandlers,
-  retryHandlers: TRetryHandlers
-): SagaBindingsFromResponseHandlers<TResponseHandlers>
-  & SagaBindingsFromErrorHandlers<TErrorHandlers>
-  & SagaBindingsFromRetryHandlers<TRetryHandlers> {
-  const bindings: Record<string, SagaResponseHandlerTokenBinding> = {};
-
-  for (const token of Object.keys(responseHandlers)) {
-    bindings[token] = { phase: 'response' };
-  }
-
-  for (const token of Object.keys(errorHandlers)) {
-    bindings[token] = { phase: 'error' };
-  }
-
-  for (const token of Object.keys(retryHandlers)) {
-    bindings[token] = { phase: 'retry' };
-  }
-
-  return bindings as SagaBindingsFromResponseHandlers<TResponseHandlers>
-    & SagaBindingsFromErrorHandlers<TErrorHandlers>
-    & SagaBindingsFromRetryHandlers<TRetryHandlers>;
-}
-
-function hasOwnToken(handlers: Record<string, unknown> | undefined, token: string): boolean {
-  if (handlers === undefined) {
-    return false;
-  }
-
-  return Object.prototype.hasOwnProperty.call(handlers, token);
-}
-
-/**
- * Executes a single saga handler with mutation-first semantics and produces
- * deterministic reducer output.
- */
-export async function runSagaHandler<
-  TState,
-  TAggregate extends SagaAggregateDefinition,
-  TEventName extends SagaAggregateEventName<TAggregate>,
-  TPlugins extends SagaPluginManifestList = readonly [],
-  TResponseHandlerBindings extends SagaResponseHandlerTokenBindings = Record<never, never>
->(
-  state: TState,
-  event: SagaAggregateEventByName<TAggregate, TEventName>,
-  handler: SagaHandler<TState, TAggregate, TEventName, TPlugins, TResponseHandlerBindings>,
-  metadata: SagaIntentMetadata,
-  responseHandlers: TResponseHandlerBindings = {} as TResponseHandlerBindings,
-  plugins: TPlugins = [] as unknown as TPlugins
-): Promise<SagaReducerOutput<TState>> {
-  const draft = createDraft(state as any);
-  const intentBuffer: SagaIntent[] = [];
-  const ctx = createSagaDispatchContext<TPlugins, TResponseHandlerBindings>(
-    metadata,
-    intentBuffer,
-    responseHandlers,
-    plugins
-  );
-
-  await handler(draft as Draft<TState>, event, ctx);
-
-  return {
-    state: finishDraft(draft) as TState,
-    intents: intentBuffer
-  };
-}
-
-export async function runSagaResponseHandler<
-  TState,
-  TPlugins extends SagaPluginManifestList = readonly [],
-  TResponseHandlerBindings extends SagaResponseHandlerTokenBindings = Record<never, never>,
-  TToken extends TResponseToken<SagaResponseTokenKey<TResponseHandlerBindings>> =
-    TResponseToken<SagaResponseTokenKey<TResponseHandlerBindings>>,
-  TPayload = unknown
->(
-  input: RunSagaResponseHandlerInput<TState, TPlugins, TResponseHandlerBindings, TToken, TPayload>
-): Promise<SagaExecutableHandlerResult<TState, TToken>> {
-  const {
-    definition,
-    state,
-    envelope,
-    intentMetadata,
-    plugins = [] as unknown as TPlugins
-  } = input;
-  const token = envelope.token;
-  if (!hasOwnToken(definition.responseHandlers as Record<string, unknown>, token)) {
-    return {
-      ok: false,
-      reason: 'token_not_defined',
-      token
-    };
-  }
-
-  const handler = (definition.responseHandlers as Record<
-    string,
-    SagaExecutableResponseHandler<TState, TPlugins, TResponseHandlerBindings, any> | undefined
-  >)[token];
-
-  if (handler === undefined) {
-    return {
-      ok: false,
-      reason: 'handler_not_registered',
-      token
-    };
-  }
-
-  const draft = createDraft(state as any);
-  const intents: SagaIntent[] = [];
-  const ctx = createSagaDispatchContext<TPlugins, TResponseHandlerBindings>(
-    resolveIntentMetadata(envelope.request, intentMetadata),
-    intents,
-    createTokenBindingsFromHandlerMaps(
-      definition.responseHandlers,
-      definition.errorHandlers,
-      definition.retryHandlers
-    ) as TResponseHandlerBindings,
-    plugins
-  );
-
-  await handler(draft as Draft<TState>, envelope as SagaResponseCallbackEnvelope<any, TPayload>, ctx);
-
-  return {
-    ok: true,
-    output: {
-      state: finishDraft(draft) as TState,
-      intents
-    },
-    token
-  };
-}
-
-export async function runSagaErrorHandler<
-  TState,
-  TPlugins extends SagaPluginManifestList = readonly [],
-  TResponseHandlerBindings extends SagaResponseHandlerTokenBindings = Record<never, never>,
-  TToken extends TErrorToken<SagaErrorTokenKey<TResponseHandlerBindings>> =
-    TErrorToken<SagaErrorTokenKey<TResponseHandlerBindings>>,
-  TError = unknown
->(
-  input: RunSagaErrorHandlerInput<TState, TPlugins, TResponseHandlerBindings, TToken, TError>
-): Promise<SagaExecutableHandlerResult<TState, TToken>> {
-  const {
-    definition,
-    state,
-    envelope,
-    intentMetadata,
-    plugins = [] as unknown as TPlugins
-  } = input;
-  const token = envelope.token;
-  if (!hasOwnToken(definition.errorHandlers as Record<string, unknown>, token)) {
-    return {
-      ok: false,
-      reason: 'token_not_defined',
-      token
-    };
-  }
-
-  const handler = (definition.errorHandlers as Record<
-    string,
-    SagaExecutableErrorHandler<TState, TPlugins, TResponseHandlerBindings, any> | undefined
-  >)[token];
-
-  if (handler === undefined) {
-    return {
-      ok: false,
-      reason: 'handler_not_registered',
-      token
-    };
-  }
-
-  const draft = createDraft(state as any);
-  const intents: SagaIntent[] = [];
-  const ctx = createSagaDispatchContext<TPlugins, TResponseHandlerBindings>(
-    resolveIntentMetadata(envelope.request, intentMetadata),
-    intents,
-    createTokenBindingsFromHandlerMaps(
-      definition.responseHandlers,
-      definition.errorHandlers,
-      definition.retryHandlers
-    ) as TResponseHandlerBindings,
-    plugins
-  );
-
-  await handler(draft as Draft<TState>, envelope as SagaErrorCallbackEnvelope<any, TError>, ctx);
-
-  return {
-    ok: true,
-    output: {
-      state: finishDraft(draft) as TState,
-      intents
-    },
-    token
-  };
 }
 
 function createSagaBuilder<

--- a/packages/saga/src/handlerExecution.ts
+++ b/packages/saga/src/handlerExecution.ts
@@ -1,0 +1,252 @@
+import { createDraft, finishDraft, type Draft } from 'immer';
+import { createSagaDispatchContext } from './createSaga';
+import type {
+  RunSagaErrorHandlerInput,
+  RunSagaResponseHandlerInput,
+  SagaAggregateDefinition,
+  SagaAggregateEventByName,
+  SagaAggregateEventName,
+  SagaErrorCallbackEnvelope,
+  SagaErrorTokenKey,
+  SagaExecutableErrorHandler,
+  SagaExecutableHandlerResult,
+  SagaExecutableResponseHandler,
+  SagaHandler,
+  SagaIntent,
+  SagaIntentMetadata,
+  SagaPluginManifestList,
+  SagaReducerOutput,
+  SagaResponseCallbackEnvelope,
+  SagaResponseTokenKey,
+  TErrorToken,
+  TResponseToken
+} from './createSaga';
+import type {
+  SagaBindingsFromErrorHandlers,
+  SagaBindingsFromResponseHandlers,
+  SagaBindingsFromRetryHandlers,
+  SagaResponseHandlerTokenBinding,
+  SagaResponseHandlerTokenBindings
+} from './responseTokens';
+
+function resolveIntentMetadata(
+  request: SagaResponseCallbackEnvelope['request'],
+  override?: Partial<SagaIntentMetadata>
+): SagaIntentMetadata {
+  return {
+    sagaId: override?.sagaId ?? request.sagaId ?? 'unknown-saga-id',
+    correlationId: override?.correlationId ?? request.correlationId ?? 'unknown-correlation-id',
+    causationId: override?.causationId ?? request.causationId ?? 'unknown-causation-id'
+  };
+}
+
+function createTokenBindingsFromHandlerMaps<
+  TResponseHandlers extends Record<string, unknown>,
+  TErrorHandlers extends Record<string, unknown>,
+  TRetryHandlers extends Record<string, unknown>
+>(
+  responseHandlers: TResponseHandlers,
+  errorHandlers: TErrorHandlers,
+  retryHandlers: TRetryHandlers
+): SagaBindingsFromResponseHandlers<TResponseHandlers>
+  & SagaBindingsFromErrorHandlers<TErrorHandlers>
+  & SagaBindingsFromRetryHandlers<TRetryHandlers> {
+  const bindings: Record<string, SagaResponseHandlerTokenBinding> = {};
+
+  for (const token of Object.keys(responseHandlers)) {
+    bindings[token] = { phase: 'response' };
+  }
+
+  for (const token of Object.keys(errorHandlers)) {
+    bindings[token] = { phase: 'error' };
+  }
+
+  for (const token of Object.keys(retryHandlers)) {
+    bindings[token] = { phase: 'retry' };
+  }
+
+  // SAFETY: The bindings are built from each handler map's own keys and fixed phase.
+  return bindings as SagaBindingsFromResponseHandlers<TResponseHandlers>
+    & SagaBindingsFromErrorHandlers<TErrorHandlers>
+    & SagaBindingsFromRetryHandlers<TRetryHandlers>;
+}
+
+function hasOwnToken(handlers: Record<string, unknown> | undefined, token: string): boolean {
+  if (handlers === undefined) {
+    return false;
+  }
+
+  return Object.prototype.hasOwnProperty.call(handlers, token);
+}
+
+function createFailureResult<TToken extends string>(
+  token: TToken,
+  reason: 'token_not_defined' | 'handler_not_registered'
+): SagaExecutableHandlerResult<never, TToken> {
+  return { ok: false, reason, token };
+}
+
+function createCallbackExecutionContext<
+  TState,
+  TPlugins extends SagaPluginManifestList,
+  TResponseHandlerBindings extends SagaResponseHandlerTokenBindings
+>(
+  state: TState,
+  definition: RunSagaResponseHandlerInput<TState, TPlugins, TResponseHandlerBindings>['definition'],
+  request: SagaResponseCallbackEnvelope['request'],
+  intentMetadata: Partial<SagaIntentMetadata> | undefined,
+  plugins: TPlugins
+) {
+  const draft = createDraft(state as any);
+  const intents: SagaIntent[] = [];
+  const ctx = createSagaDispatchContext<TPlugins, TResponseHandlerBindings>(
+    resolveIntentMetadata(request, intentMetadata),
+    intents,
+    createTokenBindingsFromHandlerMaps(
+      definition.responseHandlers,
+      definition.errorHandlers,
+      definition.retryHandlers
+    ) as TResponseHandlerBindings,
+    plugins
+  );
+
+  return { draft, intents, ctx };
+}
+
+function createSuccessResult<TState, TToken extends string>(
+  draft: Draft<TState>,
+  intents: SagaIntent[],
+  token: TToken
+): SagaExecutableHandlerResult<TState, TToken> {
+  return {
+    ok: true,
+    output: {
+      state: finishDraft(draft) as TState,
+      intents
+    },
+    token
+  };
+}
+
+/**
+ * Executes a single saga handler with mutation-first semantics and produces
+ * deterministic reducer output.
+ */
+export async function runSagaHandler<
+  TState,
+  TAggregate extends SagaAggregateDefinition,
+  TEventName extends SagaAggregateEventName<TAggregate>,
+  TPlugins extends SagaPluginManifestList = readonly [],
+  TResponseHandlerBindings extends SagaResponseHandlerTokenBindings = Record<never, never>
+>(
+  state: TState,
+  event: SagaAggregateEventByName<TAggregate, TEventName>,
+  handler: SagaHandler<TState, TAggregate, TEventName, TPlugins, TResponseHandlerBindings>,
+  metadata: SagaIntentMetadata,
+  responseHandlers: TResponseHandlerBindings = {} as TResponseHandlerBindings,
+  plugins: TPlugins = [] as unknown as TPlugins
+): Promise<SagaReducerOutput<TState>> {
+  const draft = createDraft(state as any);
+  const intentBuffer: SagaIntent[] = [];
+  const ctx = createSagaDispatchContext<TPlugins, TResponseHandlerBindings>(
+    metadata,
+    intentBuffer,
+    responseHandlers,
+    plugins
+  );
+
+  await handler(draft as Draft<TState>, event, ctx);
+
+  return {
+    state: finishDraft(draft) as TState,
+    intents: intentBuffer
+  };
+}
+
+export async function runSagaResponseHandler<
+  TState,
+  TPlugins extends SagaPluginManifestList = readonly [],
+  TResponseHandlerBindings extends SagaResponseHandlerTokenBindings = Record<never, never>,
+  TToken extends TResponseToken<SagaResponseTokenKey<TResponseHandlerBindings>> =
+    TResponseToken<SagaResponseTokenKey<TResponseHandlerBindings>>,
+  TPayload = unknown
+>(
+  input: RunSagaResponseHandlerInput<TState, TPlugins, TResponseHandlerBindings, TToken, TPayload>
+): Promise<SagaExecutableHandlerResult<TState, TToken>> {
+  const {
+    definition,
+    state,
+    envelope,
+    intentMetadata,
+    plugins = [] as unknown as TPlugins
+  } = input;
+  const token = envelope.token;
+  if (!hasOwnToken(definition.responseHandlers as Record<string, unknown>, token)) {
+    return createFailureResult(token, 'token_not_defined');
+  }
+
+  const handler = (definition.responseHandlers as Record<
+    string,
+    SagaExecutableResponseHandler<TState, TPlugins, TResponseHandlerBindings, any> | undefined
+  >)[token];
+
+  if (handler === undefined) {
+    return createFailureResult(token, 'handler_not_registered');
+  }
+
+  const { draft, intents, ctx } = createCallbackExecutionContext(
+    state,
+    definition,
+    envelope.request,
+    intentMetadata,
+    plugins
+  );
+
+  await handler(draft as Draft<TState>, envelope as SagaResponseCallbackEnvelope<any, TPayload>, ctx);
+
+  return createSuccessResult(draft, intents, token);
+}
+
+export async function runSagaErrorHandler<
+  TState,
+  TPlugins extends SagaPluginManifestList = readonly [],
+  TResponseHandlerBindings extends SagaResponseHandlerTokenBindings = Record<never, never>,
+  TToken extends TErrorToken<SagaErrorTokenKey<TResponseHandlerBindings>> =
+    TErrorToken<SagaErrorTokenKey<TResponseHandlerBindings>>,
+  TError = unknown
+>(
+  input: RunSagaErrorHandlerInput<TState, TPlugins, TResponseHandlerBindings, TToken, TError>
+): Promise<SagaExecutableHandlerResult<TState, TToken>> {
+  const {
+    definition,
+    state,
+    envelope,
+    intentMetadata,
+    plugins = [] as unknown as TPlugins
+  } = input;
+  const token = envelope.token;
+  if (!hasOwnToken(definition.errorHandlers as Record<string, unknown>, token)) {
+    return createFailureResult(token, 'token_not_defined');
+  }
+
+  const handler = (definition.errorHandlers as Record<
+    string,
+    SagaExecutableErrorHandler<TState, TPlugins, TResponseHandlerBindings, any> | undefined
+  >)[token];
+
+  if (handler === undefined) {
+    return createFailureResult(token, 'handler_not_registered');
+  }
+
+  const { draft, intents, ctx } = createCallbackExecutionContext(
+    state,
+    definition,
+    envelope.request,
+    intentMetadata,
+    plugins
+  );
+
+  await handler(draft as Draft<TState>, envelope as SagaErrorCallbackEnvelope<any, TError>, ctx);
+
+  return createSuccessResult(draft, intents, token);
+}

--- a/packages/saga/src/responseTokens.ts
+++ b/packages/saga/src/responseTokens.ts
@@ -1,0 +1,76 @@
+export type SagaResponseHandlerPhase = 'response' | 'error' | 'retry';
+
+declare const sagaResponseHandlerTokenBrand: unique symbol;
+
+type SagaPhaseToken<TToken extends string, TPhase extends SagaResponseHandlerPhase> = TToken & {
+  readonly [sagaResponseHandlerTokenBrand]: TPhase;
+};
+
+export type TResponseToken<TToken extends string = string> = SagaPhaseToken<TToken, 'response'>;
+
+export type TErrorToken<TToken extends string = string> = SagaPhaseToken<TToken, 'error'>;
+
+export type TRetryToken<TToken extends string = string> = SagaPhaseToken<TToken, 'retry'>;
+
+export interface SagaResponseHandlerTokenBinding<
+  TPhase extends SagaResponseHandlerPhase = SagaResponseHandlerPhase
+> {
+  readonly phase: TPhase;
+}
+
+export type SagaResponseHandlerTokenBindings = Record<string, SagaResponseHandlerTokenBinding>;
+
+export type SagaResponseTokenKey<TBindings extends SagaResponseHandlerTokenBindings> =
+  SagaResponseHandlerKeysByPhase<TBindings, 'response'>;
+
+export type SagaErrorTokenKey<TBindings extends SagaResponseHandlerTokenBindings> =
+  SagaResponseHandlerKeysByPhase<TBindings, 'error'>;
+
+export type SagaRetryTokenKey<TBindings extends SagaResponseHandlerTokenBindings> =
+  SagaResponseHandlerKeysByPhase<TBindings, 'retry'>;
+
+type SagaResponseHandlerTokenForPhase<
+  TToken extends string,
+  TPhase extends SagaResponseHandlerPhase
+> = TPhase extends 'response'
+  ? TResponseToken<TToken>
+  : TPhase extends 'error'
+    ? TErrorToken<TToken>
+    : TRetryToken<TToken>;
+
+export type SagaResponseHandlerKeysByPhase<
+  TBindings extends SagaResponseHandlerTokenBindings,
+  TPhase extends SagaResponseHandlerPhase
+> = {
+  [THandlerKey in keyof TBindings & string]: TBindings[THandlerKey]['phase'] extends TPhase
+    ? THandlerKey
+    : never;
+}[keyof TBindings & string];
+
+export type SagaResponseHandlerTokenNamespace<
+  TBindings extends SagaResponseHandlerTokenBindings,
+  TPhase extends SagaResponseHandlerPhase
+> = {
+  readonly [THandlerKey in SagaResponseHandlerKeysByPhase<TBindings, TPhase>]: SagaResponseHandlerTokenForPhase<
+    THandlerKey,
+    TPhase
+  >;
+};
+
+export type SagaResponseHandlerTokenAccess<TBindings extends SagaResponseHandlerTokenBindings> = {
+  readonly onResponse: SagaResponseHandlerTokenNamespace<TBindings, 'response'>;
+  readonly onError: SagaResponseHandlerTokenNamespace<TBindings, 'error'>;
+  readonly onRetry: SagaResponseHandlerTokenNamespace<TBindings, 'retry'>;
+};
+
+export type SagaBindingsFromResponseHandlers<THandlers extends Record<string, unknown>> = {
+  [TKey in keyof THandlers & string]: SagaResponseHandlerTokenBinding<'response'>;
+};
+
+export type SagaBindingsFromErrorHandlers<THandlers extends Record<string, unknown>> = {
+  [TKey in keyof THandlers & string]: SagaResponseHandlerTokenBinding<'error'>;
+};
+
+export type SagaBindingsFromRetryHandlers<THandlers extends Record<string, unknown>> = {
+  [TKey in keyof THandlers & string]: SagaResponseHandlerTokenBinding<'retry'>;
+};


### PR DESCRIPTION
## Summary

Implements Bead redemeine-q283 as a non-breaking internal split of packages/saga/src/createSaga.ts.

This is stacked on PR #89 / feature/saga-runtime-esm.

### Changes
- Extract handler execution helpers into packages/saga/src/handlerExecution.ts:
  - runSagaHandler
  - runSagaResponseHandler
  - runSagaErrorHandler
  - related private execution helpers
- Extract response/error/retry token helper types into packages/saga/src/responseTokens.ts.
- Preserve existing imports from packages/saga/src/createSaga.ts through re-exports.
- Add changeset patch for @redemeine/saga.

### Line count impact
- createSaga.ts: 2357 -> 2102 lines
- handlerExecution.ts: 252 lines
- responseTokens.ts: 76 lines

### Compatibility
- packages/saga/src/index.ts unchanged.
- Generated DTS still includes moved public names.
- Existing direct imports from createSaga.ts remain compatible via re-exports.

### Validation
- bun run --cwd packages/saga typecheck: pass
- bun run --cwd packages/saga test: pass, 69 pass / 0 fail
- bun run --cwd packages/saga build: pass
- bun run --cwd packages/saga-runtime typecheck: pass
- bun run --cwd packages/saga-runtime test: pass, 53 pass / 0 fail
- bun run --cwd packages/testing typecheck: pass

### Caveat
createSaga.ts remains above the 400-line principle as inherited technical debt, but this PR materially reduces the monolith without broad behavior risk.

Bead: redemeine-q283