### PR TITLE
test(saga): lock handler failure semantics

### DIFF
--- a/.changeset/fair-sagas-fail.md
+++ b/.changeset/fair-sagas-fail.md
@@ -1,0 +1,5 @@
+---
+"@redemeine/saga": patch
+---
+
+Document that saga execution helpers propagate thrown handler errors and reserve failure result envelopes for token resolution failures.

--- a/packages/saga-runtime/test/saga-execution-bridge.integration.test.ts
+++ b/packages/saga-runtime/test/saga-execution-bridge.integration.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from '@jest/globals';
 import {
   createSagaExecutionBridge,
   createReferenceAdaptersV1,
+  runReferenceAdapterFlowV1,
+  type SagaDefinitionLike,
+  type SagaRuntimeSideEffectIntent,
   type SagaAggregateState
 } from '../src';
 
@@ -169,6 +172,68 @@ describe('saga execution bridge integration', () => {
     expect(result.adapterResults).toEqual([]);
     expect(result.sagaState).toBeUndefined();
     expect(result.aggregateState.id).toBeNull();
+  });
+
+  it('propagates thrown saga handler errors from bridge dispatch without returning a result envelope', async () => {
+    const thrown = new Error('bridge handler failed');
+    const definition: SagaDefinitionLike<{ attempts: number }> = {
+      sagaType: 'runtime.failure.bridge.v1',
+      initialState: () => ({ attempts: 0 }),
+      responseHandlers: {},
+      errorHandlers: {},
+      retryHandlers: {},
+      handlers: [{
+        aggregateType: 'orders',
+        handlers: {
+          started: () => {
+            throw thrown;
+          }
+        }
+      }]
+    };
+    const bridge = createSagaExecutionBridge({ definition });
+
+    await expect(bridge.dispatch({
+      sagaId: 'saga-bridge-handler-failure',
+      event: {
+        type: 'orders.started.event',
+        payload: { orderId: 'order-failure' },
+        aggregateType: 'orders'
+      }
+    })).rejects.toBe(thrown);
+  });
+
+  it('propagates thrown reference adapter flow errors after side-effect execution is attempted', async () => {
+    const thrown = new Error('side effect adapter failed');
+    const baseAdapters = createReferenceAdaptersV1();
+    const handled: SagaRuntimeSideEffectIntent[] = [];
+    const adapters = {
+      ...baseAdapters,
+      sideEffects: {
+        async execute(intent: SagaRuntimeSideEffectIntent) {
+          handled.push(intent);
+          throw thrown;
+        },
+        listHandled: () => handled
+      }
+    };
+
+    await expect(runReferenceAdapterFlowV1(adapters, {
+      sagaId: 'saga-adapter-flow-failure',
+      intents: [{
+        type: 'plugin-intent',
+        plugin_key: 'telemetry',
+        action_name: 'record',
+        interaction: 'fire_and_forget',
+        execution_payload: { name: 'failure.test' },
+        metadata: {
+          sagaId: 'saga-adapter-flow-failure',
+          correlationId: 'corr-adapter-flow-failure',
+          causationId: 'cause-adapter-flow-failure'
+        }
+      }]
+    })).rejects.toBe(thrown);
+    expect(handled).toHaveLength(1);
   });
 
   it('keeps execution ids monotonic across repeated dispatches and traceable to aggregate lifecycle ids', async () => {

--- a/packages/saga/README.md
+++ b/packages/saga/README.md
@@ -40,6 +40,14 @@ runtime integration specifically requires those lower-level contracts.
 - Consume the generated `.d.ts` declarations from the published package instead
   of importing internal source files.
 
+## Handler failure semantics
+
+`runSagaHandler`, `runSagaResponseHandler`, and `runSagaErrorHandler` propagate
+errors thrown by matched handlers. Response and error execution helpers return an
+`{ ok: false, reason, token }` result only for token resolution failures such as
+unknown or unregistered handler tokens; they do not wrap thrown handler errors in
+a structured failure envelope.
+
 ## Minimal example
 
 ```ts

--- a/packages/saga/test/handlerFailures.test.ts
+++ b/packages/saga/test/handlerFailures.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  createSaga,
+  runSagaErrorHandler,
+  runSagaHandler,
+  runSagaResponseHandler,
+  type SagaAggregateEventByName,
+  type TErrorToken,
+  type TResponseToken
+} from '../src';
+
+type FailureTestState = {
+  attempts: number;
+};
+
+const FailureAggregate = {
+  aggregateType: 'billing',
+  pure: {
+    eventProjectors: {
+      charged: (_state: unknown, _event: { payload: { invoiceId: string } }) => undefined
+    }
+  },
+  commandCreators: {}
+} as const;
+
+const FAILURE_HANDLER_METADATA = {
+  sagaId: 'saga-failure-1',
+  correlationId: 'corr-failure-1',
+  causationId: 'cause-failure-1'
+} as const;
+
+describe('saga handler failure semantics', () => {
+  it('propagates errors thrown by runSagaHandler handlers without returning an envelope', async () => {
+    const thrown = new Error('saga handler failed');
+
+    await expect(runSagaHandler(
+      { attempts: 0 },
+      {
+        type: 'billing.charged.event',
+        payload: { invoiceId: 'inv-1' }
+      } as SagaAggregateEventByName<typeof FailureAggregate, 'charged'>,
+      (state) => {
+        state.attempts += 1;
+        throw thrown;
+      },
+      FAILURE_HANDLER_METADATA
+    )).rejects.toBe(thrown);
+  });
+
+  it('propagates errors thrown by runSagaResponseHandler handlers after token lookup succeeds', async () => {
+    const thrown = new Error('response handler failed');
+    const saga = createSaga<FailureTestState>({
+      identity: { namespace: 'failure', name: 'response-handler', version: 1 }
+    })
+      .onResponses({
+        'billing.charge.ok': (state) => {
+          state.attempts += 1;
+          throw thrown;
+        }
+      })
+      .build();
+
+    await expect(runSagaResponseHandler({
+      definition: saga,
+      state: { attempts: 0 },
+      envelope: {
+        token: 'billing.charge.ok' as TResponseToken<'billing.charge.ok'>,
+        payload: { invoiceId: 'inv-1' },
+        request: {
+          plugin_key: 'billing',
+          action_name: 'charge',
+          sagaId: 'saga-failure-2',
+          correlationId: 'corr-failure-2',
+          causationId: 'cause-failure-2'
+        }
+      }
+    })).rejects.toBe(thrown);
+  });
+
+  it('propagates errors thrown by runSagaErrorHandler handlers after token lookup succeeds', async () => {
+    const thrown = new Error('error handler failed');
+    const saga = createSaga<FailureTestState>({
+      identity: { namespace: 'failure', name: 'error-handler', version: 1 }
+    })
+      .onErrors({
+        'billing.charge.failed': (state) => {
+          state.attempts += 1;
+          throw thrown;
+        }
+      })
+      .build();
+
+    await expect(runSagaErrorHandler({
+      definition: saga,
+      state: { attempts: 0 },
+      envelope: {
+        token: 'billing.charge.failed' as TErrorToken<'billing.charge.failed'>,
+        error: { code: 'declined' },
+        request: {
+          plugin_key: 'billing',
+          action_name: 'charge',
+          sagaId: 'saga-failure-3',
+          correlationId: 'corr-failure-3',
+          causationId: 'cause-failure-3'
+        }
+      }
+    })).rejects.toBe(thrown);
+  });
+});


### PR DESCRIPTION
## Summary

Implements Bead redemeine-sn6a by documenting and testing current saga failure semantics without changing runtime behavior.

This is stacked on PR #92 / feature/saga-api-docs.

### Changes
- Add saga tests for thrown matched handlers:
  - runSagaHandler
  - runSagaResponseHandler
  - runSagaErrorHandler
- Add saga-runtime integration coverage for:
  - thrown saga handler errors during bridge dispatch
  - thrown side-effect adapter errors after execution is attempted
- Document current semantics in README:
  - matched handler throws propagate
  - token resolution failures return failure envelopes
- Add patch changeset for @redemeine/saga docs/package-content update.

### Validation
- bun run --cwd packages/saga typecheck: pass
- bun run --cwd packages/saga test: pass, 72 pass / 0 fail
- bun run --cwd packages/saga build: pass
- bun run --cwd packages/saga-runtime build: pass
- bun run --cwd packages/saga-runtime test: pass, 55 pass / 0 fail
- bun run --cwd packages/testing typecheck: pass

### Compatibility
- No production behavior or public API files changed.
- Tests lock existing propagation semantics.

Bead: redemeine-sn6a