### PR TITLE
refactor(saga): tighten internal type safety

### DIFF
--- a/.changeset/sharp-sagas-type.md
+++ b/.changeset/sharp-sagas-type.md
@@ -1,0 +1,5 @@
+---
+"@redemeine/saga": patch
+---
+
+Improve saga implementation type safety without changing public API or runtime behavior.

--- a/packages/saga/src/createSaga.ts
+++ b/packages/saga/src/createSaga.ts
@@ -45,7 +45,11 @@ export type SagaInitialStateFactory<TState> = () => TState;
 /** Correlation resolver for routing domain events into saga instances. */
 export type SagaCorrelationFactory = (...args: unknown[]) => unknown;
 
+// SAFETY: This public plugin/action function constraint keeps concrete plugin
+// build functions assignable under strict function variance;
+// replacing it with `unknown[]` would reject narrower user parameters.
 type AnyFunction = (...args: any[]) => unknown;
+type UnknownArgsFunction<TResult = unknown> = (...args: unknown[]) => TResult;
 const SAGA_HELPER_EMISSION_MODE = '__saga_helper_emission_mode';
 const SAGA_ACTION_RUNTIME_EMITTER = '__saga_action_runtime_emitter';
 
@@ -180,17 +184,32 @@ export type SagaPluginRequestResponseActionNames<TPlugin extends SagaPluginManif
 
 type SagaAnyResponseHandlerMap<TState, TPlugins extends SagaPluginManifestList> = Record<
   string,
-  SagaExecutableResponseHandler<TState, TPlugins, any, any>
+  SagaExecutableResponseHandler<
+    TState,
+    TPlugins,
+    Record<string, SagaResponseHandlerTokenBinding<'response'>>,
+    TResponseToken<string>
+  >
 >;
 
 type SagaAnyErrorHandlerMap<TState, TPlugins extends SagaPluginManifestList> = Record<
   string,
-  SagaExecutableErrorHandler<TState, TPlugins, any, any>
+  SagaExecutableErrorHandler<
+    TState,
+    TPlugins,
+    Record<string, SagaResponseHandlerTokenBinding<'error'>>,
+    TErrorToken<string>
+  >
 >;
 
 type SagaAnyRetryHandlerMap<TState, TPlugins extends SagaPluginManifestList> = Record<
   string,
-  SagaExecutableRetryHandler<TState, TPlugins, any, any>
+  SagaExecutableRetryHandler<
+    TState,
+    TPlugins,
+    Record<string, SagaResponseHandlerTokenBinding<'retry'>>,
+    TRetryToken<string>
+  >
 >;
 
 export interface SagaOneWayActionDefinition<TBuild extends AnyFunction = AnyFunction> {
@@ -693,6 +712,8 @@ export interface SagaAggregateCommandEnvelope {
 }
 
 /** Command creators shape emitted by `createAggregate(...).build()`. */
+// SAFETY: Public aggregate command creators are variadic. Narrowing the rest
+// parameters would reject existing command creator maps under strict variance.
 export type SagaCommandCreators = Record<string, (...args: any[]) => SagaAggregateCommandEnvelope>;
 
 /** Aggregate definition shape consumed by saga `.on(...)` and `ctx.commandsFor(...)`. */
@@ -717,7 +738,7 @@ type AggregateTypeOf<TAggregate extends SagaAggregateDefinition> =
     : string;
 
 type ProjectorPayload<TProjector> =
-  TProjector extends (state: any, event: infer TEvent, ...args: any[]) => unknown
+  TProjector extends (state: never, event: infer TEvent, ...args: never[]) => unknown
     ? TEvent extends { payload: infer TPayload }
       ? TPayload
       : unknown
@@ -823,7 +844,7 @@ export function createSagaCommandsFor<TAggregate extends SagaAggregateDefinition
   for (const commandName of Object.keys(aggregateDef.commandCreators)) {
     const createCommand = aggregateDef.commandCreators[commandName]!;
 
-    (commandIntents as Record<string, (...args: any[]) => unknown>)[commandName] = (...args: any[]) => {
+    (commandIntents as Record<string, UnknownArgsFunction>)[commandName] = (...args: unknown[]) => {
       const command = createCommand(...args);
       const intent = createSagaDispatchIntentFromEnvelope(
         commandName as keyof CommandCreatorsOf<TAggregate> & string,
@@ -979,9 +1000,9 @@ function createSagaCorePluginManifest(
   ): SagaCommandsFor<TAggregate> => {
     const emittedCommands = {} as SagaCommandsFor<TAggregate>;
 
-    for (const commandName of Object.keys(commandIntents as Record<string, unknown>)) {
-      const createIntent = (commandIntents as Record<string, (...args: any[]) => SagaIntent>)[commandName]!;
-      (emittedCommands as Record<string, (...args: any[]) => SagaIntent>)[commandName] = (...args: any[]) => {
+    for (const commandName of Object.keys(commandIntents)) {
+      const createIntent = (commandIntents as Record<string, UnknownArgsFunction<SagaIntent>>)[commandName]!;
+      (emittedCommands as Record<string, UnknownArgsFunction<SagaIntent>>)[commandName] = (...args: unknown[]) => {
         const intent = createIntent(...args);
         emitIntent(intent);
         return intent;
@@ -1051,18 +1072,18 @@ function createPluginActionsContext(
   plugins: SagaPluginManifestList,
   metadata: SagaIntentMetadata,
   emitIntent: (intent: SagaIntent) => void
-): Record<string, Record<string, (...args: any[]) => unknown>> {
-  const actionsContext: Record<string, Record<string, (...args: any[]) => unknown>> = Object.create(null);
+): Record<string, Record<string, UnknownArgsFunction>> {
+  const actionsContext: Record<string, Record<string, UnknownArgsFunction>> = Object.create(null);
 
   for (const plugin of composePluginManifestsWithPrecedence(plugins)) {
-    const pluginActions: Record<string, (...args: any[]) => unknown> =
+    const pluginActions: Record<string, UnknownArgsFunction> =
       actionsContext[plugin.plugin_key] ?? Object.create(null);
 
     for (const actionName of Object.keys(plugin.actions)) {
       const actionDescriptor = plugin.actions[actionName] as SagaPluginActionDescriptorWithHelperMetadata;
 
       if (actionDescriptor.interaction === 'request_response') {
-        pluginActions[actionName] = (...args: any[]) => {
+        pluginActions[actionName] = (...args: unknown[]) => {
           const executionPayload = actionDescriptor.build(...args);
           let terminalIntent: SagaPluginRequestIntentHandle | undefined;
 
@@ -1119,7 +1140,7 @@ function createPluginActionsContext(
         continue;
       }
 
-      pluginActions[actionName] = (...args: any[]) => {
+      pluginActions[actionName] = (...args: unknown[]) => {
         const executionPayload = actionDescriptor.build(...args);
         const runtimeEmitter = actionDescriptor[SAGA_ACTION_RUNTIME_EMITTER];
 
@@ -1292,7 +1313,7 @@ export type SagaHandlers<
   >;
 };
 
-/** Handler used by trigger-based saga starts before any aggregate events. */
+/** Handler used by trigger-based saga starts before aggregate events are available. */
 export type SagaStartHandler<
   TStartInput,
   TState,

--- a/packages/saga/src/handlerExecution.ts
+++ b/packages/saga/src/handlerExecution.ts
@@ -8,11 +8,11 @@ import type {
   SagaAggregateEventName,
   SagaErrorCallbackEnvelope,
   SagaErrorTokenKey,
-  SagaExecutableErrorHandler,
   SagaExecutableHandlerResult,
-  SagaExecutableResponseHandler,
   SagaHandler,
+  SagaHandlerResult,
   SagaIntent,
+  SagaIntentContext,
   SagaIntentMetadata,
   SagaPluginManifestList,
   SagaReducerOutput,
@@ -97,6 +97,9 @@ function createCallbackExecutionContext<
   intentMetadata: Partial<SagaIntentMetadata> | undefined,
   plugins: TPlugins
 ) {
+  // SAFETY: Immer's `createDraft` type is object-bounded, while saga state is
+  // intentionally generic for public API compatibility. Runtime behavior is
+  // unchanged: callers must still provide draftable saga state.
   const draft = createDraft(state as any);
   const intents: SagaIntent[] = [];
   const ctx = createSagaDispatchContext<TPlugins, TResponseHandlerBindings>(
@@ -146,6 +149,8 @@ export async function runSagaHandler<
   responseHandlers: TResponseHandlerBindings = {} as TResponseHandlerBindings,
   plugins: TPlugins = [] as unknown as TPlugins
 ): Promise<SagaReducerOutput<TState>> {
+  // SAFETY: See `createCallbackExecutionContext`; preserving the unbounded
+  // public `TState` avoids a breaking API constraint.
   const draft = createDraft(state as any);
   const intentBuffer: SagaIntent[] = [];
   const ctx = createSagaDispatchContext<TPlugins, TResponseHandlerBindings>(
@@ -187,7 +192,11 @@ export async function runSagaResponseHandler<
 
   const handler = (definition.responseHandlers as Record<
     string,
-    SagaExecutableResponseHandler<TState, TPlugins, TResponseHandlerBindings, any> | undefined
+    ((
+      state: Draft<TState>,
+      response: SagaResponseCallbackEnvelope<TToken, TPayload>,
+      ctx: SagaIntentContext<TPlugins, TResponseHandlerBindings>
+    ) => SagaHandlerResult) | undefined
   >)[token];
 
   if (handler === undefined) {
@@ -202,7 +211,7 @@ export async function runSagaResponseHandler<
     plugins
   );
 
-  await handler(draft as Draft<TState>, envelope as SagaResponseCallbackEnvelope<any, TPayload>, ctx);
+  await handler(draft as Draft<TState>, envelope, ctx);
 
   return createSuccessResult(draft, intents, token);
 }
@@ -231,7 +240,11 @@ export async function runSagaErrorHandler<
 
   const handler = (definition.errorHandlers as Record<
     string,
-    SagaExecutableErrorHandler<TState, TPlugins, TResponseHandlerBindings, any> | undefined
+    ((
+      state: Draft<TState>,
+      error: SagaErrorCallbackEnvelope<TToken, TError>,
+      ctx: SagaIntentContext<TPlugins, TResponseHandlerBindings>
+    ) => SagaHandlerResult) | undefined
   >)[token];
 
   if (handler === undefined) {
@@ -246,7 +259,7 @@ export async function runSagaErrorHandler<
     plugins
   );
 
-  await handler(draft as Draft<TState>, envelope as SagaErrorCallbackEnvelope<any, TError>, ctx);
+  await handler(draft as Draft<TState>, envelope, ctx);
 
   return createSuccessResult(draft, intents, token);
 }

--- a/packages/saga/src/triggers.ts
+++ b/packages/saga/src/triggers.ts
@@ -26,12 +26,12 @@ type TriggerWhenListOf<TDefinition> =
     : readonly [];
 
 type TriggerSourceOf<TDefinition> =
-  TDefinition extends { readonly toStartInput: SagaTriggerToStartInput<infer TSource, any> }
+  TDefinition extends { readonly toStartInput: SagaTriggerToStartInput<infer TSource, unknown> }
     ? TSource
     : never;
 
 type TriggerStartInputOf<TDefinition> =
-  TDefinition extends { readonly toStartInput: SagaTriggerToStartInput<any, infer TStartInput> }
+  TDefinition extends { readonly toStartInput: SagaTriggerToStartInput<never, infer TStartInput> }
     ? TStartInput
     : never;
 


### PR DESCRIPTION
## Summary

Implements Bead redemeine-xjeq by tightening @redemeine/saga implementation type safety while preserving public inference and runtime behavior.

This is stacked on PR #90 / feature/saga-create-saga-split.

### Results
- packages/saga/src any count: 29 -> 4
- cast count: 114 -> 111
- Remaining any locations have SAFETY comments.
- No public API removals or runtime behavior changes.

### Changes
- Replace fixable any with unknown, never, bounded helper types, or narrower structural types.
- Narrow handler execution casts in handlerExecution.ts.
- Improve trigger and projector conditional inference without public type weakening.
- Add patch changeset for @redemeine/saga.

### Validation
- bun run --cwd packages/saga typecheck: pass
- bun run --cwd packages/saga test: pass, 69 pass / 0 fail
- bun run --cwd packages/saga build: pass
- bun run --cwd packages/saga-runtime build: pass
- bun run --cwd packages/saga-runtime test: pass, 53 pass / 0 fail
- bun run --cwd packages/testing typecheck: pass

### Compatibility
- Public type inference remains covered by existing type tests and downstream typechecks.
- Runtime control flow is unchanged.

Bead: redemeine-xjeq