### PR TITLE
docs(saga): clarify public API and stability

### DIFF
--- a/.changeset/gentle-sagas-doc.md
+++ b/.changeset/gentle-sagas-doc.md
@@ -1,0 +1,5 @@
+---
+"@redemeine/saga": patch
+---
+
+Document the public saga API groups, ESM-only usage, prerelease stability caveats, and type-safety guidance.

--- a/packages/saga/README.md
+++ b/packages/saga/README.md
@@ -1,0 +1,72 @@
+# @redemeine/saga
+
+Definition-time saga builder for long-running process managers.
+
+## Module format and stability
+
+`@redemeine/saga` is ESM-only (`"type": "module"`). Import it with ESM syntax
+from the package root or the documented aggregate bridge subpath.
+
+This package is currently published as a prerelease. Public exports are intended
+to be stable within prerelease constraints, but some compatibility exports may be
+refined before a stable `1.0` release.
+
+## Public API groups
+
+- **Builder DSL**: `createSaga`, saga definition types, plugin helper contracts,
+  handler/intent types, and response/error/retry handler token types.
+- **Trigger contracts**: `createSagaTriggerBuilder`, trigger definitions,
+  trigger start contracts, and scheduler trigger policy contracts.
+- **Retry policy**: retry policy validation, retryable error classification, and
+  next-attempt scheduling helpers.
+- **Identity utilities**: canonical saga names, namespaces, keys, URNs, and
+  normalization errors.
+- **Runtime execution helpers**: `runSagaHandler`, `runSagaResponseHandler`, and
+  `runSagaErrorHandler` for runtimes that execute built definitions.
+- **Aggregate bridge compatibility**: `createAggregate` and bridge-oriented types
+  kept for integrations that consume saga definitions through aggregate-like
+  contracts.
+
+Some exported types are compatibility surface for generated declarations,
+persisted contracts, or runtime bridges. Prefer higher-level builders unless a
+runtime integration specifically requires those lower-level contracts.
+
+## Type-safety guidance
+
+- Prefer inferred builders: let `createSaga(...).initialState(...).start(...)`
+  carry state, start input, plugin, and handler payload types through the chain.
+- Avoid manually widening handler payloads to `unknown`, `any`, or broad record
+  types; doing so discards event and response-token inference.
+- Consume the generated `.d.ts` declarations from the published package instead
+  of importing internal source files.
+
+## Minimal example
+
+```ts
+import { createSaga } from '@redemeine/saga';
+
+type StartInput = { invoiceId: string };
+
+export const invoicePaymentSaga = createSaga({
+  identity: {
+    namespace: 'billing',
+    name: 'invoice-payment',
+    version: 1
+  }
+})
+  .initialState(() => ({ attempts: 0 }))
+  .start((start: StartInput) => {
+    void start;
+  })
+  .correlateBy((start) => start.invoiceId)
+  .triggeredBy({
+    kind: 'direct',
+    toStartInput: (source: { invoiceId: string }) => ({
+      invoiceId: source.invoiceId
+    })
+  })
+  .build();
+```
+
+The example constructs a saga definition and trigger metadata only; executing the
+definition is the responsibility of a runtime package or host integration.

--- a/packages/saga/src/index.ts
+++ b/packages/saga/src/index.ts
@@ -1,3 +1,15 @@
+/**
+ * Public entry point for `@redemeine/saga`.
+ *
+ * The exports below are grouped by their intended public API role. Some types
+ * remain exported for aggregate-bridge and persisted-contract compatibility;
+ * prefer the builder DSL and generated `.d.ts` types for new application code.
+ *
+ * @packageDocumentation
+ */
+
+// Builder DSL, plugin helper contracts, runtime execution helpers, and
+// compatibility types used by saga definitions and aggregate event handlers.
 export {
   createSaga,
   createSagaCommandsFor,
@@ -98,6 +110,8 @@ export {
   type SagaTriggerContract,
   type SagaTriggerDefinition
 } from './createSaga';
+
+// Start-policy DSL for controlling duplicate starts and restart semantics.
 export {
   startPolicy,
   type SagaRestartMode,
@@ -107,6 +121,8 @@ export {
   type SagaStartPolicyJoinExisting,
   type SagaStartPolicyRestart
 } from './startPolicy';
+
+// Trigger contracts shared between trigger builders and runtimes/schedulers.
 export {
   type SagaSchedulerTriggerPolicyContract,
   type SagaTriggerMisfirePolicy,
@@ -117,6 +133,8 @@ export {
   type SagaTriggerRestartPolicy,
   type SagaTriggerStartContract
 } from './triggerContracts';
+
+// Trigger builder DSL and schedule/event trigger definition contracts.
 export {
   createSagaTriggerBuilder,
   type SagaCronScheduleInvocation,
@@ -149,7 +167,11 @@ export {
   type SagaTriggerPredicate,
   type SagaTriggerToStartInput
 } from './triggers';
+
+// Aggregate bridge compatibility for existing aggregate-style integrations.
 export { createAggregate } from './aggregateBridge';
+
+// Saga identity utilities for canonical keys, URNs, and normalized metadata.
 export {
   buildSagaType,
   normalizeSagaIdentity,
@@ -175,7 +197,7 @@ export {
   type CanonicalSagaIdentityParts
 } from './identity/index';
 
-// Retry policy exports.
+// Retry policy validation, classification, and scheduling helpers.
 export {
   validateRetryPolicy,
   computeNextAttemptAt,


### PR DESCRIPTION
## Summary

Implements Bead redemeine-loko by documenting @redemeine/saga public API groups and prerelease stability guidance.

This is stacked on PR #91 / feature/saga-type-safety.

### Changes
- Add package-level JSDoc and grouped API section comments in packages/saga/src/index.ts.
- Add packages/saga/README.md covering:
  - ESM-only usage
  - prerelease stability caveat
  - public API groups
  - best-DX/type-safety guidance
  - minimal TypeScript usage example
- Add patch changeset for @redemeine/saga docs.

### Compatibility
- Export specifiers and order unchanged; comments only in index.ts.
- No behavior changes.

### Validation
- bun run --cwd packages/saga typecheck: pass
- bun run --cwd packages/saga build: pass
- bun run --cwd packages/saga test: pass, 69 pass / 0 fail

Bead: redemeine-loko